### PR TITLE
chore: Remove redundant test dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,10 +43,6 @@ dependencies {
 
   // Sentry reporting
   compile 'io.sentry:sentry-spring:1.7.30'
-
-  // test
-  testImplementation('org.junit.jupiter:junit-jupiter-engine:5.2.0')
-  testImplementation('org.mockito:mockito-junit-jupiter:2.23.0')
 }
 
 checkstyle {


### PR DESCRIPTION
The test dependendies are provided by the Spring Boot test starter and
do no need to be declared separately.

NO-TICKET