### PR TITLE
fix: add "haveCurrentUnresolvedDeclarations" and "havePreviousUnresolvedDeclarations" to FormRPartBDto and FormRPartB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.5.3"
+version = "0.5.4"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartBDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartBDto.java
@@ -69,4 +69,6 @@ public class FormRPartBDto {
   private LifecycleState lifecycleState;
   private Boolean haveCovidDeclarations;
   private CovidDeclarationDto covidDeclarationDto;
+  private Boolean haveCurrentUnresolvedDeclarations;
+  private Boolean havePreviousUnresolvedDeclarations;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormRPartB.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormRPartB.java
@@ -67,6 +67,8 @@ public class FormRPartB extends AbstractForm {
   private String compliments;
   private Boolean haveCovidDeclarations;
   private CovidDeclaration covidDeclaration;
+  private Boolean haveCurrentUnresolvedDeclarations;
+  private Boolean havePreviousUnresolvedDeclarations;
 
   @Override
   public String getFormType() {

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
@@ -289,10 +289,10 @@ class S3FormRPartBRepositoryImplTest {
     assertThat("Unexpected current declarations.", entity.getCurrentDeclarations(), empty());
     assertThat("Unexpected current declaration summary.", entity.getCurrentDeclarationSummary(),
         nullValue());
-    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.", entity.getHaveCurrentUnresolvedDeclarations(),
-        is(false));
-    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", entity.getHavePreviousUnresolvedDeclarations(),
-        is(false));
+    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.",
+        entity.getHaveCurrentUnresolvedDeclarations(), is(false));
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.",
+        entity.getHavePreviousUnresolvedDeclarations(), is(false));
     assertThat("Unexpected status.", entity.getLifecycleState(), is(SUBMITTED));
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
@@ -91,6 +91,8 @@ class S3FormRPartBRepositoryImplTest {
           LifecycleState.UNSUBMITTED.name(), "submissiondate",
           DEFAULT_SUBMISSION_DATE.format(ISO_LOCAL_DATE), "traineeid",
           DEFAULT_TRAINEE_TIS_ID);
+  private static final Boolean DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS = true;
+  private static final Boolean DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS = true;
   private static ObjectMapper objectMapper;
   private S3FormRPartBRepositoryImpl repo;
   @Mock
@@ -146,6 +148,8 @@ class S3FormRPartBRepositoryImplTest {
     entity.setCurrentDeclarations(Collections.singletonList(currentDeclaration));
     entity.setCurrentDeclarationSummary(DEFAULT_CURRENT_DECLARATION_SUMMARY);
     entity.setLifecycleState(LifecycleState.DRAFT);
+    entity.setHaveCurrentUnresolvedDeclarations(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS);
+    entity.setHavePreviousUnresolvedDeclarations(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS);
     return entity;
   }
 
@@ -285,6 +289,10 @@ class S3FormRPartBRepositoryImplTest {
     assertThat("Unexpected current declarations.", entity.getCurrentDeclarations(), empty());
     assertThat("Unexpected current declaration summary.", entity.getCurrentDeclarationSummary(),
         nullValue());
+    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.", entity.getHaveCurrentUnresolvedDeclarations(),
+        is(false));
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", entity.getHavePreviousUnresolvedDeclarations(),
+        is(false));
     assertThat("Unexpected status.", entity.getLifecycleState(), is(SUBMITTED));
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceImplTest.java
@@ -285,9 +285,11 @@ class FormRPartBServiceImplTest {
         is(Collections.singletonList(currentDeclarationDto)));
     assertThat("Unexpected current declaration summary.", savedDto.getCurrentDeclarationSummary(),
         is(DEFAULT_CURRENT_DECLARATION_SUMMARY));
-    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.", savedDto.getHaveCurrentUnresolvedDeclarations(),
+    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.",
+        savedDto.getHaveCurrentUnresolvedDeclarations(),
         is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
-    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", savedDto.getHavePreviousUnresolvedDeclarations(),
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.",
+        savedDto.getHavePreviousUnresolvedDeclarations(),
         is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
 
     verify(repositoryMock).save(entity);
