### PR TITLE
feat: Add Mongock insert of COVID form switch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.2.1"
+version = "0.3.0"
 sourceCompatibility = "11"
 
 configurations {
@@ -44,6 +44,11 @@ dependencies {
 
   // Sentry reporting
   implementation "io.sentry:sentry-spring-boot-starter:4.3.0"
+
+  // Mongock
+  ext.mongockVersion = "4.3.8"
+  implementation "com.github.cloudyrock.mongock:mongock-spring-v5:${mongockVersion}"
+  implementation "com.github.cloudyrock.mongock:mongodb-springdata-v3-driver:${mongockVersion}"
 }
 
 checkstyle {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/changelog/FormSwitchChangeLog.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/changelog/FormSwitchChangeLog.java
@@ -1,7 +1,6 @@
 /*
  * The MIT License (MIT)
- *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2021 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,17 +18,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.trainee.forms;
+package uk.nhs.hee.tis.trainee.forms.changelog;
 
-import com.github.cloudyrock.spring.v5.EnableMongock;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import com.github.cloudyrock.mongock.ChangeLog;
+import com.github.cloudyrock.mongock.ChangeSet;
+import com.github.cloudyrock.mongock.driver.mongodb.springdata.v3.decorator.impl.MongockTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import uk.nhs.hee.tis.trainee.forms.model.FormSwitch;
 
-@EnableMongock
-@SpringBootApplication
-public class TraineeFormsApplication {
+@ChangeLog
+public class FormSwitchChangeLog {
 
-  public static void main(String[] args) {
-    SpringApplication.run(TraineeFormsApplication.class);
+  @ChangeSet(order = "001", id = "setCovidDeclarationSwitch", author = "", runAlways = true)
+  public void setCovidDeclarationSwitch(MongockTemplate mongockTemplate) {
+    Criteria criteria = Criteria.where("name").is("COVID");
+    Query query = Query.query(criteria);
+    Update update = Update.update("enabled", true);
+    mongockTemplate.upsert(query, update, FormSwitch.class);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,9 @@ application:
     always-store: ${APPLICATION_FILESTORE_ALWAYSSTORE:false}
     bucket: ${APPLICATION_FILESTORE_BUCKET}
 
+mongock:
+  change-logs-scan-package: uk.nhs.hee.tis.trainee.forms.changelog
+
 sentry:
   dsn: ${SENTRY_DSN:}
   environment: ${SENTRY_ENVIRONMENT:local}

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/changelog/FormSwitchChangeLogTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/changelog/FormSwitchChangeLogTest.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.changelog;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import com.github.cloudyrock.mongock.driver.mongodb.springdata.v3.decorator.impl.MongockTemplate;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import uk.nhs.hee.tis.trainee.forms.model.FormSwitch;
+
+@ExtendWith(MockitoExtension.class)
+class FormSwitchChangeLogTest {
+
+  private FormSwitchChangeLog changeLog;
+
+  @Mock
+  private MongockTemplate template;
+
+  @BeforeEach
+  void setUp() {
+    changeLog = new FormSwitchChangeLog();
+  }
+
+  @Test
+  void shouldSetCovidDeclarationSwitch() {
+    changeLog.setCovidDeclarationSwitch(template);
+
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+    ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+    verify(template).upsert(queryCaptor.capture(), updateCaptor.capture(), eq(FormSwitch.class));
+
+    Query query = queryCaptor.getValue();
+    Document queryObject = query.getQueryObject();
+    assertThat("Unexpected query size.", queryObject.size(), is(1));
+    assertThat("Unexpected query value.", queryObject.get("name"), is("COVID"));
+
+    Update update = updateCaptor.getValue();
+    assertThat("Unexpected update size.", update.getUpdateObject().size(), is(1));
+    assertThat("Unexpected update target.", update.modifies("enabled"), is(true));
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,2 @@
+mongock:
+  enabled: false


### PR DESCRIPTION
The form switch for COVID needs to be inserted if it is missing, use
mongock change logs to add the entry to the database.

TIS21-1452