### PR TITLE
chore: Add auto-caching using setup-java action

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1.0.4
 
-  cache-distribution:
-    name: Cache Gradle distribution
+  assemble:
+    name: Assemble JAR
     needs: validate-wrapper
     runs-on: ubuntu-latest
 
@@ -25,30 +25,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Cache Gradle distribution
-        id: cache
-        uses: actions/cache@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2.3.0
         with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-
-      - name: Download Gradle distribution
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: ./gradlew
-
-  assemble:
-    name: Assemble JAR
-    needs: cache-distribution
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2.2.0
-        with:
+          cache: gradle
           distribution: adopt
           java-version: 11
 
@@ -63,16 +43,17 @@ jobs:
 
   check:
     name: Perform checks
-    needs: cache-distribution
+    needs: validate-wrapper
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2.2.0
+      - name: Set up JDK
+        uses: actions/setup-java@v2.3.0
         with:
+          cache: gradle
           distribution: adopt
           java-version: 11
 
@@ -87,16 +68,17 @@ jobs:
 
   test:
     name: Run automated tests
-    needs: cache-distribution
+    needs: validate-wrapper
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2.2.0
+      - name: Set up JDK
+        uses: actions/setup-java@v2.3.0
         with:
+          cache: gradle
           distribution: adopt
           java-version: 11
 
@@ -124,9 +106,10 @@ jobs:
           name: reports
           path: build/reports
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2.2.0
+      - name: Set up JDK
+        uses: actions/setup-java@v2.3.0
         with:
+          cache: gradle
           distribution: adopt
           java-version: 11
 


### PR DESCRIPTION
The `setup-java` action now supports automatic caching of maven and
gradle dependencies, update the workflow to use that caching.

TIS21-2078