### PR TITLE
chore: Change default image tag to a valid tag

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -2,7 +2,7 @@
   "containerDefinitions": [
     {
       "name": "tis-trainee-forms",
-      "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-trainee-forms:3226bb80193c321495c994fab0ede4024f8262ba",
+      "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-trainee-forms:c7d0bfd567d148e21240bfabee68ee2cfd45ed64",
       "portMappings": [
         {
           "containerPort": 8207


### PR DESCRIPTION
The task definition's default image tag should point to a valid image.

TISNEW-3848