### PR TITLE
Fix/align all metadata

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResource.java
@@ -146,7 +146,7 @@ public class FormRPartAResource {
   }
 
   /**
-   * GET /formr-parta/:id
+   * GET /formr-parta/:id.
    *
    * @param id    The ID of the form
    * @param token The authorization token from the request header.

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResource.java
@@ -146,7 +146,7 @@ public class FormRPartBResource {
   }
 
   /**
-   * GET /formr-partb/:id
+   * GET /formr-partb/:id.
    *
    * @param id    The ID of the form
    * @param token The authorization token from the request header.

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/exception/ApplicationException.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/exception/ApplicationException.java
@@ -1,3 +1,22 @@
+/*
+ * The MIT License (MIT)
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package uk.nhs.hee.tis.trainee.forms.exception;
 
 public class ApplicationException extends RuntimeException {
@@ -6,7 +25,7 @@ public class ApplicationException extends RuntimeException {
    * Create an exception.
    *
    * @param message The exception message for the Exception
-   * @param cause The cause to wrap
+   * @param cause   The cause to wrap
    */
   public ApplicationException(String message, Exception cause) {
     super(message, cause);

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
@@ -27,6 +27,8 @@ import uk.nhs.hee.tis.trainee.forms.dto.FormRPartSimpleDto;
 
 public interface FormRPartAService {
 
+  String FORM_TYPE = "formr-a";
+
   /**
    * Save the given form.
    *

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
@@ -26,6 +26,8 @@ import uk.nhs.hee.tis.trainee.forms.dto.FormRPartSimpleDto;
 
 public interface FormRPartBService {
 
+  String FORM_TYPE = "formr-b";
+
   /**
    * Save the given form.
    *

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ApplicationException.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ApplicationException.java
@@ -17,7 +17,8 @@
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package uk.nhs.hee.tis.trainee.forms.exception;
+
+package uk.nhs.hee.tis.trainee.forms.service.exception;
 
 public class ApplicationException extends RuntimeException {
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ErrorVM.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ErrorVM.java
@@ -46,12 +46,26 @@ public class ErrorVM implements Serializable {
     this.description = description;
   }
 
+  /**
+   * Create an error with errors against fields.
+   *
+   * @param message     The message
+   * @param description The larger description
+   * @param fieldErrors A list of errors for fields
+   */
   public ErrorVM(String message, String description, List<FieldErrorVM> fieldErrors) {
     this.message = message;
     this.description = description;
     this.fieldErrors = fieldErrors;
   }
 
+  /**
+   * Add a {@link FieldErrorVM} against a fields.
+   *
+   * @param objectName The name of the object containing the field
+   * @param field      The name of field with the error
+   * @param message    The error message
+   */
   public void add(String objectName, String field, String message) {
     if (fieldErrors == null) {
       fieldErrors = new ArrayList<>();

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ExceptionTranslator.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ExceptionTranslator.java
@@ -42,6 +42,12 @@ public class ExceptionTranslator {
   private final Logger log = LoggerFactory
       .getLogger(ExceptionTranslator.class);
 
+  /**
+   * Translates a validation exception into an HTTP 400 Response.
+   *
+   * @param ex The validation exception
+   * @return The View Model of the Error
+   */
   @ExceptionHandler(MethodArgumentNotValidException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ResponseBody

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/FieldErrorVM.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/FieldErrorVM.java
@@ -23,6 +23,9 @@ package uk.nhs.hee.tis.trainee.forms.service.exception;
 
 import java.io.Serializable;
 
+/**
+ * View Model for presenting an error with a field.
+ */
 public class FieldErrorVM implements Serializable {
 
   private static final long serialVersionUID = 1L;
@@ -33,6 +36,13 @@ public class FieldErrorVM implements Serializable {
 
   private final String message;
 
+  /**
+   * Instantiates a View Model for the provided error.
+   *
+   * @param dto     The name of the object
+   * @param field   The name of the field
+   * @param message The error message
+   */
   public FieldErrorVM(String dto, String field, String message) {
     this.objectName = dto;
     this.field = field;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartAServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartAServiceImpl.java
@@ -121,11 +121,12 @@ public class FormRPartAServiceImpl implements FormRPartAService {
     }
     String fileName = formRPartA.getId() + ".json";
     try {
-      String key = String.join("/", formRPartA.getTraineeTisId(), "forms", "formr-a", fileName);
+      String key = String.join("/", formRPartA.getTraineeTisId(), "forms", FORM_TYPE, fileName);
       ObjectMetadata metadata = new ObjectMetadata();
+      metadata.addUserMetadata("id", formRPartA.getId());
       metadata.addUserMetadata("name", fileName);
       metadata.addUserMetadata("type", "json");
-      metadata.addUserMetadata("formtype", "formr-a");
+      metadata.addUserMetadata("formtype", FORM_TYPE);
       metadata.addUserMetadata("lifecyclestate", formRPartA.getLifecycleState().name());
       metadata.addUserMetadata("submissiondate",
           formRPartA.getSubmissionDate().format(DateTimeFormatter.ISO_LOCAL_DATE));

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartAServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartAServiceImpl.java
@@ -37,11 +37,11 @@ import org.springframework.util.StringUtils;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartADto;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartSimpleDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
-import uk.nhs.hee.tis.trainee.forms.exception.ApplicationException;
 import uk.nhs.hee.tis.trainee.forms.mapper.FormRPartAMapper;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
 import uk.nhs.hee.tis.trainee.forms.repository.FormRPartARepository;
 import uk.nhs.hee.tis.trainee.forms.service.FormRPartAService;
+import uk.nhs.hee.tis.trainee.forms.service.exception.ApplicationException;
 
 @Slf4j
 @Service

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartBServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartBServiceImpl.java
@@ -36,11 +36,11 @@ import org.springframework.util.StringUtils;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartBDto;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartSimpleDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
-import uk.nhs.hee.tis.trainee.forms.exception.ApplicationException;
 import uk.nhs.hee.tis.trainee.forms.mapper.FormRPartBMapper;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
 import uk.nhs.hee.tis.trainee.forms.repository.FormRPartBRepository;
 import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
+import uk.nhs.hee.tis.trainee.forms.service.exception.ApplicationException;
 
 @Slf4j
 @Service

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartBServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartBServiceImpl.java
@@ -122,11 +122,12 @@ public class FormRPartBServiceImpl implements FormRPartBService {
     }
     String fileName = formRPartB.getId() + ".json";
     try {
-      String key = String.join("/", formRPartB.getTraineeTisId(), "forms", "formr-a", fileName);
+      String key = String.join("/", formRPartB.getTraineeTisId(), "forms", FORM_TYPE, fileName);
       ObjectMetadata metadata = new ObjectMetadata();
+      metadata.addUserMetadata("id", formRPartB.getId());
       metadata.addUserMetadata("name", fileName);
       metadata.addUserMetadata("type", "json");
-      metadata.addUserMetadata("formtype", "formr-a");
+      metadata.addUserMetadata("formtype", FORM_TYPE);
       metadata.addUserMetadata("lifecyclestate", formRPartB.getLifecycleState().name());
       metadata.addUserMetadata("submissiondate",
           formRPartB.getSubmissionDate().format(DateTimeFormatter.ISO_LOCAL_DATE));

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceImplTest.java
@@ -52,10 +52,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartADto;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartSimpleDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
-import uk.nhs.hee.tis.trainee.forms.exception.ApplicationException;
 import uk.nhs.hee.tis.trainee.forms.mapper.FormRPartAMapperImpl;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
 import uk.nhs.hee.tis.trainee.forms.repository.FormRPartARepository;
+import uk.nhs.hee.tis.trainee.forms.service.exception.ApplicationException;
 import uk.nhs.hee.tis.trainee.forms.service.impl.FormRPartAServiceImpl;
 
 @ExtendWith(MockitoExtension.class)
@@ -153,8 +153,8 @@ class FormRPartAServiceImplTest {
             savedDto.getId() + ".json")));
     Map<String, String> expectedMetadata = Map
         .of("id", savedDto.getId(), "name", savedDto.getId() + ".json", "type", "json", "formtype",
-            FormRPartAService.FORM_TYPE, "lifecyclestate", LifecycleState.SUBMITTED.name(), "submissiondate",
-            DEFAULT_SUBMISSION_DATE_STRING, "traineeid", DEFAULT_TRAINEE_TIS_ID);
+            FormRPartAService.FORM_TYPE, "lifecyclestate", LifecycleState.SUBMITTED.name(),
+            "submissiondate", DEFAULT_SUBMISSION_DATE_STRING, "traineeid", DEFAULT_TRAINEE_TIS_ID);
 
     assertThat("Unexpected metadata.", actual.getMetadata().getUserMetadata().entrySet(),
         containsInAnyOrder(expectedMetadata.entrySet().toArray(new Entry[0])));

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceImplTest.java
@@ -23,7 +23,9 @@ package uk.nhs.hee.tis.trainee.forms.service;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -34,12 +36,17 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartADto;
@@ -59,6 +66,8 @@ class FormRPartAServiceImplTest {
   private static final String DEFAULT_FORENAME = "DEFAULT_FORENAME";
   private static final String DEFAULT_SURNAME = "DEFAULT_SURNAME";
   private static final LocalDate DEFAULT_SUBMISSION_DATE = LocalDate.of(2020, 8, 29);
+  private static final String DEFAULT_SUBMISSION_DATE_STRING = DEFAULT_SUBMISSION_DATE.format(
+      DateTimeFormatter.ISO_LOCAL_DATE);
 
   private FormRPartAServiceImpl service;
 
@@ -67,6 +76,9 @@ class FormRPartAServiceImplTest {
 
   @Mock
   private AmazonS3 s3Mock;
+
+  @Captor
+  private ArgumentCaptor<PutObjectRequest> putRequestCaptor;
 
   private FormRPartA entity;
 
@@ -133,7 +145,19 @@ class FormRPartAServiceImplTest {
     assertThat("Unexpected trainee ID.", savedDto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected forename.", savedDto.getForename(), is(DEFAULT_FORENAME));
     assertThat("Unexpected surname.", savedDto.getSurname(), is(DEFAULT_SURNAME));
-    verify(s3Mock).putObject(any(PutObjectRequest.class));
+    verify(s3Mock).putObject(putRequestCaptor.capture());
+    PutObjectRequest actual = putRequestCaptor.getValue();
+    assertThat("Unexpected Bucket Name.", actual.getBucketName(), nullValue());
+    assertThat("Unexpected Object Key.", actual.getKey(),
+        is(String.join("/", DEFAULT_TRAINEE_TIS_ID, "forms", FormRPartAService.FORM_TYPE,
+            savedDto.getId() + ".json")));
+    Map<String, String> expectedMetadata = Map
+        .of("id", savedDto.getId(), "name", savedDto.getId() + ".json", "type", "json", "formtype",
+            FormRPartAService.FORM_TYPE, "lifecyclestate", LifecycleState.SUBMITTED.name(), "submissiondate",
+            DEFAULT_SUBMISSION_DATE_STRING, "traineeid", DEFAULT_TRAINEE_TIS_ID);
+
+    assertThat("Unexpected metadata.", actual.getMetadata().getUserMetadata().entrySet(),
+        containsInAnyOrder(expectedMetadata.entrySet().toArray(new Entry[0])));
     entity.setId(savedDto.getId());
     verify(repositoryMock).save(entity);
   }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceImplTest.java
@@ -56,7 +56,6 @@ import uk.nhs.hee.tis.trainee.forms.dto.FormRPartBDto;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartSimpleDto;
 import uk.nhs.hee.tis.trainee.forms.dto.WorkDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
-import uk.nhs.hee.tis.trainee.forms.exception.ApplicationException;
 import uk.nhs.hee.tis.trainee.forms.mapper.CovidDeclarationMapperImpl;
 import uk.nhs.hee.tis.trainee.forms.mapper.FormRPartBMapper;
 import uk.nhs.hee.tis.trainee.forms.mapper.FormRPartBMapperImpl;
@@ -64,6 +63,7 @@ import uk.nhs.hee.tis.trainee.forms.model.Declaration;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
 import uk.nhs.hee.tis.trainee.forms.model.Work;
 import uk.nhs.hee.tis.trainee.forms.repository.FormRPartBRepository;
+import uk.nhs.hee.tis.trainee.forms.service.exception.ApplicationException;
 import uk.nhs.hee.tis.trainee.forms.service.impl.FormRPartBServiceImpl;
 
 @ExtendWith(MockitoExtension.class)
@@ -283,8 +283,8 @@ class FormRPartBServiceImplTest {
             savedDto.getId() + ".json")));
     Map<String, String> expectedMetadata = Map
         .of("id", savedDto.getId(), "name", savedDto.getId() + ".json", "type", "json", "formtype",
-            FormRPartBService.FORM_TYPE, "lifecyclestate", LifecycleState.SUBMITTED.name(), "submissiondate",
-            DEFAULT_SUBMISSION_DATE_STRING, "traineeid", DEFAULT_TRAINEE_TIS_ID);
+            FormRPartBService.FORM_TYPE, "lifecyclestate", LifecycleState.SUBMITTED.name(),
+            "submissiondate", DEFAULT_SUBMISSION_DATE_STRING, "traineeid", DEFAULT_TRAINEE_TIS_ID);
 
     assertThat("Unexpected metadata.", actual.getMetadata().getUserMetadata().entrySet(),
         containsInAnyOrder(expectedMetadata.entrySet().toArray(new Entry[0])));


### PR DESCRIPTION
@StevenHee @john12321, this seemed as good a place as any to confirm the metadata that should be saved on a submitted/unsubmitted form.  Please approve if it's right.  If not, let me know what isn't as expected or, even better, push over the top.

It's probably [FormRPartAServiceImpl.java](https://github.com/Health-Education-England/tis-trainee-forms/pull/53/files#diff-bc8c011666df416bb83c4b18335123d9678c0aef356ad5795f2b2d40bdf67597) and [FormRPartBServiceImpl.java](https://github.com/Health-Education-England/tis-trainee-forms/pull/53/files#diff-913de133c3aed4bca0c2a6c56d59ce33ec2294346ef0ab5db98922fb01598db7) that you're most interested in.