### PR TITLE
chore: Remove DB_NAME secret from task definition

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -36,10 +36,6 @@
           "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-trainee-db-port"
         },
         {
-          "name": "DB_NAME",
-          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-trainee-db-name"
-        },
-        {
           "name": "DB_USER",
           "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-trainee-db-user"
         },


### PR DESCRIPTION
The DB_NAME secret does not exist and is not required at this time,
remove it from the task definition file.

TISNEW-3848