### PR TITLE
refactor: Set context path

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 server:
   port: 8207
+  servlet:
+    context-path: /forms
 
 spring:
   data:


### PR DESCRIPTION
AWS ALB is unable to rewrite paths, so to avoid a separate nginx
instance the service must have its own context path.

TISNEW-3848