### PR TITLE
feat: Use the trainee's TIS ID from token

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResource.java
@@ -20,11 +20,13 @@
 
 package uk.nhs.hee.tis.trainee.forms.api;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,8 +34,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.hee.tis.trainee.forms.api.util.AuthTokenUtil;
 import uk.nhs.hee.tis.trainee.forms.api.util.HeaderUtil;
 import uk.nhs.hee.tis.trainee.forms.api.validation.FormRPartBValidator;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartBDto;
@@ -47,36 +51,42 @@ public class FormRPartBResource {
 
   private static final String ENTITY_NAME = "formR_partB";
 
-  private final FormRPartBService formRPartBService;
-  private final FormRPartBValidator formRPartBValidator;
+  private final FormRPartBService service;
+  private final FormRPartBValidator validator;
 
-  public FormRPartBResource(FormRPartBService formRPartBService,
-      FormRPartBValidator formRPartBValidator) {
-    this.formRPartBService = formRPartBService;
-    this.formRPartBValidator = formRPartBValidator;
+  public FormRPartBResource(FormRPartBService service, FormRPartBValidator validator) {
+    this.service = service;
+    this.validator = validator;
   }
 
   /**
    * POST  /formr-partb : Create a new FormRPartB.
    *
-   * @param formRPartBDto the formRPartBDto to create
-   * @return the ResponseEntity with status 201 (Created) and with body the new formRPartBDto, or
-   * with status 400 (Bad Request) if the formRPartB has already an ID
+   * @param dto   the dto to create
+   * @param token The authorization token from the request header.
+   * @return the ResponseEntity with status 201 (Created) and with body the new dto, or with status
+   *     400 (Bad Request) if the formRPartB has already an ID
    * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PostMapping("/formr-partb")
-  public ResponseEntity<FormRPartBDto> createFormRPartB(
-      @RequestBody FormRPartBDto formRPartBDto)
+  public ResponseEntity<FormRPartBDto> createFormRPartB(@RequestBody FormRPartBDto dto,
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String token)
       throws URISyntaxException, MethodArgumentNotValidException {
-    log.debug("REST request to save FormRPartB : {}", formRPartBDto);
-    if (formRPartBDto.getId() != null) {
+    log.debug("REST request to save FormRPartB : {}", dto);
+    if (dto.getId() != null) {
       return ResponseEntity.badRequest().headers(HeaderUtil
           .createFailureAlert(ENTITY_NAME, "idexists",
-              "A new formRpartB cannot already have an ID"))
-          .body(null);
+              "A new formRpartB cannot already have an ID")).body(null);
     }
-    formRPartBValidator.validate(formRPartBDto);
-    FormRPartBDto result = formRPartBService.save(formRPartBDto);
+
+    Optional<ResponseEntity<FormRPartBDto>> responseEntity = AuthTokenUtil
+        .verifyTraineeTisId(dto.getTraineeTisId(), token);
+    if (responseEntity.isPresent()) {
+      return responseEntity.get();
+    }
+
+    validator.validate(dto);
+    FormRPartBDto result = service.save(dto);
     return ResponseEntity.created(new URI("/api/formr-partb/" + result.getId()))
         .body(result);
   }
@@ -84,58 +94,78 @@ public class FormRPartBResource {
   /**
    * PUT /formr-partb : Update a FormRPartB.
    *
-   * @param formRPartBDto the formRPartBDto to update
-   * @return the ResponseEntity with status 200 and with body the new formRPartBDto, or with status
-   * 500 (Internal Server Error) if the formRPartBDto couldn't be updated. If the id is not
-   * provided, will create a new FormRPartB
-   * @throws URISyntaxException
+   * @param dto   the dto to update
+   * @param token The authorization token from the request header.
+   * @return the ResponseEntity with status 200 and with body the new dto, or with status 500
+   *     (Internal Server Error) if the dto couldn't be updated. If the id is not provided, will
+   *     create a new FormRPartB
+   * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PutMapping("/formr-partb")
-  public ResponseEntity<FormRPartBDto> updateFormRPartB(
-      @RequestBody FormRPartBDto formRPartBDto)
+  public ResponseEntity<FormRPartBDto> updateFormRPartB(@RequestBody FormRPartBDto dto,
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String token)
       throws URISyntaxException, MethodArgumentNotValidException {
-    log.debug("REST request to update FormRPartB : {}", formRPartBDto);
-    if (formRPartBDto.getId() == null) {
-      return createFormRPartB(formRPartBDto);
+    log.debug("REST request to update FormRPartB : {}", dto);
+    if (dto.getId() == null) {
+      return createFormRPartB(dto, token);
     }
-    formRPartBValidator.validate(formRPartBDto);
-    FormRPartBDto result = formRPartBService.save(formRPartBDto);
+
+    Optional<ResponseEntity<FormRPartBDto>> responseEntity = AuthTokenUtil
+        .verifyTraineeTisId(dto.getTraineeTisId(), token);
+    if (responseEntity.isPresent()) {
+      return responseEntity.get();
+    }
+
+    validator.validate(dto);
+    FormRPartBDto result = service.save(dto);
     return ResponseEntity.ok().body(result);
   }
 
   /**
-   * GET /formr-partbs/:traineeTisId.
+   * GET /formr-partbs.
    *
-   * @param traineeProfileId the id of trainee profile to get
-   * @return list of formR partB based on the traineeTisId
+   * @param token The authorization token from the request header.
+   * @return list of the trainee's formR partB forms.
    */
-  @GetMapping("/formr-partbs/{traineeTisId}")
-  public ResponseEntity<List<FormRPartSimpleDto>> getFormRPartBsByTraineeId(
-      @PathVariable(name = "traineeTisId") String traineeProfileId) {
-    // TODO: verify if the traineeId belongs to the trainee
-    log.debug("FormR-PartB of a trainee by traineeTisId {}", traineeProfileId);
-    List<FormRPartSimpleDto> formRPartBDtos = formRPartBService
-        .getFormRPartBsByTraineeTisId(traineeProfileId);
-    return ResponseEntity.ok(formRPartBDtos);
+  @GetMapping("/formr-partbs")
+  public ResponseEntity<List<FormRPartSimpleDto>> getTraineeFormRPartBs(
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+    log.trace("FormR-PartAs of authenticated user.");
+    String traineeTisId;
+
+    try {
+      traineeTisId = AuthTokenUtil.getTraineeTisId(token);
+    } catch (IOException e) {
+      log.warn("Unable to read tisId from token.", e);
+      return ResponseEntity.badRequest().build();
+    }
+
+    List<FormRPartSimpleDto> formRPartSimpleDtos = service
+        .getFormRPartBsByTraineeTisId(traineeTisId);
+    return ResponseEntity.ok(formRPartSimpleDtos);
   }
 
   /**
    * GET /formr-partb/:id
    *
-   * @param id The ID of the form
+   * @param id    The ID of the form
+   * @param token The authorization token from the request header.
    * @return the formR partB based on the id
    */
   @GetMapping("/formr-partb/{id}")
-  public ResponseEntity<FormRPartBDto> getFormRPartAsById(
-      @PathVariable(name = "id") String id
-  ) {
-    // TODO: verify the formR PartB for the id belongs to the trainee
+  public ResponseEntity<FormRPartBDto> getFormRPartAsById(@PathVariable String id,
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
     log.debug("FormR-PartA by id {}", id);
-    FormRPartBDto formRPartBDto = formRPartBService.getFormRPartBById(id);
-    if (formRPartBDto != null) {
-      return ResponseEntity.ok(formRPartBDto);
-    } else {
-      return new ResponseEntity(HttpStatus.NOT_FOUND);
+
+    String traineeTisId;
+    try {
+      traineeTisId = AuthTokenUtil.getTraineeTisId(token);
+    } catch (IOException e) {
+      log.warn("Unable to read tisId from token.", e);
+      return ResponseEntity.badRequest().build();
     }
+
+    FormRPartBDto formRPartBDto = service.getFormRPartBById(id, traineeTisId);
+    return ResponseEntity.of(Optional.ofNullable(formRPartBDto));
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtil.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtil.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.api.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Slf4j
+public class AuthTokenUtil {
+
+  private static final String TIS_ID_ATTRIBUTE = "custom:tisId";
+
+  private static ObjectMapper mapper = new ObjectMapper();
+
+  public static String getTraineeTisId(String token) throws IOException {
+    String[] tokenSections = token.split("\\.");
+    byte[] payloadBytes = Base64.getDecoder()
+        .decode(tokenSections[1].getBytes(StandardCharsets.UTF_8));
+
+    Map payload = mapper.readValue(payloadBytes, Map.class);
+    return (String) payload.get(TIS_ID_ATTRIBUTE);
+  }
+
+  public static <T> Optional<ResponseEntity<T>> verifyTraineeTisId(String requestedTraineeTisId,
+      String token) {
+    ResponseEntity<T> responseEntity = null;
+
+    String tokenTraineeTisId;
+    try {
+      tokenTraineeTisId = getTraineeTisId(token);
+
+      if (!requestedTraineeTisId.equals(tokenTraineeTisId)) {
+        log.warn("The form's trainee TIS ID did not match authenticated user.");
+        responseEntity = ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+      }
+    } catch (IOException e) {
+      log.warn("Unable to read tisId from token.", e);
+      responseEntity = ResponseEntity.badRequest().build();
+    }
+
+    return Optional.ofNullable(responseEntity);
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtil.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtil.java
@@ -36,17 +36,36 @@ public class AuthTokenUtil {
 
   private static final String TIS_ID_ATTRIBUTE = "custom:tisId";
 
-  private static ObjectMapper mapper = new ObjectMapper();
+  private static final ObjectMapper mapper = new ObjectMapper();
 
+  private AuthTokenUtil() {
+
+  }
+
+  /**
+   * Get the trainee's TIS ID from the provided token.
+   *
+   * @param token The token to use.
+   * @return The trainee's TIS ID.
+   * @throws IOException If the token's payload was not a Map.
+   */
   public static String getTraineeTisId(String token) throws IOException {
     String[] tokenSections = token.split("\\.");
     byte[] payloadBytes = Base64.getDecoder()
         .decode(tokenSections[1].getBytes(StandardCharsets.UTF_8));
 
-    Map payload = mapper.readValue(payloadBytes, Map.class);
+    Map<?, ?> payload = mapper.readValue(payloadBytes, Map.class);
     return (String) payload.get(TIS_ID_ATTRIBUTE);
   }
 
+  /**
+   * Verify that the token contains a valid trainee TIS ID and that it matches the expected ID.
+   *
+   * @param requestedTraineeTisId The ID to validate against.
+   * @param token                 The token to use.
+   * @param <T>                   The type of the response body.
+   * @return A ResponseEntity with a suitable error status, or empty if valid.
+   */
   public static <T> Optional<ResponseEntity<T>> verifyTraineeTisId(String requestedTraineeTisId,
       String token) {
     ResponseEntity<T> responseEntity = null;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartARepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartARepository.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.forms.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -30,6 +31,8 @@ import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
 
 @Repository
 public interface FormRPartARepository extends MongoRepository<FormRPartA, String> {
+
+  Optional<FormRPartA> findByIdAndTraineeTisId(String id, String traineeTisId);
 
   @Query(fields = "{traineeTisId:1, id:1, submissionDate:1, lifecycleState:1}")
   List<FormRPartA> findByTraineeTisId(String traineeTisId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartBRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartBRepository.java
@@ -21,6 +21,7 @@
 package uk.nhs.hee.tis.trainee.forms.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -29,6 +30,8 @@ import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
 
 @Repository
 public interface FormRPartBRepository extends MongoRepository<FormRPartB, String> {
+
+  Optional<FormRPartB> findByIdAndTraineeTisId(String id, String traineeTisId);
 
   @Query(fields = "{traineeTisId:1, id:1, submissionDate:1, lifecycleState:1}")
   List<FormRPartB> findByTraineeTisId(String traineeTisId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
@@ -38,16 +38,17 @@ public interface FormRPartAService {
   /**
    * Get the forms for a trainee.
    *
-   * @param traineeProfileId The ID of the trainee to get the forms for.
+   * @param traineeTisId The ID of the trainee to get the forms for.
    * @return A collection of forms found for the trainee.
    */
-  List<FormRPartSimpleDto> getFormRPartAsByTraineeTisId(String traineeProfileId);
+  List<FormRPartSimpleDto> getFormRPartAsByTraineeTisId(String traineeTisId);
 
   /**
    * Get a form by id.
    *
-   * @param id The ID of the form.
+   * @param id           The ID of the form.
+   * @param traineeTisId The ID of the trainee to get the form for.
    * @return The retrieved form.
    */
-  FormRPartADto getFormRPartAById(String id);
+  FormRPartADto getFormRPartAById(String id, String traineeTisId);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
@@ -37,16 +37,17 @@ public interface FormRPartBService {
   /**
    * Get the forms for a trainee.
    *
-   * @param traineeProfileId The ID of the trainee to get the forms for.
+   * @param traineeTisId The ID of the trainee to get the forms for.
    * @return A collection of forms found for the trainee.
    */
-  List<FormRPartSimpleDto> getFormRPartBsByTraineeTisId(String traineeProfileId);
+  List<FormRPartSimpleDto> getFormRPartBsByTraineeTisId(String traineeTisId);
 
   /**
    * Get a form by id.
    *
-   * @param id The ID of the form.
+   * @param id           The ID of the form.
+   * @param traineeTisId The ID of the trainee to get the form for.
    * @return The retrieved form.
    */
-  FormRPartBDto getFormRPartBById(String id);
+  FormRPartBDto getFormRPartBById(String id, String traineeTisId);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartAServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartAServiceImpl.java
@@ -37,14 +37,13 @@ import uk.nhs.hee.tis.trainee.forms.service.FormRPartAService;
 @Transactional
 public class FormRPartAServiceImpl implements FormRPartAService {
 
-  private final FormRPartAMapper formRPartAMapper;
+  private final FormRPartAMapper mapper;
 
-  private final FormRPartARepository formRPartARepository;
+  private final FormRPartARepository repository;
 
-  public FormRPartAServiceImpl(FormRPartARepository formRPartARepository,
-      FormRPartAMapper formRPartAMapper) {
-    this.formRPartARepository = formRPartARepository;
-    this.formRPartAMapper = formRPartAMapper;
+  public FormRPartAServiceImpl(FormRPartARepository repository, FormRPartAMapper mapper) {
+    this.repository = repository;
+    this.mapper = mapper;
   }
 
   /**
@@ -53,9 +52,9 @@ public class FormRPartAServiceImpl implements FormRPartAService {
   @Override
   public FormRPartADto save(FormRPartADto formRPartADto) {
     log.info("Request to save FormRPartA : {}", formRPartADto);
-    FormRPartA formRPartA = formRPartAMapper.toEntity(formRPartADto);
-    formRPartA = formRPartARepository.save(formRPartA);
-    return formRPartAMapper.toDto(formRPartA);
+    FormRPartA formRPartA = mapper.toEntity(formRPartADto);
+    formRPartA = repository.save(formRPartA);
+    return mapper.toDto(formRPartA);
   }
 
   /**
@@ -64,17 +63,17 @@ public class FormRPartAServiceImpl implements FormRPartAService {
   @Override
   public List<FormRPartSimpleDto> getFormRPartAsByTraineeTisId(String traineeTisId) {
     log.info("Request to get FormRPartA list by trainee profileId : {}", traineeTisId);
-    List<FormRPartA> formRPartAList = formRPartARepository.findByTraineeTisId(traineeTisId);
-    return formRPartAMapper.toSimpleDtos(formRPartAList);
+    List<FormRPartA> formRPartAList = repository.findByTraineeTisId(traineeTisId);
+    return mapper.toSimpleDtos(formRPartAList);
   }
 
   /**
    * get FormRPartA by id.
    */
   @Override
-  public FormRPartADto getFormRPartAById(String id) {
+  public FormRPartADto getFormRPartAById(String id, String traineeTisId) {
     log.info("Request to get FormRPartA by id : {}", id);
-    FormRPartA formRPartA = formRPartARepository.findById(id).orElse(null);
-    return formRPartAMapper.toDto(formRPartA);
+    FormRPartA formRPartA = repository.findByIdAndTraineeTisId(id, traineeTisId).orElse(null);
+    return mapper.toDto(formRPartA);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartBServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartBServiceImpl.java
@@ -71,9 +71,10 @@ public class FormRPartBServiceImpl implements FormRPartBService {
    * get FormRPartB by id.
    */
   @Override
-  public FormRPartBDto getFormRPartBById(String id) {
+  public FormRPartBDto getFormRPartBById(String id, String traineeTisId) {
     log.info("Request to get FormRPartB by id : {}", id);
-    FormRPartB formRPartB = formRPartBRepository.findById(id).orElse(null);
+    FormRPartB formRPartB = formRPartBRepository.findByIdAndTraineeTisId(id, traineeTisId)
+        .orElse(null);
     return formRPartBMapper.toDto(formRPartB);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ server:
 spring:
   data:
     mongodb:
-      uri: mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:forms}
+      uri: mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:forms}?authSource=admin
 
 logging:
   level:

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceTest.java
@@ -164,7 +164,7 @@ class FormRPartAResourceTest {
     BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(dto, "formDto");
     bindingResult.addError(new FieldError("formDto", "formField", "Form field not valid."));
 
-    Method method = validator.getClass().getMethods()[0];
+    Method method = validator.getClass().getMethod("validate", FormRPartADto.class);
     Exception exception = new MethodArgumentNotValidException(new MethodParameter(method, 0),
         bindingResult);
     doThrow(exception).when(validator).validate(dto);
@@ -224,7 +224,7 @@ class FormRPartAResourceTest {
     BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(dto, "formDto");
     bindingResult.addError(new FieldError("formDto", "formField", "Form field not valid."));
 
-    Method method = validator.getClass().getMethods()[0];
+    Method method = validator.getClass().getMethod("validate", FormRPartADto.class);
     Exception exception = new MethodArgumentNotValidException(new MethodParameter(method, 0),
         bindingResult);
     doThrow(exception).when(validator).validate(dto);

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceTest.java
@@ -21,19 +21,22 @@
 
 package uk.nhs.hee.tis.trainee.forms.api;
 
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,6 +44,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -57,7 +61,9 @@ import uk.nhs.hee.tis.trainee.forms.service.FormRPartAService;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(controllers = FormRPartAResource.class)
-public class FormRPartAResourceTest {
+class FormRPartAResourceTest {
+
+  private static final String TIS_ID_ATTRIBUTE = "custom:tisId";
 
   private static final String DEFAULT_ID = "DEFAULT_ID";
   private static final String DEFAULT_TRAINEE_TIS_ID = "1";
@@ -65,27 +71,35 @@ public class FormRPartAResourceTest {
   private static final String DEFAULT_SURNAME = "DEFAULT_SURNAME";
   private static final LifecycleState DEFAULT_LIFECYCLESTATE = LifecycleState.DRAFT;
 
+  private static final String AUTH_TOKEN;
+
+  static {
+    String payload = String.format("{\"%s\":\"%s\"}", TIS_ID_ATTRIBUTE, DEFAULT_TRAINEE_TIS_ID);
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    AUTH_TOKEN = String.format("aGVhZGVy.%s.c2lnbmF0dXJl", encodedPayload);
+  }
+
   @Autowired
   private MappingJackson2HttpMessageConverter jacksonMessageConverter;
 
   private MockMvc mockMvc;
 
   @MockBean
-  private FormRPartAService formRPartAServiceMock;
+  private FormRPartAService service;
 
   @MockBean
-  private FormRPartAValidator formRPartAValidator;
+  private FormRPartAValidator validator;
 
-  private FormRPartADto formRPartADto;
-  private FormRPartSimpleDto formRPartSimpleDto;
+  private FormRPartADto dto;
+  private FormRPartSimpleDto simpleDto;
 
   /**
    * setup the Mvc test environment.
    */
   @BeforeEach
   void setup() {
-    FormRPartAResource formRPartAResource = new FormRPartAResource(formRPartAServiceMock,
-        formRPartAValidator);
+    FormRPartAResource formRPartAResource = new FormRPartAResource(service, validator);
     mockMvc = MockMvcBuilders.standaloneSetup(formRPartAResource)
         .setMessageConverters(jacksonMessageConverter)
         .build();
@@ -96,108 +110,248 @@ public class FormRPartAResourceTest {
    */
   @BeforeEach
   void initData() {
-    formRPartADto = new FormRPartADto();
-    formRPartADto.setId(DEFAULT_ID);
-    formRPartADto.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    formRPartADto.setForename(DEFAULT_FORENAME);
-    formRPartADto.setSurname(DEFAULT_SURNAME);
-    formRPartADto.setLifecycleState(DEFAULT_LIFECYCLESTATE);
+    dto = new FormRPartADto();
+    dto.setId(DEFAULT_ID);
+    dto.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
+    dto.setForename(DEFAULT_FORENAME);
+    dto.setSurname(DEFAULT_SURNAME);
+    dto.setLifecycleState(DEFAULT_LIFECYCLESTATE);
 
-    formRPartSimpleDto = new FormRPartSimpleDto();
-    formRPartSimpleDto.setId(DEFAULT_ID);
-    formRPartSimpleDto.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    formRPartSimpleDto.setLifecycleState(DEFAULT_LIFECYCLESTATE);
+    simpleDto = new FormRPartSimpleDto();
+    simpleDto.setId(DEFAULT_ID);
+    simpleDto.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
+    simpleDto.setLifecycleState(DEFAULT_LIFECYCLESTATE);
   }
 
   @Test
-  void testCreateNewFormRPartAWithExistingId() throws Exception {
-    this.mockMvc.perform(post("/api/formr-parta")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(formRPartADto)))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  void testCreateNewFormRPartAShouldSucceed() throws Exception {
-    formRPartADto.setId(null);
-    FormRPartADto formRPartADtoReturn = new FormRPartADto();
-    formRPartADtoReturn.setId(DEFAULT_ID);
-    formRPartADtoReturn.setTraineeTisId(formRPartADto.getTraineeTisId());
-    formRPartADtoReturn.setForename(formRPartADto.getForename());
-    formRPartADtoReturn.setSurname(formRPartADto.getSurname());
-
-    when(formRPartAServiceMock.save(formRPartADto)).thenReturn(formRPartADtoReturn);
+  void postShouldNotCreateFormWhenNoToken() throws Exception {
+    dto.setId(null);
     mockMvc.perform(post("/api/formr-parta")
         .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(formRPartADto)))
-        .andExpect(status().isCreated());
+        .content(TestUtil.convertObjectToJsonBytes(dto)))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
   }
 
   @Test
-  void testCreateDraftFormRPartAWithDraftExists() throws Exception {
-    formRPartADto.setId(null);
-    final String formRPartADtoName = "FormRPartADto";
+  void postShouldNotCreateFormWhenTokenIsInvalid() throws Exception {
+    dto.setId(null);
+    mockMvc.perform(post("/api/formr-parta")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+        .andExpect(status().isBadRequest());
 
-    BeanPropertyBindingResult bindingResult =
-        new BeanPropertyBindingResult(formRPartADto, formRPartADtoName);
-    bindingResult.addError(new FieldError(formRPartADtoName, "lifecycleState",
-        "Draft form R Part A already exists"));
+    verifyNoInteractions(service);
+  }
 
-    Method method = formRPartAValidator.getClass().getMethods()[0];
-    doThrow(new MethodArgumentNotValidException(new MethodParameter(method, 0), bindingResult))
-        .when(formRPartAValidator).validate(formRPartADto);
+  @Test
+  void postShouldNotCreateFormWhenFormExists() throws Exception {
+    mockMvc.perform(post("/api/formr-parta")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void postShouldNotCreateFormWhenDtoValidationFails() throws Exception {
+    dto.setId(null);
+
+    BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(dto, "formDto");
+    bindingResult.addError(new FieldError("formDto", "formField", "Form field not valid."));
+
+    Method method = validator.getClass().getMethods()[0];
+    Exception exception = new MethodArgumentNotValidException(new MethodParameter(method, 0),
+        bindingResult);
+    doThrow(exception).when(validator).validate(dto);
 
     mockMvc.perform(post("/api/formr-parta")
         .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(formRPartADto)))
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
   }
 
   @Test
-  void testUpdateFormRPartBShouldSucceed() throws Exception {
-    formRPartADto.setId(DEFAULT_ID);
-    FormRPartADto formRPartADtoReturn = new FormRPartADto();
-    formRPartADtoReturn.setId(DEFAULT_ID);
-    formRPartADtoReturn.setLifecycleState(LifecycleState.SUBMITTED);
+  void postShouldCreateFormWhenDtoValidationPasses() throws Exception {
+    dto.setId(null);
+    FormRPartADto createdDto = new FormRPartADto();
+    createdDto.setId(DEFAULT_ID);
+    createdDto.setLifecycleState(LifecycleState.DRAFT);
 
-    when(formRPartAServiceMock.save(formRPartADto)).thenReturn(formRPartADtoReturn);
+    when(service.save(dto)).thenReturn(createdDto);
 
     mockMvc.perform(put("/api/formr-parta")
         .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(formRPartADto)))
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isCreated())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(header().string(HttpHeaders.LOCATION, "/api/formr-parta/" + DEFAULT_ID))
+        .andExpect(jsonPath("$.id").value(DEFAULT_ID))
+        .andExpect(jsonPath("$.lifecycleState").value(LifecycleState.DRAFT.name()));
+  }
+
+  @Test
+  void putShouldNotUpdateFormWhenNoToken() throws Exception {
+    mockMvc.perform(put("/api/formr-parta")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .content(TestUtil.convertObjectToJsonBytes(dto)))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void putShouldNotUpdateFormWhenTokenIsInvalid() throws Exception {
+    mockMvc.perform(put("/api/formr-parta")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void putShouldNotCreateFormWhenDtoValidationFails() throws Exception {
+    BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(dto, "formDto");
+    bindingResult.addError(new FieldError("formDto", "formField", "Form field not valid."));
+
+    Method method = validator.getClass().getMethods()[0];
+    Exception exception = new MethodArgumentNotValidException(new MethodParameter(method, 0),
+        bindingResult);
+    doThrow(exception).when(validator).validate(dto);
+
+    mockMvc.perform(put("/api/formr-parta")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void putShouldUpdateFormWhenFormExists() throws Exception {
+    FormRPartADto savedDto = new FormRPartADto();
+    savedDto.setId(DEFAULT_ID);
+    savedDto.setLifecycleState(LifecycleState.SUBMITTED);
+
+    when(service.save(dto)).thenReturn(savedDto);
+
+    mockMvc.perform(put("/api/formr-parta")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value(DEFAULT_ID))
-        .andExpect(jsonPath("$.lifecycleState")
-            .value(LifecycleState.SUBMITTED.name()));
+        .andExpect(jsonPath("$.lifecycleState").value(LifecycleState.SUBMITTED.name()));
   }
 
   @Test
-  void testGetFormRPartAsByTraineeTisId() throws Exception {
-    when(formRPartAServiceMock.getFormRPartAsByTraineeTisId(DEFAULT_TRAINEE_TIS_ID)).thenReturn(
-        Arrays.asList(formRPartSimpleDto));
-    mockMvc.perform(get("/api/formr-partas/" + DEFAULT_TRAINEE_TIS_ID)
+  void putShouldCreateFormWhenFormNotExists() throws Exception {
+    dto.setId(null);
+    FormRPartADto createdDto = new FormRPartADto();
+    createdDto.setId(DEFAULT_ID);
+    createdDto.setLifecycleState(LifecycleState.DRAFT);
+
+    when(service.save(dto)).thenReturn(createdDto);
+
+    mockMvc.perform(put("/api/formr-parta")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isCreated())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(header().string(HttpHeaders.LOCATION, "/api/formr-parta/" + DEFAULT_ID))
+        .andExpect(jsonPath("$.id").value(DEFAULT_ID))
+        .andExpect(jsonPath("$.lifecycleState").value(LifecycleState.DRAFT.name()));
+  }
+
+  @Test
+  void getShouldNotReturnTraineesFormsWhenNoToken() throws Exception {
+    mockMvc.perform(get("/api/formr-partas")
         .contentType(TestUtil.APPLICATION_JSON_UTF8))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void getShouldNotReturnTraineesFormsWhenTokenHasNoTraineeId() throws Exception {
+    mockMvc.perform(get("/api/formr-partas")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void getShouldReturnTraineesFormsWhenTokenHasTraineeId() throws Exception {
+    when(service.getFormRPartAsByTraineeTisId(DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(Collections.singletonList(simpleDto));
+
+    mockMvc.perform(get("/api/formr-partas")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$").value(hasSize(1)))
-        .andExpect(jsonPath("$.[*].id").value(hasItem(DEFAULT_ID)))
-        .andExpect(jsonPath("$.[*].lifecycleState")
-            .value(hasItem(DEFAULT_LIFECYCLESTATE.name())));
+        .andExpect(jsonPath("$.[0].id").value(DEFAULT_ID))
+        .andExpect(jsonPath("$.[0].traineeTisId").value(DEFAULT_TRAINEE_TIS_ID))
+        .andExpect(jsonPath("$.[0].lifecycleState").value(DEFAULT_LIFECYCLESTATE.name()));
   }
 
   @Test
-  void testGetFormRPartBById() throws Exception {
-    when(formRPartAServiceMock.getFormRPartAById(DEFAULT_ID)).thenReturn(formRPartADto);
+  void getByIdShouldNotReturnFormWhenNoToken() throws Exception {
     mockMvc.perform(get("/api/formr-parta/" + DEFAULT_ID)
         .contentType(TestUtil.APPLICATION_JSON_UTF8))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void getByIdShouldNotReturnFormWhenTokenHasNoTraineeId() throws Exception {
+    mockMvc.perform(get("/api/formr-parta/" + DEFAULT_ID)
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void getByIdShouldNotReturnFormWhenFormIsNotTrainees() throws Exception {
+    when(service.getFormRPartAById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID)).thenReturn(null);
+    mockMvc.perform(get("/api/formr-parta/" + DEFAULT_ID)
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void getByIdShouldReturnFormWhenFormIsTrainees() throws Exception {
+    when(service.getFormRPartAById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(dto);
+    mockMvc.perform(get("/api/formr-parta/" + DEFAULT_ID)
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value(DEFAULT_ID))
         .andExpect(jsonPath("$.traineeTisId").value(DEFAULT_TRAINEE_TIS_ID))
         .andExpect(jsonPath("$.forename").value(DEFAULT_FORENAME))
         .andExpect(jsonPath("$.surname").value(DEFAULT_SURNAME))
-        .andExpect(jsonPath("$.lifecycleState")
-            .value(DEFAULT_LIFECYCLESTATE.name()));
+        .andExpect(jsonPath("$.lifecycleState").value(DEFAULT_LIFECYCLESTATE.name()));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResourceTest.java
@@ -1,5 +1,6 @@
 /*
  * The MIT License (MIT)
+ *
  * Copyright 2020 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
@@ -20,22 +21,22 @@
 
 package uk.nhs.hee.tis.trainee.forms.api;
 
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.lang.reflect.Method;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.Arrays;
-import org.assertj.core.util.Lists;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,6 +44,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -52,49 +54,31 @@ import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import uk.nhs.hee.tis.trainee.forms.api.validation.FormRPartBValidator;
-import uk.nhs.hee.tis.trainee.forms.dto.DeclarationDto;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartBDto;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartSimpleDto;
-import uk.nhs.hee.tis.trainee.forms.dto.WorkDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(controllers = FormRPartBResource.class)
-public class FormRPartBResourceTest {
+class FormRPartBResourceTest {
+
+  private static final String TIS_ID_ATTRIBUTE = "custom:tisId";
 
   private static final String DEFAULT_ID = "DEFAULT_ID";
   private static final String DEFAULT_TRAINEE_TIS_ID = "1";
   private static final String DEFAULT_FORENAME = "DEFAULT_FORENAME";
   private static final String DEFAULT_SURNAME = "DEFAULT_SURNAME";
+  private static final LifecycleState DEFAULT_LIFECYCLESTATE = LifecycleState.DRAFT;
 
-  private static final String DEFAULT_TYPE_OF_WORK = "DEFAULT_TYPE_OF_WORK";
-  private static final LocalDate DEFAULT_WORK_START_DATE = LocalDate.now(ZoneId.systemDefault());
-  private static final LocalDate DEFAULT_WORk_END_DATE = LocalDate.now(ZoneId.systemDefault());
-  private static final String DEFAULT_WORK_TRAINING_POST = "DEFAULT_WORK_TRAINING_POST";
-  private static final String DEFAULT_WORK_SITE = "DEFAULT_WORK_SITE";
-  private static final String DEFAULT_WORK_SITE_LOCATION = "DEFAULT_WORK_SITE_LOCATION";
-  private static final Integer DEFAULT_TOTAL_LEAVE = 10;
+  private static final String AUTH_TOKEN;
 
-  private static final Boolean DEFAULT_IS_HONEST = true;
-  private static final Boolean DEFAULT_IS_HEALTHY = true;
-  private static final String DEFAULT_HEALTHY_STATEMENT = "DEFAULT_HEALTHY_STATEMENT";
-
-  private static final Boolean DEFAULT_HAVE_PREVIOUS_DECLARATIONS = true;
-  private static final String DEFAULT_PREVIOUS_DECLARATION_TYPE = "Signification event";
-  private static final LocalDate DEFAULT_PREVIOUS_DATE_OF_ENTRY = LocalDate
-      .now(ZoneId.systemDefault());
-  private static final String DEFAULT_PREVIOUS_DECLARATION_SUMMARY =
-      "DEFAULT_PREVIOUS_DECLARATION_SUMMARY";
-
-  private static final Boolean DEFAULT_HAVE_CURRENT_DECLARATIONS = true;
-  private static final String DEFAULT_CURRENT_DECLARATION_TYPE = "Signification event";
-  private static final LocalDate DEFAULT_CURRENT_DATE_OF_ENTRY = LocalDate
-      .now(ZoneId.systemDefault());
-  private static final String DEFAULT_CURRENT_DECLARATION_SUMMARY =
-      "DEFAULT_CURRENT_DECLARATION_SUMMARY";
-  private static final String DEFAULT_COMPLIMENTS = "DEFAULT_COMPLIMENTS";
-  private static final LifecycleState DEFAULT_LIFECYLCESTATE = LifecycleState.DRAFT;
+  static {
+    String payload = String.format("{\"%s\":\"%s\"}", TIS_ID_ATTRIBUTE, DEFAULT_TRAINEE_TIS_ID);
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    AUTH_TOKEN = String.format("aGVhZGVy.%s.c2lnbmF0dXJl", encodedPayload);
+  }
 
   @Autowired
   private MappingJackson2HttpMessageConverter jacksonMessageConverter;
@@ -102,24 +86,20 @@ public class FormRPartBResourceTest {
   private MockMvc mockMvc;
 
   @MockBean
-  private FormRPartBService formRPartBServiceMock;
+  private FormRPartBService service;
 
   @MockBean
-  private FormRPartBValidator formRPartBValidator;
+  private FormRPartBValidator validator;
 
-  private FormRPartBDto formRPartBDto;
-  private WorkDto workDto;
-  private FormRPartSimpleDto formRPartSimpleDto;
-  private DeclarationDto previousDeclarationDto;
-  private DeclarationDto currentDeclarationDto;
+  private FormRPartBDto dto;
+  private FormRPartSimpleDto simpleDto;
 
   /**
    * setup the Mvc test environment.
    */
   @BeforeEach
   void setup() {
-    FormRPartBResource formRPartBResource = new FormRPartBResource(formRPartBServiceMock,
-        formRPartBValidator);
+    FormRPartBResource formRPartBResource = new FormRPartBResource(service, validator);
     mockMvc = MockMvcBuilders.standaloneSetup(formRPartBResource)
         .setMessageConverters(jacksonMessageConverter)
         .build();
@@ -130,187 +110,248 @@ public class FormRPartBResourceTest {
    */
   @BeforeEach
   void initData() {
-    setupWorkData();
-    setupPreviousDeclarationData();
-    setupCurrentDeclarationData();
+    dto = new FormRPartBDto();
+    dto.setId(DEFAULT_ID);
+    dto.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
+    dto.setForename(DEFAULT_FORENAME);
+    dto.setSurname(DEFAULT_SURNAME);
+    dto.setLifecycleState(DEFAULT_LIFECYCLESTATE);
 
-    formRPartBDto = new FormRPartBDto();
-    formRPartBDto.setId(DEFAULT_ID);
-    formRPartBDto.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    formRPartBDto.setForename(DEFAULT_FORENAME);
-    formRPartBDto.setSurname(DEFAULT_SURNAME);
-    formRPartBDto.setWork(Lists.newArrayList(workDto));
-    formRPartBDto.setTotalLeave(DEFAULT_TOTAL_LEAVE);
-    formRPartBDto.setIsHonest(DEFAULT_IS_HONEST);
-    formRPartBDto.setIsHealthy(DEFAULT_IS_HEALTHY);
-    formRPartBDto.setHealthStatement(DEFAULT_HEALTHY_STATEMENT);
-    formRPartBDto.setHavePreviousDeclarations(DEFAULT_HAVE_PREVIOUS_DECLARATIONS);
-    formRPartBDto.setPreviousDeclarations(Lists.newArrayList(previousDeclarationDto));
-    formRPartBDto.setPreviousDeclarationSummary(DEFAULT_PREVIOUS_DECLARATION_SUMMARY);
-    formRPartBDto.setHaveCurrentDeclarations(DEFAULT_HAVE_CURRENT_DECLARATIONS);
-    formRPartBDto.setCurrentDeclarations(Lists.newArrayList(currentDeclarationDto));
-    formRPartBDto.setCurrentDeclarationSummary(DEFAULT_CURRENT_DECLARATION_SUMMARY);
-    formRPartBDto.setCompliments(DEFAULT_COMPLIMENTS);
-    formRPartBDto.setLifecycleState(DEFAULT_LIFECYLCESTATE);
-
-    formRPartSimpleDto = new FormRPartSimpleDto();
-    formRPartSimpleDto.setId(DEFAULT_ID);
-    formRPartSimpleDto.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    formRPartSimpleDto.setLifecycleState(DEFAULT_LIFECYLCESTATE);
-  }
-
-  /**
-   * Set up data for work.
-   */
-  void setupWorkData() {
-    workDto = new WorkDto();
-    workDto.setTypeOfWork(DEFAULT_TYPE_OF_WORK);
-    workDto.setStartDate(DEFAULT_WORK_START_DATE);
-    workDto.setEndDate(DEFAULT_WORk_END_DATE);
-    workDto.setTrainingPost(DEFAULT_WORK_TRAINING_POST);
-    workDto.setSite(DEFAULT_WORK_SITE);
-    workDto.setSiteLocation(DEFAULT_WORK_SITE_LOCATION);
-  }
-
-  /**
-   * Set up data for previous declaration.
-   */
-  void setupPreviousDeclarationData() {
-    previousDeclarationDto = new DeclarationDto();
-    previousDeclarationDto.setDeclarationType(DEFAULT_PREVIOUS_DECLARATION_TYPE);
-    previousDeclarationDto.setDateOfEntry(DEFAULT_PREVIOUS_DATE_OF_ENTRY);
-  }
-
-  /**
-   * Set up data for current declaration.
-   */
-  void setupCurrentDeclarationData() {
-    currentDeclarationDto = new DeclarationDto();
-    currentDeclarationDto.setDeclarationType(DEFAULT_CURRENT_DECLARATION_TYPE);
-    currentDeclarationDto.setDateOfEntry(DEFAULT_CURRENT_DATE_OF_ENTRY);
+    simpleDto = new FormRPartSimpleDto();
+    simpleDto.setId(DEFAULT_ID);
+    simpleDto.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
+    simpleDto.setLifecycleState(DEFAULT_LIFECYCLESTATE);
   }
 
   @Test
-  void testCreateNewFormRPartBWithExistingId() throws Exception {
+  void postShouldNotCreateFormWhenNoToken() throws Exception {
+    dto.setId(null);
     mockMvc.perform(post("/api/formr-partb")
         .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(formRPartBDto)))
+        .content(TestUtil.convertObjectToJsonBytes(dto)))
         .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
   }
 
   @Test
-  void testCreateNewFormRPartBShouldSucceed() throws Exception {
-    formRPartBDto.setId(null);
-    FormRPartBDto formRPartBDtoReturn = new FormRPartBDto();
-    formRPartBDtoReturn.setId(DEFAULT_ID);
-    formRPartBDtoReturn.setTraineeTisId(formRPartBDto.getTraineeTisId());
-    formRPartBDtoReturn.setForename(formRPartBDto.getForename());
-    formRPartBDtoReturn.setSurname(formRPartBDto.getSurname());
-    formRPartBDtoReturn.setWork(formRPartBDto.getWork());
-    formRPartBDtoReturn.setTotalLeave(formRPartBDto.getTotalLeave());
-    formRPartBDtoReturn.setIsHonest(formRPartBDto.getIsHonest());
-    formRPartBDtoReturn.setIsHealthy(formRPartBDto.getIsHealthy());
-    formRPartBDtoReturn.setHealthStatement(formRPartBDto.getHealthStatement());
-    formRPartBDtoReturn.setHavePreviousDeclarations(formRPartBDto.getHavePreviousDeclarations());
-    formRPartBDtoReturn.setPreviousDeclarations(formRPartBDto.getPreviousDeclarations());
-    formRPartBDtoReturn
-        .setPreviousDeclarationSummary(formRPartBDto.getPreviousDeclarationSummary());
-    formRPartBDtoReturn.setHaveCurrentDeclarations(formRPartBDto.getHaveCurrentDeclarations());
-    formRPartBDtoReturn.setCurrentDeclarations(formRPartBDto.getCurrentDeclarations());
-    formRPartBDtoReturn.setCurrentDeclarationSummary(formRPartBDto.getCurrentDeclarationSummary());
-    formRPartBDtoReturn.setCompliments(formRPartBDto.getCompliments());
-
-    when(formRPartBServiceMock.save(formRPartBDto)).thenReturn(formRPartBDtoReturn);
+  void postShouldNotCreateFormWhenTokenIsInvalid() throws Exception {
+    dto.setId(null);
     mockMvc.perform(post("/api/formr-partb")
         .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(formRPartBDto)))
-        .andExpect(status().isCreated());
-  }
-
-  @Test
-  void testCreateDraftFormRPartBWithDraftExists() throws Exception {
-    formRPartBDto.setId(null);
-    final String formRPartBDtoName = "FormRPartBDto";
-
-    BeanPropertyBindingResult bindingResult =
-        new BeanPropertyBindingResult(formRPartBDto, formRPartBDtoName);
-    bindingResult.addError(new FieldError(formRPartBDtoName, "lifecycleState",
-        "Draft form R Part B already exists"));
-
-    Method method = formRPartBValidator.getClass().getMethods()[0];
-    doThrow(new MethodArgumentNotValidException(new MethodParameter(method, 0), bindingResult))
-        .when(formRPartBValidator).validate(formRPartBDto);
-
-    mockMvc.perform(post("/api/formr-partb")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(formRPartBDto)))
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
         .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
   }
 
   @Test
-  void testUpdateFormRPartBShouldSucceed() throws Exception {
-    formRPartBDto.setId(DEFAULT_ID);
-    FormRPartBDto formRPartBDtoReturn = new FormRPartBDto();
-    formRPartBDtoReturn.setId(DEFAULT_ID);
-    formRPartBDtoReturn.setLifecycleState(LifecycleState.SUBMITTED);
+  void postShouldNotCreateFormWhenFormExists() throws Exception {
+    mockMvc.perform(post("/api/formr-partb")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isBadRequest());
 
-    when(formRPartBServiceMock.save(formRPartBDto)).thenReturn(formRPartBDtoReturn);
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void postShouldNotCreateFormWhenDtoValidationFails() throws Exception {
+    dto.setId(null);
+
+    BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(dto, "formDto");
+    bindingResult.addError(new FieldError("formDto", "formField", "Form field not valid."));
+
+    Method method = validator.getClass().getMethods()[0];
+    Exception exception = new MethodArgumentNotValidException(new MethodParameter(method, 0),
+        bindingResult);
+    doThrow(exception).when(validator).validate(dto);
+
+    mockMvc.perform(post("/api/formr-partb")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void postShouldCreateFormWhenDtoValidationPasses() throws Exception {
+    dto.setId(null);
+    FormRPartBDto createdDto = new FormRPartBDto();
+    createdDto.setId(DEFAULT_ID);
+    createdDto.setLifecycleState(LifecycleState.DRAFT);
+
+    when(service.save(dto)).thenReturn(createdDto);
 
     mockMvc.perform(put("/api/formr-partb")
         .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(formRPartBDto)))
-        .andExpect(status().isOk())
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isCreated())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(header().string(HttpHeaders.LOCATION, "/api/formr-partb/" + DEFAULT_ID))
         .andExpect(jsonPath("$.id").value(DEFAULT_ID))
-        .andExpect(jsonPath("$.lifecycleState")
-            .value(LifecycleState.SUBMITTED.name()));
+        .andExpect(jsonPath("$.lifecycleState").value(LifecycleState.DRAFT.name()));
   }
 
   @Test
-  void testGetFormRPartBsByTraineeTisId() throws Exception {
-    when(formRPartBServiceMock.getFormRPartBsByTraineeTisId(DEFAULT_TRAINEE_TIS_ID)).thenReturn(
-        Arrays.asList(formRPartSimpleDto));
-    mockMvc.perform(get("/api/formr-partbs/" + DEFAULT_TRAINEE_TIS_ID)
+  void putShouldNotUpdateFormWhenNoToken() throws Exception {
+    mockMvc.perform(put("/api/formr-partb")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .content(TestUtil.convertObjectToJsonBytes(dto)))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void putShouldNotUpdateFormWhenTokenIsInvalid() throws Exception {
+    mockMvc.perform(put("/api/formr-partb")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void putShouldNotCreateFormWhenDtoValidationFails() throws Exception {
+    BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(dto, "formDto");
+    bindingResult.addError(new FieldError("formDto", "formField", "Form field not valid."));
+
+    Method method = validator.getClass().getMethods()[0];
+    Exception exception = new MethodArgumentNotValidException(new MethodParameter(method, 0),
+        bindingResult);
+    doThrow(exception).when(validator).validate(dto);
+
+    mockMvc.perform(put("/api/formr-partb")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void putShouldUpdateFormWhenFormExists() throws Exception {
+    FormRPartBDto savedDto = new FormRPartBDto();
+    savedDto.setId(DEFAULT_ID);
+    savedDto.setLifecycleState(LifecycleState.SUBMITTED);
+
+    when(service.save(dto)).thenReturn(savedDto);
+
+    mockMvc.perform(put("/api/formr-partb")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.id").value(DEFAULT_ID))
+        .andExpect(jsonPath("$.lifecycleState").value(LifecycleState.SUBMITTED.name()));
+  }
+
+  @Test
+  void putShouldCreateFormWhenFormNotExists() throws Exception {
+    dto.setId(null);
+    FormRPartBDto createdDto = new FormRPartBDto();
+    createdDto.setId(DEFAULT_ID);
+    createdDto.setLifecycleState(LifecycleState.DRAFT);
+
+    when(service.save(dto)).thenReturn(createdDto);
+
+    mockMvc.perform(put("/api/formr-partb")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .content(TestUtil.convertObjectToJsonBytes(dto))
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isCreated())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(header().string(HttpHeaders.LOCATION, "/api/formr-partb/" + DEFAULT_ID))
+        .andExpect(jsonPath("$.id").value(DEFAULT_ID))
+        .andExpect(jsonPath("$.lifecycleState").value(LifecycleState.DRAFT.name()));
+  }
+
+  @Test
+  void getShouldNotReturnTraineesFormsWhenNoToken() throws Exception {
+    mockMvc.perform(get("/api/formr-partbs")
         .contentType(TestUtil.APPLICATION_JSON_UTF8))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void getShouldNotReturnTraineesFormsWhenTokenHasNoTraineeId() throws Exception {
+    mockMvc.perform(get("/api/formr-partbs")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void getShouldReturnTraineesFormsWhenTokenHasTraineeId() throws Exception {
+    when(service.getFormRPartBsByTraineeTisId(DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(Collections.singletonList(simpleDto));
+
+    mockMvc.perform(get("/api/formr-partbs")
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$").value(hasSize(1)))
-        .andExpect(jsonPath("$.[*].id").value(hasItem(DEFAULT_ID)))
-        .andExpect(jsonPath("$.[*].lifecycleState").value(hasItem(DEFAULT_LIFECYLCESTATE.name())));
+        .andExpect(jsonPath("$.[0].id").value(DEFAULT_ID))
+        .andExpect(jsonPath("$.[0].traineeTisId").value(DEFAULT_TRAINEE_TIS_ID))
+        .andExpect(jsonPath("$.[0].lifecycleState").value(DEFAULT_LIFECYCLESTATE.name()));
   }
 
   @Test
-  void testGetFormRPartBById() throws Exception {
-    when(formRPartBServiceMock.getFormRPartBById(DEFAULT_ID)).thenReturn(formRPartBDto);
+  void getByIdShouldNotReturnFormWhenNoToken() throws Exception {
     mockMvc.perform(get("/api/formr-partb/" + DEFAULT_ID)
         .contentType(TestUtil.APPLICATION_JSON_UTF8))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void getByIdShouldNotReturnFormWhenTokenHasNoTraineeId() throws Exception {
+    mockMvc.perform(get("/api/formr-partb/" + DEFAULT_ID)
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void getByIdShouldNotReturnFormWhenFormIsNotTrainees() throws Exception {
+    when(service.getFormRPartBById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID)).thenReturn(null);
+    mockMvc.perform(get("/api/formr-partb/" + DEFAULT_ID)
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void getByIdShouldReturnFormWhenFormIsTrainees() throws Exception {
+    when(service.getFormRPartBById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(dto);
+    mockMvc.perform(get("/api/formr-partb/" + DEFAULT_ID)
+        .contentType(TestUtil.APPLICATION_JSON_UTF8)
+        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value(DEFAULT_ID))
-        .andExpect(jsonPath("$.work[*].typeOfWork").value(DEFAULT_TYPE_OF_WORK))
-        .andExpect(jsonPath("$.totalLeave").value(DEFAULT_TOTAL_LEAVE))
-        .andExpect(jsonPath("$.isHonest").value(DEFAULT_IS_HONEST))
-        .andExpect(jsonPath("$.isHealthy").value(DEFAULT_IS_HEALTHY))
-        .andExpect(jsonPath("$.healthStatement").value(DEFAULT_HEALTHY_STATEMENT))
-        .andExpect(jsonPath("$.havePreviousDeclarations")
-            .value(DEFAULT_HAVE_PREVIOUS_DECLARATIONS))
-        .andExpect(jsonPath("$.previousDeclarations[*].declarationType")
-            .value(DEFAULT_PREVIOUS_DECLARATION_TYPE))
-        .andExpect(jsonPath("$.previousDeclarations[*].dateOfEntry")
-            .value(DEFAULT_PREVIOUS_DATE_OF_ENTRY.toString()))
-        .andExpect(jsonPath("$.previousDeclarationSummary")
-            .value(DEFAULT_PREVIOUS_DECLARATION_SUMMARY))
-        .andExpect(jsonPath("$.haveCurrentDeclarations")
-            .value(DEFAULT_HAVE_CURRENT_DECLARATIONS))
-        .andExpect(jsonPath("$.currentDeclarations[*].declarationType")
-            .value(DEFAULT_CURRENT_DECLARATION_TYPE))
-        .andExpect(jsonPath("$.currentDeclarations[*].dateOfEntry")
-            .value(DEFAULT_CURRENT_DATE_OF_ENTRY.toString()))
-        .andExpect(jsonPath("$.currentDeclarationSummary")
-            .value(DEFAULT_CURRENT_DECLARATION_SUMMARY))
-        .andExpect(jsonPath("$.compliments")
-            .value(DEFAULT_COMPLIMENTS))
-        .andExpect(jsonPath("$.lifecycleState")
-            .value(DEFAULT_LIFECYLCESTATE.name()));
+        .andExpect(jsonPath("$.traineeTisId").value(DEFAULT_TRAINEE_TIS_ID))
+        .andExpect(jsonPath("$.forename").value(DEFAULT_FORENAME))
+        .andExpect(jsonPath("$.surname").value(DEFAULT_SURNAME))
+        .andExpect(jsonPath("$.lifecycleState").value(DEFAULT_LIFECYCLESTATE.name()));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResourceTest.java
@@ -164,7 +164,7 @@ class FormRPartBResourceTest {
     BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(dto, "formDto");
     bindingResult.addError(new FieldError("formDto", "formField", "Form field not valid."));
 
-    Method method = validator.getClass().getMethods()[0];
+    Method method = validator.getClass().getMethod("validate", FormRPartBDto.class);
     Exception exception = new MethodArgumentNotValidException(new MethodParameter(method, 0),
         bindingResult);
     doThrow(exception).when(validator).validate(dto);
@@ -224,7 +224,7 @@ class FormRPartBResourceTest {
     BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(dto, "formDto");
     bindingResult.addError(new FieldError("formDto", "formField", "Form field not valid."));
 
-    Method method = validator.getClass().getMethods()[0];
+    Method method = validator.getClass().getMethod("validate", FormRPartBDto.class);
     Exception exception = new MethodArgumentNotValidException(new MethodParameter(method, 0),
         bindingResult);
     doThrow(exception).when(validator).validate(dto);

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtilTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtilTest.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.api.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+class AuthTokenUtilTest {
+
+  private static final String TIS_ID_ATTRIBUTE = "custom:tisId";
+
+  @Test
+  void getTraineeTisIdShouldThrowExceptionWhenTokenPayloadNotMap() {
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString("[]".getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    assertThrows(IOException.class, () -> AuthTokenUtil.getTraineeTisId(token));
+  }
+
+  @Test
+  void getTraineeTisIdShouldReturnNullWhenTisIdNotInToken() throws IOException {
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString("{}".getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    String tisId = AuthTokenUtil.getTraineeTisId(token);
+
+    assertThat("Unexpected trainee TIS ID", tisId, nullValue());
+  }
+
+  @Test
+  void getTraineeTisIdShouldReturnIdWhenTisIdInToken() throws IOException {
+    String payload = String.format("{\"%s\":\"%s\"}", TIS_ID_ATTRIBUTE, "40");
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    String tisId = AuthTokenUtil.getTraineeTisId(token);
+
+    assertThat("Unexpected trainee TIS ID", tisId, is("40"));
+  }
+
+  @Test
+  void verifyTraineeTisIdShouldReturnBadRequestWhenTokenIdNotReadable() {
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString("[]".getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    Optional<ResponseEntity<Object>> response = AuthTokenUtil.verifyTraineeTisId("1", token);
+
+    assertThat("Unexpected response isPresent.", response.isPresent(), is(true));
+    assertThat("Unexpected response status.", response.get().getStatusCode(),
+        is(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  void verifyTraineeTisIdShouldReturnForbiddenWhenTokenIdNotMatching() {
+    String payload = String.format("{\"%s\":\"%s\"}", TIS_ID_ATTRIBUTE, "40");
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    Optional<ResponseEntity<Object>> response = AuthTokenUtil.verifyTraineeTisId("1", token);
+
+    assertThat("Unexpected response isPresent.", response.isPresent(), is(true));
+    assertThat("Unexpected response status.", response.get().getStatusCode(),
+        is(HttpStatus.FORBIDDEN));
+  }
+
+  @Test
+  void verifyTraineeTisIdShouldReturnEmptyWhenTokenIdMatching() {
+    String payload = String.format("{\"%s\":\"%s\"}", TIS_ID_ATTRIBUTE, "40");
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    Optional<ResponseEntity<Object>> response = AuthTokenUtil.verifyTraineeTisId("40", token);
+
+    assertThat("Unexpected response isPresent.", response.isPresent(), is(false));
+  }
+}


### PR DESCRIPTION
Currently the trainee ID is provided as part of the request, but this
would potentially allow users to access data that is not theirs. Instead
the authentication token should be used to retrieve the logged in user's
TIS ID directly.

TISNEW-3833