### PR TITLE
feat: add Draft Unique validation for FormR PartA

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResource.java
@@ -27,7 +27,6 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResource.java
@@ -27,6 +27,8 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,6 +37,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.tis.trainee.forms.api.util.HeaderUtil;
+import uk.nhs.hee.tis.trainee.forms.api.validation.FormRPartAValidator;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartADto;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartSimpleDto;
 import uk.nhs.hee.tis.trainee.forms.service.FormRPartAService;
@@ -47,9 +50,12 @@ public class FormRPartAResource {
   private static final String ENTITY_NAME = "formR_partA";
 
   private final FormRPartAService formRPartAService;
+  private final FormRPartAValidator formRPartAValidator;
 
-  public FormRPartAResource(FormRPartAService formRPartAService) {
+  public FormRPartAResource(FormRPartAService formRPartAService,
+      FormRPartAValidator formRPartAValidator) {
     this.formRPartAService = formRPartAService;
+    this.formRPartAValidator = formRPartAValidator;
   }
 
   /**
@@ -62,7 +68,8 @@ public class FormRPartAResource {
    */
   @PostMapping("/formr-parta")
   public ResponseEntity<FormRPartADto> createFormRPartA(
-      @RequestBody FormRPartADto formRPartADto) throws URISyntaxException {
+      @RequestBody FormRPartADto formRPartADto)
+      throws URISyntaxException, MethodArgumentNotValidException {
     log.debug("REST request to save FormRPartA : {}", formRPartADto);
     if (formRPartADto.getId() != null) {
       return ResponseEntity.badRequest().headers(HeaderUtil
@@ -70,6 +77,7 @@ public class FormRPartAResource {
               "A new formRpartA cannot already have an ID"))
           .body(null);
     }
+    formRPartAValidator.validate(formRPartADto);
     FormRPartADto result = formRPartAService.save(formRPartADto);
     return ResponseEntity.created(new URI("/api/formr-parta/" + result.getId()))
         .body(result);
@@ -86,11 +94,13 @@ public class FormRPartAResource {
    */
   @PutMapping("/formr-parta")
   public ResponseEntity<FormRPartADto> updateFormRPartA(
-      @RequestBody FormRPartADto formRPartADto) throws URISyntaxException {
+      @RequestBody FormRPartADto formRPartADto)
+      throws URISyntaxException, MethodArgumentNotValidException {
     log.debug("REST request to update FormRPartA : {}", formRPartADto);
     if (formRPartADto.getId() == null) {
       return createFormRPartA(formRPartADto);
     }
+    formRPartAValidator.validate(formRPartADto);
     FormRPartADto result = formRPartAService.save(formRPartADto);
     return ResponseEntity.ok().body(result);
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidator.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidator.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.api.validation;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import uk.nhs.hee.tis.trainee.forms.dto.FormRPartADto;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
+import uk.nhs.hee.tis.trainee.forms.repository.FormRPartARepository;
+
+@Component
+public class FormRPartAValidator {
+
+  private static final String FORMR_PARTA_DTO_NAME = "FormRPartADto";
+
+  FormRPartARepository formRPartARepository;
+
+  public FormRPartAValidator(FormRPartARepository formRPartARepository) {
+    this.formRPartARepository = formRPartARepository;
+  }
+
+  /**
+   * validation for formR PartA fields.
+   *
+   * @param formRPartADto Dto to be validated
+   * @throws MethodArgumentNotValidException if validation fails, throw exception
+   */
+  public void validate(FormRPartADto formRPartADto) throws MethodArgumentNotValidException {
+    List<FieldError> fieldErrors = new ArrayList<>();
+    fieldErrors.addAll(checkIfDraftUnique(formRPartADto));
+
+    if (!fieldErrors.isEmpty()) {
+      BeanPropertyBindingResult bindingResult =
+          new BeanPropertyBindingResult(formRPartADto, FORMR_PARTA_DTO_NAME);
+      fieldErrors.forEach(bindingResult::addError);
+      Method method = this.getClass().getMethods()[0];
+      throw new MethodArgumentNotValidException(new MethodParameter(method, 0), bindingResult);
+    }
+  }
+
+  /**
+   * Check when formR PartA Dto is a draft, should validate if it's unique.
+   */
+  List<FieldError> checkIfDraftUnique(FormRPartADto formRPartADto) {
+    List<FieldError> fieldErrors = new ArrayList<>();
+    LifecycleState lifecycleState = formRPartADto.getLifecycleState();
+
+    if (lifecycleState.equals(LifecycleState.DRAFT)) {
+      // query all drafted formRPartAs
+      List<FormRPartA> existingFormRPartA = formRPartARepository
+          .findByLifecycleState(LifecycleState.DRAFT);
+      // there should be only one draft in the db, no more other draft allowed to be saved
+      if (!existingFormRPartA.isEmpty()) {
+        if (existingFormRPartA.size() == 1) {
+          FormRPartA formRPartA = existingFormRPartA.get(0);
+          if (formRPartADto.getId() == null || !formRPartA.getId().equals(formRPartADto.getId())) {
+            fieldErrors.add(new FieldError(FORMR_PARTA_DTO_NAME, "lifecycleState",
+                "Draft form R Part A already exists"));
+          }
+        } else { // size > 1
+          fieldErrors.add(new FieldError(FORMR_PARTA_DTO_NAME, "lifecycleState",
+              "More than one draft form R Part A already exist"));
+        }
+      }
+    }
+    return fieldErrors;
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidator.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidator.java
@@ -74,7 +74,8 @@ public class FormRPartAValidator {
     if (lifecycleState.equals(LifecycleState.DRAFT)) {
       // query all drafted formRPartAs
       List<FormRPartA> existingFormRPartA = formRPartARepository
-          .findByLifecycleState(LifecycleState.DRAFT);
+          .findByTraineeTisIdAndLifecycleState(formRPartADto.getTraineeTisId(),
+              LifecycleState.DRAFT);
       // there should be only one draft in the db, no more other draft allowed to be saved
       if (!existingFormRPartA.isEmpty()) {
         if (existingFormRPartA.size() == 1) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartARepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartARepository.java
@@ -34,5 +34,7 @@ public interface FormRPartARepository extends MongoRepository<FormRPartA, String
   @Query(fields = "{traineeTisId:1, id:1, submissionDate:1, lifecycleState:1}")
   List<FormRPartA> findByTraineeTisId(String traineeTisId);
 
-  List<FormRPartA> findByLifecycleState(LifecycleState lifecycleState);
+  @Query(fields = "{id:1}")
+  List<FormRPartA> findByTraineeTisIdAndLifecycleState(String traineeTisId,
+      LifecycleState lifecycleState);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ErrorConstants.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ErrorConstants.java
@@ -19,20 +19,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.trainee.forms.repository;
+package uk.nhs.hee.tis.trainee.forms.service.exception;
 
-import java.util.List;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
-import org.springframework.stereotype.Repository;
-import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
-import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
+public final class ErrorConstants {
 
-@Repository
-public interface FormRPartARepository extends MongoRepository<FormRPartA, String> {
+  public static final String ERR_VALIDATION = "error.validation";
+  public static final String ERR_INTERNAL_SERVER_ERROR = "error.internalServerError";
 
-  @Query(fields = "{traineeTisId:1, id:1, submissionDate:1, lifecycleState:1}")
-  List<FormRPartA> findByTraineeTisId(String traineeTisId);
+  private ErrorConstants() {
+  }
 
-  List<FormRPartA> findByLifecycleState(LifecycleState lifecycleState);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ErrorConstants.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ErrorConstants.java
@@ -24,9 +24,7 @@ package uk.nhs.hee.tis.trainee.forms.service.exception;
 public final class ErrorConstants {
 
   public static final String ERR_VALIDATION = "error.validation";
-  public static final String ERR_INTERNAL_SERVER_ERROR = "error.internalServerError";
 
   private ErrorConstants() {
   }
-
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ErrorVM.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ErrorVM.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.service.exception;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * View Model for transferring error message with a list of field errors.
+ */
+public class ErrorVM implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String message;
+  private final String description;
+
+  private List<FieldErrorVM> fieldErrors;
+
+  public ErrorVM(String message) {
+    this(message, null);
+  }
+
+  public ErrorVM(String message, String description) {
+    this.message = message;
+    this.description = description;
+  }
+
+  public ErrorVM(String message, String description, List<FieldErrorVM> fieldErrors) {
+    this.message = message;
+    this.description = description;
+    this.fieldErrors = fieldErrors;
+  }
+
+  public void add(String objectName, String field, String message) {
+    if (fieldErrors == null) {
+      fieldErrors = new ArrayList<>();
+    }
+    fieldErrors.add(new FieldErrorVM(objectName, field, message));
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public List<FieldErrorVM> getFieldErrors() {
+    return fieldErrors;
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ExceptionTranslator.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ExceptionTranslator.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.service.exception;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.ResponseEntity.BodyBuilder;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Controller advice to translate the server side exceptions to client-friendly json structures.
+ */
+@ControllerAdvice
+public class ExceptionTranslator {
+
+  private final Logger log = LoggerFactory
+      .getLogger(ExceptionTranslator.class);
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ResponseBody
+  public ErrorVM processValidationError(MethodArgumentNotValidException ex) {
+    BindingResult result = ex.getBindingResult();
+    List<FieldError> fieldErrors = result.getFieldErrors();
+
+    return processFieldErrors(fieldErrors);
+  }
+
+  private ErrorVM processFieldErrors(
+      List<FieldError> fieldErrors) {
+    ErrorVM dto = new ErrorVM(ErrorConstants.ERR_VALIDATION);
+
+    for (FieldError fieldError : fieldErrors) {
+      dto.add(fieldError.getObjectName(), fieldError.getField(), fieldError.getDefaultMessage());
+    }
+
+    return dto;
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorVM> processRuntimeException(
+      Exception ex) {
+    BodyBuilder builder;
+    ErrorVM errorVM;
+    log.error(ex.getMessage(), ex);
+    ResponseStatus responseStatus = AnnotationUtils
+        .findAnnotation(ex.getClass(), ResponseStatus.class);
+    if (responseStatus != null) {
+      builder = ResponseEntity.status(responseStatus.value());
+      errorVM = new ErrorVM("error." + responseStatus.value().value(), responseStatus.reason());
+    } else {
+      builder = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR);
+      errorVM = new ErrorVM(ErrorConstants.ERR_INTERNAL_SERVER_ERROR, "Internal server error");
+    }
+    return builder.body(errorVM);
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/FieldErrorVM.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/FieldErrorVM.java
@@ -19,20 +19,36 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.trainee.forms.repository;
+package uk.nhs.hee.tis.trainee.forms.service.exception;
 
-import java.util.List;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
-import org.springframework.stereotype.Repository;
-import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
-import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
+import java.io.Serializable;
 
-@Repository
-public interface FormRPartARepository extends MongoRepository<FormRPartA, String> {
+public class FieldErrorVM implements Serializable {
 
-  @Query(fields = "{traineeTisId:1, id:1, submissionDate:1, lifecycleState:1}")
-  List<FormRPartA> findByTraineeTisId(String traineeTisId);
+  private static final long serialVersionUID = 1L;
 
-  List<FormRPartA> findByLifecycleState(LifecycleState lifecycleState);
+  private final String objectName;
+
+  private final String field;
+
+  private final String message;
+
+  public FieldErrorVM(String dto, String field, String message) {
+    this.objectName = dto;
+    this.field = field;
+    this.message = message;
+  }
+
+  public String getObjectName() {
+    return objectName;
+  }
+
+  public String getField() {
+    return field;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceTest.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.trainee.forms.api;
 
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -31,6 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,11 +40,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import uk.nhs.hee.tis.trainee.forms.api.validation.FormRPartAValidator;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartADto;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartSimpleDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
@@ -66,6 +73,9 @@ public class FormRPartAResourceTest {
   @MockBean
   private FormRPartAService formRPartAServiceMock;
 
+  @MockBean
+  private FormRPartAValidator formRPartAValidator;
+
   private FormRPartADto formRPartADto;
   private FormRPartSimpleDto formRPartSimpleDto;
 
@@ -73,8 +83,9 @@ public class FormRPartAResourceTest {
    * setup the Mvc test environment.
    */
   @BeforeEach
-  public void setup() {
-    FormRPartAResource formRPartAResource = new FormRPartAResource(formRPartAServiceMock);
+  void setup() {
+    FormRPartAResource formRPartAResource = new FormRPartAResource(formRPartAServiceMock,
+        formRPartAValidator);
     mockMvc = MockMvcBuilders.standaloneSetup(formRPartAResource)
         .setMessageConverters(jacksonMessageConverter)
         .build();
@@ -84,7 +95,7 @@ public class FormRPartAResourceTest {
    * init test data.
    */
   @BeforeEach
-  public void initData() {
+  void initData() {
     formRPartADto = new FormRPartADto();
     formRPartADto.setId(DEFAULT_ID);
     formRPartADto.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
@@ -99,7 +110,7 @@ public class FormRPartAResourceTest {
   }
 
   @Test
-  public void testCreateNewFormRPartAWithExistingId() throws Exception {
+  void testCreateNewFormRPartAWithExistingId() throws Exception {
     this.mockMvc.perform(post("/api/formr-parta")
         .contentType(TestUtil.APPLICATION_JSON_UTF8)
         .content(TestUtil.convertObjectToJsonBytes(formRPartADto)))
@@ -107,7 +118,7 @@ public class FormRPartAResourceTest {
   }
 
   @Test
-  public void testCreateNewFormRPartAShouldSucceed() throws Exception {
+  void testCreateNewFormRPartAShouldSucceed() throws Exception {
     formRPartADto.setId(null);
     FormRPartADto formRPartADtoReturn = new FormRPartADto();
     formRPartADtoReturn.setId(DEFAULT_ID);
@@ -123,7 +134,27 @@ public class FormRPartAResourceTest {
   }
 
   @Test
-  public void testUpdateFormRPartBShouldSucceed() throws Exception {
+  void testCreateDraftFormRPartAWithDraftExists() throws Exception {
+    formRPartADto.setId(null);
+    final String FORMR_PARTA_DTO_NAME = "FormRPartADto";
+
+    BeanPropertyBindingResult bindingResult =
+        new BeanPropertyBindingResult(formRPartADto, FORMR_PARTA_DTO_NAME);
+    bindingResult.addError(new FieldError(FORMR_PARTA_DTO_NAME, "lifecycleState",
+        "Draft form R Part A already exists"));
+
+    Method method = formRPartAValidator.getClass().getMethods()[0];
+    doThrow(new MethodArgumentNotValidException(new MethodParameter(method, 0), bindingResult))
+        .when(formRPartAValidator).validate(formRPartADto);
+
+    this.mockMvc.perform(post("/api/formr-parta")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .content(TestUtil.convertObjectToJsonBytes(formRPartADto)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void testUpdateFormRPartBShouldSucceed() throws Exception {
     formRPartADto.setId(DEFAULT_ID);
     FormRPartADto formRPartADtoReturn = new FormRPartADto();
     formRPartADtoReturn.setId(DEFAULT_ID);
@@ -142,7 +173,7 @@ public class FormRPartAResourceTest {
   }
 
   @Test
-  public void testGetFormRPartAsByTraineeTisId() throws Exception {
+  void testGetFormRPartAsByTraineeTisId() throws Exception {
     when(formRPartAServiceMock.getFormRPartAsByTraineeTisId(DEFAULT_TRAINEE_TIS_ID)).thenReturn(
         Arrays.asList(formRPartSimpleDto));
     this.mockMvc.perform(get("/api/formr-partas/" + DEFAULT_TRAINEE_TIS_ID)
@@ -156,7 +187,7 @@ public class FormRPartAResourceTest {
   }
 
   @Test
-  public void testGetFormRPartBById() throws Exception {
+  void testGetFormRPartBById() throws Exception {
     when(formRPartAServiceMock.getFormRPartAById(DEFAULT_ID)).thenReturn(formRPartADto);
     this.mockMvc.perform(get("/api/formr-parta/" + DEFAULT_ID)
         .contentType(TestUtil.APPLICATION_JSON_UTF8))

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceTest.java
@@ -127,7 +127,7 @@ public class FormRPartAResourceTest {
     formRPartADtoReturn.setSurname(formRPartADto.getSurname());
 
     when(formRPartAServiceMock.save(formRPartADto)).thenReturn(formRPartADtoReturn);
-    this.mockMvc.perform(post("/api/formr-parta")
+    mockMvc.perform(post("/api/formr-parta")
         .contentType(TestUtil.APPLICATION_JSON_UTF8)
         .content(TestUtil.convertObjectToJsonBytes(formRPartADto)))
         .andExpect(status().isCreated());
@@ -147,7 +147,7 @@ public class FormRPartAResourceTest {
     doThrow(new MethodArgumentNotValidException(new MethodParameter(method, 0), bindingResult))
         .when(formRPartAValidator).validate(formRPartADto);
 
-    this.mockMvc.perform(post("/api/formr-parta")
+    mockMvc.perform(post("/api/formr-parta")
         .contentType(TestUtil.APPLICATION_JSON_UTF8)
         .content(TestUtil.convertObjectToJsonBytes(formRPartADto)))
         .andExpect(status().isBadRequest());
@@ -162,7 +162,7 @@ public class FormRPartAResourceTest {
 
     when(formRPartAServiceMock.save(formRPartADto)).thenReturn(formRPartADtoReturn);
 
-    this.mockMvc.perform(put("/api/formr-parta")
+    mockMvc.perform(put("/api/formr-parta")
         .contentType(TestUtil.APPLICATION_JSON_UTF8)
         .content(TestUtil.convertObjectToJsonBytes(formRPartADto)))
         .andExpect(status().isOk())
@@ -176,7 +176,7 @@ public class FormRPartAResourceTest {
   void testGetFormRPartAsByTraineeTisId() throws Exception {
     when(formRPartAServiceMock.getFormRPartAsByTraineeTisId(DEFAULT_TRAINEE_TIS_ID)).thenReturn(
         Arrays.asList(formRPartSimpleDto));
-    this.mockMvc.perform(get("/api/formr-partas/" + DEFAULT_TRAINEE_TIS_ID)
+    mockMvc.perform(get("/api/formr-partas/" + DEFAULT_TRAINEE_TIS_ID)
         .contentType(TestUtil.APPLICATION_JSON_UTF8))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -189,7 +189,7 @@ public class FormRPartAResourceTest {
   @Test
   void testGetFormRPartBById() throws Exception {
     when(formRPartAServiceMock.getFormRPartAById(DEFAULT_ID)).thenReturn(formRPartADto);
-    this.mockMvc.perform(get("/api/formr-parta/" + DEFAULT_ID)
+    mockMvc.perform(get("/api/formr-parta/" + DEFAULT_ID)
         .contentType(TestUtil.APPLICATION_JSON_UTF8))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceTest.java
@@ -136,11 +136,11 @@ public class FormRPartAResourceTest {
   @Test
   void testCreateDraftFormRPartAWithDraftExists() throws Exception {
     formRPartADto.setId(null);
-    final String FORMR_PARTA_DTO_NAME = "FormRPartADto";
+    final String formRPartADtoName = "FormRPartADto";
 
     BeanPropertyBindingResult bindingResult =
-        new BeanPropertyBindingResult(formRPartADto, FORMR_PARTA_DTO_NAME);
-    bindingResult.addError(new FieldError(FORMR_PARTA_DTO_NAME, "lifecycleState",
+        new BeanPropertyBindingResult(formRPartADto, formRPartADtoName);
+    bindingResult.addError(new FieldError(formRPartADtoName, "lifecycleState",
         "Draft form R Part A already exists"));
 
     Method method = formRPartAValidator.getClass().getMethods()[0];

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidatorTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidatorTest.java
@@ -44,9 +44,10 @@ import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
 import uk.nhs.hee.tis.trainee.forms.repository.FormRPartARepository;
 
 @ExtendWith(MockitoExtension.class)
-public class FormRPartAValidatorTest {
+class FormRPartAValidatorTest {
 
   private static final String DEFAULT_ID = "DEFAULT_ID";
+  private static final String DEFAULT_TRAINEE_TIS_ID = "DEFAULT_TRAINEE_TIS_ID";
   private static final LifecycleState DEFAULT_LIFECYCLESTATE = LifecycleState.DRAFT;
 
   @InjectMocks
@@ -69,7 +70,9 @@ public class FormRPartAValidatorTest {
 
   @Test
   void validateDraftIfNoExistingDraftFound() {
-    when(formRPartARepositoryMock.findByLifecycleState(formRPartADto.getLifecycleState()))
+    when(formRPartARepositoryMock
+        .findByTraineeTisIdAndLifecycleState(formRPartADto.getTraineeTisId(),
+            formRPartADto.getLifecycleState()))
         .thenReturn(Lists.emptyList());
 
     List<FieldError> fieldErrors = validator.checkIfDraftUnique(formRPartADto);
@@ -79,16 +82,20 @@ public class FormRPartAValidatorTest {
 
   @Test
   void validateDraftIfMultipleDraftsFound() {
-    FormRPartA formRPartA_1 = new FormRPartA();
-    formRPartA_1.setId("ANOTHER_ID_1");
-    formRPartA_1.setLifecycleState(LifecycleState.DRAFT);
+    FormRPartA formRPartA1 = new FormRPartA();
+    formRPartA1.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
+    formRPartA1.setId("ANOTHER_ID_1");
+    formRPartA1.setLifecycleState(LifecycleState.DRAFT);
 
-    FormRPartA formRPartA_2 = new FormRPartA();
-    formRPartA_2.setId("ANOTHER_ID_2");
-    formRPartA_1.setLifecycleState(LifecycleState.DRAFT);
+    FormRPartA formRPartA2 = new FormRPartA();
+    formRPartA2.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
+    formRPartA2.setId("ANOTHER_ID_2");
+    formRPartA2.setLifecycleState(LifecycleState.DRAFT);
 
-    when(formRPartARepositoryMock.findByLifecycleState(formRPartADto.getLifecycleState()))
-        .thenReturn(Lists.list(formRPartA_1, formRPartA_2));
+    when(formRPartARepositoryMock
+        .findByTraineeTisIdAndLifecycleState(formRPartADto.getTraineeTisId(),
+            formRPartADto.getLifecycleState()))
+        .thenReturn(Lists.list(formRPartA1, formRPartA2));
 
     List<FieldError> fieldErrors = validator.checkIfDraftUnique(formRPartADto);
     assertThat("Should not return any errors", fieldErrors.size(), is(1));
@@ -99,10 +106,13 @@ public class FormRPartAValidatorTest {
   @Test
   void validateUpdateDraftIfOneDraftWithSameIdFound() {
     FormRPartA formRPartA = new FormRPartA();
+    formRPartA.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
     formRPartA.setId(DEFAULT_ID);
     formRPartA.setLifecycleState(LifecycleState.DRAFT);
 
-    when(formRPartARepositoryMock.findByLifecycleState(formRPartADto.getLifecycleState()))
+    when(formRPartARepositoryMock
+        .findByTraineeTisIdAndLifecycleState(formRPartADto.getTraineeTisId(),
+            formRPartADto.getLifecycleState()))
         .thenReturn(Lists.list(formRPartA));
 
     List<FieldError> fieldErrors = validator.checkIfDraftUnique(formRPartADto);
@@ -112,10 +122,13 @@ public class FormRPartAValidatorTest {
   @Test
   void validateUpdateDraftIfOneDraftWithDifferentIdFound() {
     FormRPartA formRPartA = new FormRPartA();
+    formRPartA.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
     formRPartA.setId("ANOTHER_ID");
     formRPartA.setLifecycleState(LifecycleState.DRAFT);
 
-    when(formRPartARepositoryMock.findByLifecycleState(formRPartADto.getLifecycleState()))
+    when(formRPartARepositoryMock
+        .findByTraineeTisIdAndLifecycleState(formRPartADto.getTraineeTisId(),
+            formRPartADto.getLifecycleState()))
         .thenReturn(Lists.list(formRPartA));
 
     List<FieldError> fieldErrors = validator.checkIfDraftUnique(formRPartADto);
@@ -129,10 +142,13 @@ public class FormRPartAValidatorTest {
     formRPartADto.setId(null);
 
     FormRPartA formRPartA = new FormRPartA();
+    formRPartA.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
     formRPartA.setId("ANOTHER_ID");
     formRPartA.setLifecycleState(LifecycleState.DRAFT);
 
-    when(formRPartARepositoryMock.findByLifecycleState(formRPartADto.getLifecycleState()))
+    when(formRPartARepositoryMock
+        .findByTraineeTisIdAndLifecycleState(formRPartADto.getTraineeTisId(),
+            formRPartADto.getLifecycleState()))
         .thenReturn(Lists.list(formRPartA));
 
     List<FieldError> fieldErrors = validator.checkIfDraftUnique(formRPartADto);
@@ -144,10 +160,13 @@ public class FormRPartAValidatorTest {
   @Test
   void validateShouldThrowExceptionWhenValidationFails() {
     FormRPartA formRPartA = new FormRPartA();
+    formRPartA.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
     formRPartA.setId("ANOTHER_ID");
     formRPartA.setLifecycleState(LifecycleState.DRAFT);
 
-    when(formRPartARepositoryMock.findByLifecycleState(formRPartADto.getLifecycleState()))
+    when(formRPartARepositoryMock
+        .findByTraineeTisIdAndLifecycleState(formRPartADto.getTraineeTisId(),
+            formRPartADto.getLifecycleState()))
         .thenReturn(Lists.list(formRPartA));
 
     String message = assertThrows(MethodArgumentNotValidException.class,
@@ -158,7 +177,9 @@ public class FormRPartAValidatorTest {
 
   @Test
   void validateShouldNotThrowExceptionWhenValidationSucceed() {
-    when(formRPartARepositoryMock.findByLifecycleState(formRPartADto.getLifecycleState()))
+    when(formRPartARepositoryMock
+        .findByTraineeTisIdAndLifecycleState(formRPartADto.getTraineeTisId(),
+            formRPartADto.getLifecycleState()))
         .thenReturn(Lists.emptyList());
 
     assertDoesNotThrow(() -> validator.validate(formRPartADto));

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidatorTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidatorTest.java
@@ -1,0 +1,166 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.api.validation;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import uk.nhs.hee.tis.trainee.forms.dto.FormRPartADto;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
+import uk.nhs.hee.tis.trainee.forms.repository.FormRPartARepository;
+
+@ExtendWith(MockitoExtension.class)
+public class FormRPartAValidatorTest {
+
+  private static final String DEFAULT_ID = "DEFAULT_ID";
+  private static final LifecycleState DEFAULT_LIFECYCLESTATE = LifecycleState.DRAFT;
+
+  @InjectMocks
+  FormRPartAValidator validator;
+
+  @Mock
+  private FormRPartARepository formRPartARepositoryMock;
+
+  private FormRPartADto formRPartADto;
+
+  /**
+   * init test data.
+   */
+  @BeforeEach
+  public void initData() {
+    formRPartADto = new FormRPartADto();
+    formRPartADto.setId(DEFAULT_ID);
+    formRPartADto.setLifecycleState(DEFAULT_LIFECYCLESTATE);
+  }
+
+  @Test
+  void validateDraftIfNoExistingDraftFound() {
+    when(formRPartARepositoryMock.findByLifecycleState(formRPartADto.getLifecycleState()))
+        .thenReturn(Lists.emptyList());
+
+    List<FieldError> fieldErrors = validator.checkIfDraftUnique(formRPartADto);
+    assertThat("Should not return any errors",
+        fieldErrors.size(), is(0));
+  }
+
+  @Test
+  void validateDraftIfMultipleDraftsFound() {
+    FormRPartA formRPartA_1 = new FormRPartA();
+    formRPartA_1.setId("ANOTHER_ID_1");
+    formRPartA_1.setLifecycleState(LifecycleState.DRAFT);
+
+    FormRPartA formRPartA_2 = new FormRPartA();
+    formRPartA_2.setId("ANOTHER_ID_2");
+    formRPartA_1.setLifecycleState(LifecycleState.DRAFT);
+
+    when(formRPartARepositoryMock.findByLifecycleState(formRPartADto.getLifecycleState()))
+        .thenReturn(Lists.list(formRPartA_1, formRPartA_2));
+
+    List<FieldError> fieldErrors = validator.checkIfDraftUnique(formRPartADto);
+    assertThat("Should not return any errors", fieldErrors.size(), is(1));
+    assertThat("Error not valid", fieldErrors.get(0).getDefaultMessage(),
+        is("More than one draft form R Part A already exist"));
+  }
+
+  @Test
+  void validateUpdateDraftIfOneDraftWithSameIdFound() {
+    FormRPartA formRPartA = new FormRPartA();
+    formRPartA.setId(DEFAULT_ID);
+    formRPartA.setLifecycleState(LifecycleState.DRAFT);
+
+    when(formRPartARepositoryMock.findByLifecycleState(formRPartADto.getLifecycleState()))
+        .thenReturn(Lists.list(formRPartA));
+
+    List<FieldError> fieldErrors = validator.checkIfDraftUnique(formRPartADto);
+    assertThat("Should not return any errors", fieldErrors.size(), is(0));
+  }
+
+  @Test
+  void validateUpdateDraftIfOneDraftWithDifferentIdFound() {
+    FormRPartA formRPartA = new FormRPartA();
+    formRPartA.setId("ANOTHER_ID");
+    formRPartA.setLifecycleState(LifecycleState.DRAFT);
+
+    when(formRPartARepositoryMock.findByLifecycleState(formRPartADto.getLifecycleState()))
+        .thenReturn(Lists.list(formRPartA));
+
+    List<FieldError> fieldErrors = validator.checkIfDraftUnique(formRPartADto);
+    assertThat("Should not return any errors", fieldErrors.size(), is(1));
+    assertThat("Error not valid", fieldErrors.get(0).getDefaultMessage(),
+        is("Draft form R Part A already exists"));
+  }
+
+  @Test
+  void validateCreateDraftIfOneDraftFound() {
+    formRPartADto.setId(null);
+
+    FormRPartA formRPartA = new FormRPartA();
+    formRPartA.setId("ANOTHER_ID");
+    formRPartA.setLifecycleState(LifecycleState.DRAFT);
+
+    when(formRPartARepositoryMock.findByLifecycleState(formRPartADto.getLifecycleState()))
+        .thenReturn(Lists.list(formRPartA));
+
+    List<FieldError> fieldErrors = validator.checkIfDraftUnique(formRPartADto);
+    assertThat("Should not return any errors", fieldErrors.size(), is(1));
+    assertThat("Error not valid", fieldErrors.get(0).getDefaultMessage(),
+        is("Draft form R Part A already exists"));
+  }
+
+  @Test
+  void validateShouldThrowExceptionWhenValidationFails() {
+    FormRPartA formRPartA = new FormRPartA();
+    formRPartA.setId("ANOTHER_ID");
+    formRPartA.setLifecycleState(LifecycleState.DRAFT);
+
+    when(formRPartARepositoryMock.findByLifecycleState(formRPartADto.getLifecycleState()))
+        .thenReturn(Lists.list(formRPartA));
+
+    String message = assertThrows(MethodArgumentNotValidException.class,
+        () -> validator.validate(formRPartADto)).getMessage();
+
+    assertThat(message, containsString("Draft form R Part A already exists"));
+  }
+
+  @Test
+  void validateShouldNotThrowExceptionWhenValidationSucceed() {
+    when(formRPartARepositoryMock.findByLifecycleState(formRPartADto.getLifecycleState()))
+        .thenReturn(Lists.emptyList());
+
+    assertDoesNotThrow(() -> validator.validate(formRPartADto));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidatorTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidatorTest.java
@@ -98,7 +98,7 @@ class FormRPartAValidatorTest {
         .thenReturn(Lists.list(formRPartA1, formRPartA2));
 
     List<FieldError> fieldErrors = validator.checkIfDraftUnique(formRPartADto);
-    assertThat("Should not return any errors", fieldErrors.size(), is(1));
+    assertThat("Should return 1 error", fieldErrors.size(), is(1));
     assertThat("Error not valid", fieldErrors.get(0).getDefaultMessage(),
         is("More than one draft form R Part A already exist"));
   }
@@ -132,7 +132,7 @@ class FormRPartAValidatorTest {
         .thenReturn(Lists.list(formRPartA));
 
     List<FieldError> fieldErrors = validator.checkIfDraftUnique(formRPartADto);
-    assertThat("Should not return any errors", fieldErrors.size(), is(1));
+    assertThat("Should return 1 error", fieldErrors.size(), is(1));
     assertThat("Error not valid", fieldErrors.get(0).getDefaultMessage(),
         is("Draft form R Part A already exists"));
   }


### PR DESCRIPTION
1. add Controller Advice to forms service to deal with the Exception Response which is referenced from the tcs service.
2. add FormR PartA validator and add validation for checking if the draft is unique for both update and creation APIs.
3. add unit tests for the newly added validator.

When the validation failes, it returns 400 Bad Request http status and the format of reponse body is below:
```
{
    "message": "error.validation",
    "description": null,
    "fieldErrors": [
        {
            "objectName": "FormRPartADto",
            "field": "lifecycleState",
            "message": "Draft form R Part A already exists"
        }
    ]
}
```