### PR TITLE
Sort form Rs by date time and display time for submitted forms

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartADto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartADto.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.forms.dto;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Data;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
@@ -37,11 +38,11 @@ public class FormRPartADto {
   private String surname;
   private String gmcNumber;
   private String localOfficeName;
-  private LocalDateTime dateOfBirth;
+  private LocalDate dateOfBirth;
   private String gender;
   private String immigrationStatus;
   private String qualification;
-  private LocalDateTime dateAttained;
+  private LocalDate dateAttained;
   private String medicalSchool;
   private String address1;
   private String address2;
@@ -57,7 +58,7 @@ public class FormRPartADto {
   private String cctSpecialty1;
   private String cctSpecialty2;
   private String college;
-  private LocalDateTime completionDate;
+  private LocalDate completionDate;
   private String trainingGrade;
   private LocalDateTime startDate;
   private String programmeMembershipType;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartADto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartADto.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.forms.dto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.Data;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 
@@ -62,7 +63,7 @@ public class FormRPartADto {
   private LocalDate startDate;
   private String programmeMembershipType;
   private String wholeTimeEquivalent;
-  private LocalDate submissionDate;
+  private LocalDateTime submissionDate;
   private LocalDate lastModifiedDate;
   private String otherImmigrationStatus;
   private LifecycleState lifecycleState;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartADto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartADto.java
@@ -38,11 +38,11 @@ public class FormRPartADto {
   private String surname;
   private String gmcNumber;
   private String localOfficeName;
-  private LocalDate dateOfBirth;
+  private LocalDateTime dateOfBirth;
   private String gender;
   private String immigrationStatus;
   private String qualification;
-  private LocalDate dateAttained;
+  private LocalDateTime dateAttained;
   private String medicalSchool;
   private String address1;
   private String address2;
@@ -58,13 +58,13 @@ public class FormRPartADto {
   private String cctSpecialty1;
   private String cctSpecialty2;
   private String college;
-  private LocalDate completionDate;
+  private LocalDateTime completionDate;
   private String trainingGrade;
-  private LocalDate startDate;
+  private LocalDateTime startDate;
   private String programmeMembershipType;
   private String wholeTimeEquivalent;
   private LocalDateTime submissionDate;
-  private LocalDate lastModifiedDate;
+  private LocalDateTime lastModifiedDate;
   private String otherImmigrationStatus;
   private LifecycleState lifecycleState;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartADto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartADto.java
@@ -21,7 +21,6 @@
 
 package uk.nhs.hee.tis.trainee.forms.dto;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Data;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartBDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartBDto.java
@@ -21,6 +21,7 @@
 package uk.nhs.hee.tis.trainee.forms.dto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Data;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
@@ -64,7 +65,7 @@ public class FormRPartBDto {
   private List<DeclarationDto> currentDeclarations;
   private String currentDeclarationSummary;
   private String compliments;
-  private LocalDate submissionDate;
+  private LocalDateTime submissionDate;
   private LocalDate lastModifiedDate;
   private LifecycleState lifecycleState;
   private Boolean haveCovidDeclarations;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartSimpleDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartSimpleDto.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.forms.dto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.Data;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 
@@ -30,6 +31,6 @@ public class FormRPartSimpleDto {
 
   private String id;
   private String traineeTisId;
-  private LocalDate submissionDate;
+  private LocalDateTime submissionDate;
   private LifecycleState lifecycleState;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartSimpleDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartSimpleDto.java
@@ -21,7 +21,6 @@
 
 package uk.nhs.hee.tis.trainee.forms.dto;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Data;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractForm.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractForm.java
@@ -22,6 +22,7 @@ package uk.nhs.hee.tis.trainee.forms.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
@@ -38,7 +39,7 @@ public abstract class AbstractForm {
   private String traineeTisId;
 
   private LifecycleState lifecycleState;
-  private LocalDate submissionDate;
+  private LocalDateTime submissionDate;
   private LocalDate lastModifiedDate;
 
   @JsonIgnore

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
@@ -118,8 +118,10 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
         try {
           form.setSubmissionDate(LocalDateTime.parse(metadata.getUserMetaDataOf(SUBMISSION_DATE)));
         } catch (DateTimeParseException e) {
-          log.debug("Existing date {} not in latest format, trying as LocalDate.", e.getParsedString());
-          localDateTime = LocalDate.parse(metadata.getUserMetaDataOf(SUBMISSION_DATE)).atStartOfDay();
+          log.debug("Existing date {} not in latest format, trying as LocalDate.",
+              e.getParsedString());
+          localDateTime = LocalDate.parse(metadata.getUserMetaDataOf(SUBMISSION_DATE))
+              .atStartOfDay();
           form.setSubmissionDate(localDateTime);
         }
         form.setLifecycleState(

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
@@ -115,7 +115,7 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
         T form = getTypeClass().getConstructor().newInstance();
         form.setId(metadata.getUserMetaDataOf("id"));
         form.setTraineeTisId(metadata.getUserMetaDataOf("traineeid"));
-        if(metadata.getUserMetaDataOf("submissiondate").length() == 23)
+        if(metadata.getUserMetaDataOf("submissiondate").length() > 10)
         {
           form.setSubmissionDate(LocalDateTime.parse(metadata.getUserMetaDataOf("submissiondate")));
         }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
@@ -52,6 +52,10 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
 
   protected final ObjectMapper objectMapper;
 
+  private LocalDateTime localDateTime;
+  private LocalDate localDate;
+  private String localString;
+
   protected String bucketName;
 
   protected AbstractCloudRepository(AmazonS3 amazonS3,
@@ -111,7 +115,15 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
         T form = getTypeClass().getConstructor().newInstance();
         form.setId(metadata.getUserMetaDataOf("id"));
         form.setTraineeTisId(metadata.getUserMetaDataOf("traineeid"));
-        form.setSubmissionDate(LocalDateTime.parse(metadata.getUserMetaDataOf("submissiondate")));
+        if(metadata.getUserMetaDataOf("submissiondate").length() == 23)
+        {
+          form.setSubmissionDate(LocalDateTime.parse(metadata.getUserMetaDataOf("submissiondate")));
+        }
+        else
+        {
+          localDateTime = LocalDate.parse(metadata.getUserMetaDataOf("submissiondate")).atStartOfDay();
+          form.setSubmissionDate(localDateTime);
+        }
         form.setLifecycleState(
             LifecycleState.valueOf(metadata.getUserMetaDataOf("lifecyclestate").toUpperCase()));
         return form;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
 import java.lang.reflect.ParameterizedType;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
@@ -80,7 +81,7 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
       metadata.addUserMetadata("formtype", form.getFormType());
       metadata.addUserMetadata("lifecyclestate", form.getLifecycleState().name());
       metadata.addUserMetadata("submissiondate",
-          form.getSubmissionDate().format(DateTimeFormatter.ISO_LOCAL_DATE));
+          form.getSubmissionDate().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
       metadata.addUserMetadata("traineeid", form.getTraineeTisId());
 
       PutObjectRequest request = new PutObjectRequest(bucketName, key,
@@ -110,7 +111,7 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
         T form = getTypeClass().getConstructor().newInstance();
         form.setId(metadata.getUserMetaDataOf("id"));
         form.setTraineeTisId(metadata.getUserMetaDataOf("traineeid"));
-        form.setSubmissionDate(LocalDate.parse(metadata.getUserMetaDataOf("submissiondate")));
+        form.setSubmissionDate(LocalDateTime.parse(metadata.getUserMetaDataOf("submissiondate")));
         form.setLifecycleState(
             LifecycleState.valueOf(metadata.getUserMetaDataOf("lifecyclestate").toUpperCase()));
         return form;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
@@ -53,8 +53,7 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
   protected final ObjectMapper objectMapper;
 
   private LocalDateTime localDateTime;
-  private LocalDate localDate;
-  private String localString;
+  private String submissionDate = "submissiondate";
 
   protected String bucketName;
 
@@ -84,7 +83,7 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
       metadata.addUserMetadata("type", "json");
       metadata.addUserMetadata("formtype", form.getFormType());
       metadata.addUserMetadata("lifecyclestate", form.getLifecycleState().name());
-      metadata.addUserMetadata("submissiondate",
+      metadata.addUserMetadata(submissionDate,
           form.getSubmissionDate().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
       metadata.addUserMetadata("traineeid", form.getTraineeTisId());
 
@@ -115,17 +114,17 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
         T form = getTypeClass().getConstructor().newInstance();
         form.setId(metadata.getUserMetaDataOf("id"));
         form.setTraineeTisId(metadata.getUserMetaDataOf("traineeid"));
-        if(metadata.getUserMetaDataOf("submissiondate").length() > 10)
-        {
-          form.setSubmissionDate(LocalDateTime.parse(metadata.getUserMetaDataOf("submissiondate")));
+        if (metadata.getUserMetaDataOf("submissiondate").length() > 10) {
+          form.setSubmissionDate(LocalDateTime.parse(metadata.getUserMetaDataOf(submissionDate)));
         }
-        else
-        {
-          localDateTime = LocalDate.parse(metadata.getUserMetaDataOf("submissiondate")).atStartOfDay();
+        else {
+          localDateTime = LocalDate.parse(metadata
+              .getUserMetaDataOf(submissionDate)).atStartOfDay();
           form.setSubmissionDate(localDateTime);
         }
         form.setLifecycleState(
-            LifecycleState.valueOf(metadata.getUserMetaDataOf("lifecyclestate").toUpperCase()));
+            LifecycleState.valueOf(metadata.getUserMetaDataOf("lifecyclestate")
+                .toUpperCase()));
         return form;
       } catch (Exception e) {
         log.error("Problem reading form [{}] from S3 bucket [{}]", summary.getKey(), bucketName, e);

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartARepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartARepositoryImplTest.java
@@ -82,12 +82,12 @@ class S3FormRPartARepositoryImplTest {
       "DEFAULT_CURRENT_DECLARATION_SUMMARY";
   private static final LocalDateTime DEFAULT_SUBMISSION_DATE = LocalDateTime.now();
   private static final String DEFAULT_SUBMISSION_DATE_STRING = DEFAULT_SUBMISSION_DATE.format(
-      DateTimeFormatter.ISO_LOCAL_DATE);
+      DateTimeFormatter.ISO_LOCAL_DATE_TIME);
   private static final String DEFAULT_FORM_ID = "my-first-cloud-object-id";
   private static final Map<String, String> DEFAULT_UNSUBMITTED_METADATA = Map
       .of("id", DEFAULT_FORM_ID, "formtype", "inform", "lifecyclestate",
           LifecycleState.UNSUBMITTED.name(), "submissiondate",
-          DEFAULT_SUBMISSION_DATE.format(ISO_LOCAL_DATE), "traineeid",
+          DEFAULT_SUBMISSION_DATE_STRING, "traineeid",
           DEFAULT_TRAINEE_TIS_ID);
   private static ObjectMapper objectMapper;
   private S3FormRPartARepositoryImpl repo;

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartARepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartARepositoryImplTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -79,7 +80,7 @@ class S3FormRPartARepositoryImplTest {
       .now(ZoneId.systemDefault());
   private static final String DEFAULT_CURRENT_DECLARATION_SUMMARY =
       "DEFAULT_CURRENT_DECLARATION_SUMMARY";
-  private static final LocalDate DEFAULT_SUBMISSION_DATE = LocalDate.of(2020, 8, 29);
+  private static final LocalDateTime DEFAULT_SUBMISSION_DATE = LocalDateTime.now();
   private static final String DEFAULT_SUBMISSION_DATE_STRING = DEFAULT_SUBMISSION_DATE.format(
       DateTimeFormatter.ISO_LOCAL_DATE);
   private static final String DEFAULT_FORM_ID = "my-first-cloud-object-id";

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
@@ -1,6 +1,5 @@
 package uk.nhs.hee.tis.trainee.forms.repository;
 
-import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -85,12 +84,11 @@ class S3FormRPartBRepositoryImplTest {
       "DEFAULT_CURRENT_DECLARATION_SUMMARY";
   private static final LocalDateTime DEFAULT_SUBMISSION_DATE = LocalDateTime.now();
   private static final String DEFAULT_SUBMISSION_DATE_STRING = DEFAULT_SUBMISSION_DATE.format(
-      DateTimeFormatter.ISO_LOCAL_DATE);
+      DateTimeFormatter.ISO_LOCAL_DATE_TIME);
   private static final String DEFAULT_FORM_ID = "my-first-cloud-object-id";
   private static final Map<String, String> DEFAULT_UNSUBMITTED_METADATA = Map
       .of("id", DEFAULT_FORM_ID, "formtype", "inform", "lifecyclestate",
-          LifecycleState.UNSUBMITTED.name(), "submissiondate",
-          DEFAULT_SUBMISSION_DATE.format(ISO_LOCAL_DATE), "traineeid",
+          LifecycleState.UNSUBMITTED.name(), "submissiondate", DEFAULT_SUBMISSION_DATE_STRING, "traineeid",
           DEFAULT_TRAINEE_TIS_ID);
   private static final Boolean DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS = true;
   private static final Boolean DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS = true;

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -82,7 +83,7 @@ class S3FormRPartBRepositoryImplTest {
       .now(ZoneId.systemDefault());
   private static final String DEFAULT_CURRENT_DECLARATION_SUMMARY =
       "DEFAULT_CURRENT_DECLARATION_SUMMARY";
-  private static final LocalDate DEFAULT_SUBMISSION_DATE = LocalDate.of(2020, 8, 29);
+  private static final LocalDateTime DEFAULT_SUBMISSION_DATE = LocalDateTime.now();
   private static final String DEFAULT_SUBMISSION_DATE_STRING = DEFAULT_SUBMISSION_DATE.format(
       DateTimeFormatter.ISO_LOCAL_DATE);
   private static final String DEFAULT_FORM_ID = "my-first-cloud-object-id";

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
@@ -88,8 +88,8 @@ class S3FormRPartBRepositoryImplTest {
   private static final String DEFAULT_FORM_ID = "my-first-cloud-object-id";
   private static final Map<String, String> DEFAULT_UNSUBMITTED_METADATA = Map
       .of("id", DEFAULT_FORM_ID, "formtype", "inform", "lifecyclestate",
-          LifecycleState.UNSUBMITTED.name(), "submissiondate", DEFAULT_SUBMISSION_DATE_STRING, "traineeid",
-          DEFAULT_TRAINEE_TIS_ID);
+          LifecycleState.UNSUBMITTED.name(), "submissiondate", DEFAULT_SUBMISSION_DATE_STRING,
+          "traineeid", DEFAULT_TRAINEE_TIS_ID);
   private static final Boolean DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS = true;
   private static final Boolean DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS = true;
   private static ObjectMapper objectMapper;

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
@@ -265,16 +265,11 @@ class S3FormRPartBRepositoryImplTest {
         .thenReturn(s3ListingMock);
     S3ObjectSummary s3Summary = new S3ObjectSummary();
     s3Summary.setKey(KEY);
-    String otherKey = KEY + "w/error";
-    S3ObjectSummary errorSummary = new S3ObjectSummary();
-    errorSummary.setKey(otherKey);
-    List<S3ObjectSummary> cloudStoredEntities = List.of(s3Summary, errorSummary);
+    List<S3ObjectSummary> cloudStoredEntities = List.of(s3Summary);
     when(s3ListingMock.getObjectSummaries()).thenReturn(cloudStoredEntities);
     ObjectMetadata metadata = new ObjectMetadata();
     metadata.setUserMetadata(UNSUBMITTED_METADATA_DATE_FORMAT_SUBMISSIONDATE);
     when(s3Mock.getObjectMetadata(bucketName, KEY)).thenReturn(metadata);
-    when(s3Mock.getObjectMetadata(bucketName, otherKey))
-        .thenThrow(new AmazonServiceException("Expected Exception"));
 
     List<FormRPartB> entities = repo.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceImplTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -58,7 +59,7 @@ class FormRPartAServiceImplTest {
   private static final String DEFAULT_TRAINEE_TIS_ID = "1";
   private static final String DEFAULT_FORENAME = "DEFAULT_FORENAME";
   private static final String DEFAULT_SURNAME = "DEFAULT_SURNAME";
-  private static final LocalDate DEFAULT_SUBMISSION_DATE = LocalDate.of(2020, 8, 29);
+  private static final LocalDateTime DEFAULT_SUBMISSION_DATE = LocalDateTime.now();
 
   private FormRPartAServiceImpl service;
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceImplTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -95,7 +96,7 @@ class FormRPartBServiceImplTest {
       .now(ZoneId.systemDefault());
   private static final String DEFAULT_CURRENT_DECLARATION_SUMMARY =
       "DEFAULT_CURRENT_DECLARATION_SUMMARY";
-  private static final LocalDate DEFAULT_SUBMISSION_DATE = LocalDate.of(2020, 8, 29);
+  private static final LocalDateTime DEFAULT_SUBMISSION_DATE = LocalDateTime.now();
   private static final String DEFAULT_FORM_ID = "my-first-cloud-object-id";
 
   private static final Boolean DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS = true;
@@ -580,7 +581,7 @@ class FormRPartBServiceImplTest {
     assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.",
         dto.getHaveCurrentUnresolvedDeclarations(),
         is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
-    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", 
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.",
         dto.getHavePreviousUnresolvedDeclarations(),
         is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
   }

--- a/src/test/resources/forms/testFormRPartA.json
+++ b/src/test/resources/forms/testFormRPartA.json
@@ -30,7 +30,7 @@
   "startDate": "2020-01-01",
   "programmeMembershipType": "LAT",
   "wholeTimeEquivalent": "1",
-  "submissionDate": "2020-09-18",
+  "submissionDate": "2020-10-02T00:00",
   "lastModifiedDate": "2020-09-18",
   "otherImmigrationStatus": "",
   "lifecycleState": "SUBMITTED"

--- a/src/test/resources/forms/testFormRPartB.json
+++ b/src/test/resources/forms/testFormRPartB.json
@@ -39,7 +39,7 @@
   "currentDeclarations": [],
   "currentDeclarationSummary": null,
   "compliments": "",
-  "submissionDate": "2020-10-02",
+  "submissionDate": "2020-10-02T00:00",
   "lastModifiedDate": "2020-10-02",
   "lifecycleState": "SUBMITTED",
   "haveCovidDeclarations": false,


### PR DESCRIPTION
change type of submission date to 'LocalDateTime' to add hours and minutes with the date when saving a new form. 

previous forms are in a LocalDate format and need to be converted to LocalDateTime using .atStartOfDay() to populate the time

This PR is dependant on PR 'Sort form Rs by date time and display time for submitted forms' in trainee-ui and will need to be merged together

TIS21-3088