### PR TITLE
chore: delete non-ARCP pilot forms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ dependencies {
   annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
   testAnnotationProcessor "org.mapstruct:mapstruct-processor:1.3.1.Final"
 
+  ext.mongockVersion = "5.0.35"
+  implementation "io.mongock:mongock-springboot:${mongockVersion}"
+  implementation "io.mongock:mongodb-springdata-v3-driver:${mongockVersion}"
+
   // Sentry reporting
   implementation "io.sentry:sentry-spring-boot-starter:5.5.2"
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/TraineeFormsApplication.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/TraineeFormsApplication.java
@@ -21,9 +21,11 @@
 
 package uk.nhs.hee.tis.trainee.forms;
 
+import io.mongock.runner.springboot.EnableMongock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+@EnableMongock
 @SpringBootApplication
 public class TraineeFormsApplication {
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/DeletePilotForms.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/DeletePilotForms.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2022 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.migration;
+
+import static java.time.Month.SEPTEMBER;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import java.time.LocalDate;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
+
+/**
+ *
+ */
+@Slf4j
+@ChangeUnit(id = "deletePilotForms", order = "1")
+public class DeletePilotForms {
+
+  private final MongoTemplate mongoTemplate;
+
+  public DeletePilotForms(MongoTemplate mongoTemplate) {
+    this.mongoTemplate = mongoTemplate;
+  }
+
+  /**
+   *
+   */
+  @Execution
+  public void migrate() {
+    var pilotEndDate = LocalDate.of(2021, SEPTEMBER, 1);
+    var lessThanPilotEndDateCriteria = Criteria.where("lastModifiedDate").lt(pilotEndDate);
+    var lessThanPilotEndDateQuery = Query.query(lessThanPilotEndDateCriteria);
+
+    mongoTemplate.remove(lessThanPilotEndDateQuery, FormRPartA.class);
+    mongoTemplate.remove(lessThanPilotEndDateQuery, FormRPartB.class);
+  }
+
+  /**
+   *
+   */
+  @RollbackExecution
+  public void rollback() {
+    log.warn("Rollback requested but not available for 'deletePilotForms' migration.");
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,19 +1,3 @@
-server:
-  port: 8207
-  servlet:
-    context-path: /forms
-
-spring:
-  data:
-    mongodb:
-      uri: mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:forms}?authSource=admin
-
-logging:
-  level:
-    root: INFO
-    org.springframework.data: DEBUG
-    uk.nhs.hee.tis.trainee.forms: TRACE
-
 application:
   file-store:
     always-store: ${APPLICATION_FILESTORE_ALWAYSSTORE:false}
@@ -23,6 +7,25 @@ features:
   formr-partb:
     covid-declaration: ${FEATURE_FORMR_PARTB_COVID_DECLARATION:true}
 
+logging:
+  level:
+    root: INFO
+    org.springframework.data: DEBUG
+    uk.nhs.hee.tis.trainee.forms: TRACE
+
+mongock:
+  migration-scan-package: uk.nhs.hee.tis.trainee.forms.migration
+
 sentry:
   dsn: ${SENTRY_DSN:}
   environment: ${SENTRY_ENVIRONMENT:local}
+
+server:
+  port: 8207
+  servlet:
+    context-path: /forms
+
+spring:
+  data:
+    mongodb:
+      uri: mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:forms}?authSource=admin

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/DeletePilotFormsTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/DeletePilotFormsTest.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2022 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.migration;
+
+import static java.time.Month.SEPTEMBER;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractForm;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
+
+class DeletePilotFormsTest {
+
+  private DeletePilotForms migration;
+
+  private MongoTemplate template;
+
+  @BeforeEach
+  void setUp() {
+    template = mock(MongoTemplate.class);
+    migration = new DeletePilotForms(template);
+  }
+
+  @ParameterizedTest(name = "Should migrate forms of type '{0}'.")
+  @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
+  void shouldMigrateForms(Class<AbstractForm> formClass) {
+    migration.migrate();
+
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+    verify(template).remove(queryCaptor.capture(), eq(formClass));
+
+    Query query = queryCaptor.getValue();
+    Document queryObject = query.getQueryObject();
+    LocalDate queryDate = queryObject.getEmbedded(List.of("lastModifiedDate", "$lt"),
+        LocalDate.class);
+    assertThat("Unexpected query date.", queryDate, is(LocalDate.of(2021, SEPTEMBER, 1)));
+  }
+
+  @Test
+  void shouldNotAttemptRollback() {
+    migration.rollback();
+    verifyNoInteractions(template);
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,6 @@
+mongock:
+  enabled: false
+
+spring:
+  config:
+    import: file:src/main/resources/application.yml


### PR DESCRIPTION
Trainees who took part in the initial pilot created forms which were not
used for official ARCP submissions.
Delete all forms created before the second pilot (2021-09-01).

TIS21-2550