@@ -334,9 +336,11 @@ class FormRPartBServiceImplTest {
         is(Collections.singletonList(currentDeclarationDto)));
     assertThat("Unexpected current declaration summary.", savedDto.getCurrentDeclarationSummary(),
         is(DEFAULT_CURRENT_DECLARATION_SUMMARY));
-    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.", savedDto.getHaveCurrentUnresolvedDeclarations(),
+    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.",
+        savedDto.getHaveCurrentUnresolvedDeclarations(),
         is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
-    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", savedDto.getHavePreviousUnresolvedDeclarations(),
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.",
+        savedDto.getHavePreviousUnresolvedDeclarations(),
         is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
 
     verify(repositoryMock).save(entity);
@@ -382,9 +386,11 @@ class FormRPartBServiceImplTest {
         is(Collections.singletonList(currentDeclarationDto)));
     assertThat("Unexpected current declaration summary.", savedDto.getCurrentDeclarationSummary(),
         is(DEFAULT_CURRENT_DECLARATION_SUMMARY));
-    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.", savedDto.getHaveCurrentUnresolvedDeclarations(),
+    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.",
+        savedDto.getHaveCurrentUnresolvedDeclarations(),
         is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
-    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", savedDto.getHavePreviousUnresolvedDeclarations(),
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.",
+        savedDto.getHavePreviousUnresolvedDeclarations(),
         is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
 
     verify(repositoryMock).save(entity);
@@ -430,9 +436,11 @@ class FormRPartBServiceImplTest {
         is(Collections.singletonList(currentDeclarationDto)));
     assertThat("Unexpected current declaration summary.", savedDto.getCurrentDeclarationSummary(),
         is(DEFAULT_CURRENT_DECLARATION_SUMMARY));
-    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.", savedDto.getHaveCurrentUnresolvedDeclarations(),
+    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.",
+        savedDto.getHaveCurrentUnresolvedDeclarations(),
         is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
-    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", savedDto.getHavePreviousUnresolvedDeclarations(),
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.",
+        savedDto.getHavePreviousUnresolvedDeclarations(),
         is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
 
     verify(repositoryMock).save(entity);
@@ -531,9 +539,11 @@ class FormRPartBServiceImplTest {
         is(Collections.singletonList(currentDeclarationDto)));
     assertThat("Unexpected current declaration summary.", dto.getCurrentDeclarationSummary(),
         is(DEFAULT_CURRENT_DECLARATION_SUMMARY));
-    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.", dto.getHaveCurrentUnresolvedDeclarations(),
+    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.",
+        dto.getHaveCurrentUnresolvedDeclarations(),
         is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
-    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", dto.getHavePreviousUnresolvedDeclarations(),
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.",
+        dto.getHavePreviousUnresolvedDeclarations(),
         is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
     assertThat("Unexpected status.", dto.getLifecycleState(), is(LifecycleState.SUBMITTED));
   }
@@ -567,9 +577,11 @@ class FormRPartBServiceImplTest {
         is(Collections.singletonList(currentDeclarationDto)));
     assertThat("Unexpected current declaration summary.", dto.getCurrentDeclarationSummary(),
         is(DEFAULT_CURRENT_DECLARATION_SUMMARY));
-    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.", dto.getHaveCurrentUnresolvedDeclarations(),
+    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.",
+        dto.getHaveCurrentUnresolvedDeclarations(),
         is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
-    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", dto.getHavePreviousUnresolvedDeclarations(),
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", 
+        dto.getHavePreviousUnresolvedDeclarations(),
         is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceImplTest.java
