### PR TITLE
chore: Add Sentry env vars to task definition

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -16,6 +16,10 @@
         {
           "name": "AWS_REGION",
           "value": "eu-west-2"
+        },
+        {
+          "name": "SENTRY_ENVIRONMENT",
+          "value": "stage"
         }
       ],
       "logConfiguration": {
@@ -42,6 +46,10 @@
         {
           "name": "DB_PASSWORD",
           "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-trainee-db-password"
+        },
+        {
+          "name": "SENTRY_DSN",
+          "valueFrom": "tis-trainee-forms-sentry-dsn"
         }
       ]
     }


### PR DESCRIPTION
Add the SENTRY_DSN and SENTRY_ENVIRONMENT environmental variables to the
task definition file. These values will be populated via the parameter
store in AWS.

NO-TICKET