### PR TITLE
fix: handle null work endDates in sort

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/SortWorkPlacements.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/SortWorkPlacements.java
@@ -60,7 +60,8 @@ public class SortWorkPlacements {
    */
   @Execution
   public void migrate() {
-    Comparator<Work> compareEndDates = Comparator.comparing(Work::getEndDate).reversed();
+    Comparator<Work> compareEndDates = Comparator.comparing(Work::getEndDate,
+        Comparator.nullsLast(Comparator.naturalOrder())).reversed();
 
     for (FormRPartB formRPartB : mongoTemplate.findAll(FormRPartB.class)) {
       List<Work> originalList = new ArrayList<>(formRPartB.getWork());

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/SortWorkPlacementsTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/SortWorkPlacementsTest.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.util.AssertionErrors.assertNull;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -103,6 +104,35 @@ class SortWorkPlacementsTest {
 
     //then
     verifyNoInteractions(service);
+  }
+
+  @Test
+  void shouldSortWorkPlacementsWithoutEndDates() {
+    //given
+    List<Work> workInOrder = new ArrayList<>();
+    workInOrder.add(workNewest);
+    workInOrder.add(new Work());
+    workInOrder.add(workOldest);
+
+    FormRPartB form = new FormRPartB();
+    form.setWork(workInOrder);
+
+    when(covidDeclarationMapper.toDto(any())).thenReturn(null);
+    when(template.findAll(FormRPartB.class)).thenReturn(Collections.singletonList(form));
+
+    //when
+    migration.migrate();
+
+    //then
+    ArgumentCaptor<FormRPartBDto> formCaptor = ArgumentCaptor.forClass(FormRPartBDto.class);
+    verify(service).save(formCaptor.capture());
+
+    FormRPartBDto updatedForm = formCaptor.getValue();
+    List<WorkDto> sortedWorkDto = updatedForm.getWork();
+    assertNull("Unexpected work ordering.",
+        sortedWorkDto.get(0).getEndDate());
+    assertThat("Unexpected work ordering.",
+        sortedWorkDto.get(1).getEndDate().isAfter(sortedWorkDto.get(2).getEndDate()), is(true));
   }
 
   @Test


### PR DESCRIPTION
TIS21-2911: Sort work placements for previously-submitted forms