@@ -98,6 +98,10 @@ class FormRPartBServiceImplTest {
   private static final LocalDate DEFAULT_SUBMISSION_DATE = LocalDate.of(2020, 8, 29);
   private static final String DEFAULT_FORM_ID = "my-first-cloud-object-id";
 
+  private static final Boolean DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS = true;
+  private static final Boolean DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS = true;
+
+
   private FormRPartBServiceImpl service;
 
   @Mock
@@ -167,6 +171,8 @@ class FormRPartBServiceImplTest {
     entity.setCurrentDeclarations(Collections.singletonList(currentDeclaration));
     entity.setCurrentDeclarationSummary(DEFAULT_CURRENT_DECLARATION_SUMMARY);
     entity.setLifecycleState(LifecycleState.DRAFT);
+    entity.setHaveCurrentUnresolvedDeclarations(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS);
+    entity.setHavePreviousUnresolvedDeclarations(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS);
     return entity;
   }
 
@@ -279,6 +285,10 @@ class FormRPartBServiceImplTest {
         is(Collections.singletonList(currentDeclarationDto)));
     assertThat("Unexpected current declaration summary.", savedDto.getCurrentDeclarationSummary(),
         is(DEFAULT_CURRENT_DECLARATION_SUMMARY));
+    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.", savedDto.getHaveCurrentUnresolvedDeclarations(),
+        is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", savedDto.getHavePreviousUnresolvedDeclarations(),
+        is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
 
     verify(repositoryMock).save(entity);
     verify(s3FormRPartBRepository).save(entity);
@@ -324,6 +334,10 @@ class FormRPartBServiceImplTest {
         is(Collections.singletonList(currentDeclarationDto)));
     assertThat("Unexpected current declaration summary.", savedDto.getCurrentDeclarationSummary(),
         is(DEFAULT_CURRENT_DECLARATION_SUMMARY));
+    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.", savedDto.getHaveCurrentUnresolvedDeclarations(),
+        is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", savedDto.getHavePreviousUnresolvedDeclarations(),
+        is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
 
     verify(repositoryMock).save(entity);
     verifyNoInteractions(s3FormRPartBRepository);
@@ -368,6 +382,10 @@ class FormRPartBServiceImplTest {
         is(Collections.singletonList(currentDeclarationDto)));
     assertThat("Unexpected current declaration summary.", savedDto.getCurrentDeclarationSummary(),
         is(DEFAULT_CURRENT_DECLARATION_SUMMARY));
+    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.", savedDto.getHaveCurrentUnresolvedDeclarations(),
+        is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", savedDto.getHavePreviousUnresolvedDeclarations(),
+        is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
 
     verify(repositoryMock).save(entity);
     verify(s3FormRPartBRepository).save(entity);
@@ -412,6 +430,10 @@ class FormRPartBServiceImplTest {
         is(Collections.singletonList(currentDeclarationDto)));
     assertThat("Unexpected current declaration summary.", savedDto.getCurrentDeclarationSummary(),
         is(DEFAULT_CURRENT_DECLARATION_SUMMARY));
+    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.", savedDto.getHaveCurrentUnresolvedDeclarations(),
+        is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", savedDto.getHavePreviousUnresolvedDeclarations(),
+        is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
 
     verify(repositoryMock).save(entity);
     verify(s3FormRPartBRepository).save(entity);
@@ -509,6 +531,10 @@ class FormRPartBServiceImplTest {
         is(Collections.singletonList(currentDeclarationDto)));
     assertThat("Unexpected current declaration summary.", dto.getCurrentDeclarationSummary(),
         is(DEFAULT_CURRENT_DECLARATION_SUMMARY));
+    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.", dto.getHaveCurrentUnresolvedDeclarations(),
+        is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", dto.getHavePreviousUnresolvedDeclarations(),
+        is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
     assertThat("Unexpected status.", dto.getLifecycleState(), is(LifecycleState.SUBMITTED));
   }
 
@@ -541,5 +567,9 @@ class FormRPartBServiceImplTest {
         is(Collections.singletonList(currentDeclarationDto)));
     assertThat("Unexpected current declaration summary.", dto.getCurrentDeclarationSummary(),
         is(DEFAULT_CURRENT_DECLARATION_SUMMARY));
+    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.", dto.getHaveCurrentUnresolvedDeclarations(),
+        is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", dto.getHavePreviousUnresolvedDeclarations(),
+        is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
   }
 }

--- a/src/test/resources/forms/testFormRPartB.json
+++ b/src/test/resources/forms/testFormRPartB.json
@@ -43,5 +43,7 @@
   "lastModifiedDate": "2020-10-02",
   "lifecycleState": "SUBMITTED",
   "haveCovidDeclarations": false,
-  "covidDeclaration": null
+  "covidDeclaration": null,
+  "haveCurrentUnresolvedDeclarations": false,
+  "havePreviousUnresolvedDeclarations": false
 }


### PR DESCRIPTION
…vedDeclarations` to `FormRPartBDto` and `FormRPartB`

TIS21-2965: FormR Part B: Resolved declaration required if previous unresolved declaration given