### PR TITLE
fix: recalculate total leave on all FormR Part Bs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.5.2"
+version = "0.5.3"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/RecalculateTotalLeave.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/RecalculateTotalLeave.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2022 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.migration;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.AggregationUpdate;
+import org.springframework.data.mongodb.core.aggregation.ArithmeticOperators.Add;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
+
+/**
+ * Recalculate the total leave field on all Form R Part Bs to resolve an issue where it was not
+ * populated correctly.
+ */
+@Slf4j
+@ChangeUnit(id = "recalculateTotalLeave", order = "2")
+public class RecalculateTotalLeave {
+
+  private static final String TOTAL_LEAVE = "totalLeave";
+
+  private final MongoTemplate mongoTemplate;
+
+  public RecalculateTotalLeave(MongoTemplate mongoTemplate) {
+    this.mongoTemplate = mongoTemplate;
+  }
+
+  /**
+   * Recalculate total leave on all Form R Part Bs.
+   */
+  @Execution
+  public void migrate() {
+    var criteria = Criteria.where(TOTAL_LEAVE).is(0);
+    var query = Query.query(criteria);
+
+    var add =
+        Add.valueOf("sicknessAbsence")
+            .add("parentalLeave")
+            .add("careerBreaks")
+            .add("paidLeave")
+            .add("unauthorisedLeave")
+            .add("otherLeave");
+    var update = AggregationUpdate.update().set(TOTAL_LEAVE).toValueOf(add);
+
+    mongoTemplate.updateMulti(query, update, FormRPartB.class);
+  }
+
+  /**
+   * Do not attempt rollback, any successfully recalculate total leave should stay updated.
+   */
+  @RollbackExecution
+  public void rollback() {
+    log.warn("Rollback requested but not available for 'recalculateTotalLeave' migration.");
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/RecalculateTotalLeaveTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/RecalculateTotalLeaveTest.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2022 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.migration;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.List;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.UpdateDefinition;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
+
+class RecalculateTotalLeaveTest {
+
+  private RecalculateTotalLeave migration;
+
+  private MongoTemplate template;
+
+  @BeforeEach
+  void setUp() {
+    template = mock(MongoTemplate.class);
+    migration = new RecalculateTotalLeave(template);
+  }
+
+  @Test
+  void shouldOnlyRecalculateDocumentsWithZeroTotalLeave() {
+    migration.migrate();
+
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+    verify(template).updateMulti(queryCaptor.capture(), any(), eq(FormRPartB.class));
+
+    Query query = queryCaptor.getValue();
+    Document queryObject = query.getQueryObject();
+    int queryFilter = queryObject.getInteger("totalLeave");
+    assertThat("Unexpected query filter.", queryFilter, is(0));
+  }
+
+  @Test
+  void shouldAddAllLeaveFields() {
+    migration.migrate();
+
+    ArgumentCaptor<UpdateDefinition> updateCaptor = ArgumentCaptor.forClass(UpdateDefinition.class);
+    verify(template).updateMulti(any(), updateCaptor.capture(), eq(FormRPartB.class));
+
+    UpdateDefinition updateDefinition = updateCaptor.getValue();
+    Document root = updateDefinition.getUpdateObject();
+    List<Document> updates = root.getList("", Document.class);
+    assertThat("Unexpected number of updates.", updates.size(), is(1));
+
+    Document update = updates.get(0);
+    List<String> addedFields = update.getEmbedded(
+        List.of("$set", "totalLeave", "$add"), List.class);
+    assertThat("Unexpected field count.", addedFields.size(), is(6));
+    assertThat("Unexpected fields.", addedFields, hasItems(
+        "$sicknessAbsence",
+        "$parentalLeave",
+        "$careerBreaks",
+        "$paidLeave",
+        "$unauthorisedLeave",
+        "$otherLeave"
+    ));
+  }
+
+  @Test
+  void shouldNotAttemptRollback() {
+    migration.rollback();
+    verifyNoInteractions(template);
+  }
+}


### PR DESCRIPTION
The `totalLeave` field was not correctly populated for some forms,
create a migrator to recalculate the field any record where it is zero.

TIS21-2791