### PR TITLE
Revert "Sort form Rs by date time and display time for submitted forms"

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartADto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartADto.java
@@ -22,7 +22,6 @@
 package uk.nhs.hee.tis.trainee.forms.dto;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.Data;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 
@@ -63,8 +62,8 @@ public class FormRPartADto {
   private LocalDate startDate;
   private String programmeMembershipType;
   private String wholeTimeEquivalent;
-  private LocalDateTime submissionDate;
-  private LocalDateTime lastModifiedDate;
+  private LocalDate submissionDate;
+  private LocalDate lastModifiedDate;
   private String otherImmigrationStatus;
   private LifecycleState lifecycleState;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartBDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartBDto.java
@@ -21,7 +21,6 @@
 package uk.nhs.hee.tis.trainee.forms.dto;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Data;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
@@ -65,7 +64,7 @@ public class FormRPartBDto {
   private List<DeclarationDto> currentDeclarations;
   private String currentDeclarationSummary;
   private String compliments;
-  private LocalDateTime submissionDate;
+  private LocalDate submissionDate;
   private LocalDate lastModifiedDate;
   private LifecycleState lifecycleState;
   private Boolean haveCovidDeclarations;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartSimpleDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartSimpleDto.java
@@ -21,7 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.forms.dto;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import lombok.Data;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 
@@ -30,6 +30,6 @@ public class FormRPartSimpleDto {
 
   private String id;
   private String traineeTisId;
-  private LocalDateTime submissionDate;
+  private LocalDate submissionDate;
   private LifecycleState lifecycleState;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractForm.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractForm.java
@@ -22,7 +22,6 @@ package uk.nhs.hee.tis.trainee.forms.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
@@ -39,7 +38,7 @@ public abstract class AbstractForm {
   private String traineeTisId;
 
   private LifecycleState lifecycleState;
-  private LocalDateTime submissionDate;
+  private LocalDate submissionDate;
   private LocalDate lastModifiedDate;
 
   @JsonIgnore

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartARepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartARepositoryImplTest.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -80,14 +79,14 @@ class S3FormRPartARepositoryImplTest {
       .now(ZoneId.systemDefault());
   private static final String DEFAULT_CURRENT_DECLARATION_SUMMARY =
       "DEFAULT_CURRENT_DECLARATION_SUMMARY";
-  private static final LocalDateTime DEFAULT_SUBMISSION_DATE = LocalDateTime.now();
+  private static final LocalDate DEFAULT_SUBMISSION_DATE = LocalDate.of(2020, 8, 29);
   private static final String DEFAULT_SUBMISSION_DATE_STRING = DEFAULT_SUBMISSION_DATE.format(
-      DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+      DateTimeFormatter.ISO_LOCAL_DATE);
   private static final String DEFAULT_FORM_ID = "my-first-cloud-object-id";
   private static final Map<String, String> DEFAULT_UNSUBMITTED_METADATA = Map
       .of("id", DEFAULT_FORM_ID, "formtype", "inform", "lifecyclestate",
           LifecycleState.UNSUBMITTED.name(), "submissiondate",
-          DEFAULT_SUBMISSION_DATE_STRING, "traineeid",
+          DEFAULT_SUBMISSION_DATE.format(ISO_LOCAL_DATE), "traineeid",
           DEFAULT_TRAINEE_TIS_ID);
   private static ObjectMapper objectMapper;
   private S3FormRPartARepositoryImpl repo;

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
@@ -1,5 +1,6 @@
 package uk.nhs.hee.tis.trainee.forms.repository;
 
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -27,7 +28,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -82,24 +82,15 @@ class S3FormRPartBRepositoryImplTest {
       .now(ZoneId.systemDefault());
   private static final String DEFAULT_CURRENT_DECLARATION_SUMMARY =
       "DEFAULT_CURRENT_DECLARATION_SUMMARY";
-  private static final LocalDateTime DEFAULT_SUBMISSION_DATE = LocalDateTime.now();
+  private static final LocalDate DEFAULT_SUBMISSION_DATE = LocalDate.of(2020, 8, 29);
   private static final String DEFAULT_SUBMISSION_DATE_STRING = DEFAULT_SUBMISSION_DATE.format(
-      DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-  private static final LocalDate DATE_FORMAT_SUBMISSION_DATE = LocalDate
-      .of(2020, 8, 29);
-  private static final LocalDateTime DATE_FORMAT_SUBMISSION_DATE_PARSED =
-      DATE_FORMAT_SUBMISSION_DATE.atStartOfDay();
-  private static final String DATE_FORMAT_DATE_STRING = DATE_FORMAT_SUBMISSION_DATE.format(
       DateTimeFormatter.ISO_LOCAL_DATE);
   private static final String DEFAULT_FORM_ID = "my-first-cloud-object-id";
   private static final Map<String, String> DEFAULT_UNSUBMITTED_METADATA = Map
       .of("id", DEFAULT_FORM_ID, "formtype", "inform", "lifecyclestate",
-          LifecycleState.UNSUBMITTED.name(), "submissiondate", DEFAULT_SUBMISSION_DATE_STRING,
-          "traineeid", DEFAULT_TRAINEE_TIS_ID);
-  private static final Map<String, String> UNSUBMITTED_METADATA_DATE_FORMAT_SUBMISSIONDATE = Map
-      .of("id", DEFAULT_FORM_ID, "formtype", "inform", "lifecyclestate",
-          LifecycleState.UNSUBMITTED.name(), "submissiondate", DATE_FORMAT_DATE_STRING,
-          "traineeid", DEFAULT_TRAINEE_TIS_ID);
+          LifecycleState.UNSUBMITTED.name(), "submissiondate",
+          DEFAULT_SUBMISSION_DATE.format(ISO_LOCAL_DATE), "traineeid",
+          DEFAULT_TRAINEE_TIS_ID);
   private static final Boolean DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS = true;
   private static final Boolean DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS = true;
   private static ObjectMapper objectMapper;
@@ -257,28 +248,6 @@ class S3FormRPartBRepositoryImplTest {
         is(DEFAULT_SUBMISSION_DATE));
     assertThat("Unexpected lifecycle state.", entity.getLifecycleState(),
         is(LifecycleState.UNSUBMITTED));
-  }
-
-  @Test
-  void shouldParseSubmissionDateWhenInDateFormat() {
-    when(s3Mock.listObjects(bucketName, DEFAULT_TRAINEE_TIS_ID + "/forms/formr-b"))
-        .thenReturn(s3ListingMock);
-    S3ObjectSummary s3Summary = new S3ObjectSummary();
-    s3Summary.setKey(KEY);
-    List<S3ObjectSummary> cloudStoredEntities = List.of(s3Summary);
-    when(s3ListingMock.getObjectSummaries()).thenReturn(cloudStoredEntities);
-    ObjectMetadata metadata = new ObjectMetadata();
-    metadata.setUserMetadata(UNSUBMITTED_METADATA_DATE_FORMAT_SUBMISSIONDATE);
-    when(s3Mock.getObjectMetadata(bucketName, KEY)).thenReturn(metadata);
-
-    List<FormRPartB> entities = repo.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-
-    assertThat("Unexpected numbers of forms.", entities.size(), is(1));
-
-    FormRPartB entity = entities.get(0);
-
-    assertThat("Unexpected submitted date.", entity.getSubmissionDate(),
-        is(DATE_FORMAT_SUBMISSION_DATE_PARSED));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceImplTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -59,7 +58,7 @@ class FormRPartAServiceImplTest {
   private static final String DEFAULT_TRAINEE_TIS_ID = "1";
   private static final String DEFAULT_FORENAME = "DEFAULT_FORENAME";
   private static final String DEFAULT_SURNAME = "DEFAULT_SURNAME";
-  private static final LocalDateTime DEFAULT_SUBMISSION_DATE = LocalDateTime.now();
+  private static final LocalDate DEFAULT_SUBMISSION_DATE = LocalDate.of(2020, 8, 29);
 
   private FormRPartAServiceImpl service;
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceImplTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.when;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -96,7 +95,7 @@ class FormRPartBServiceImplTest {
       .now(ZoneId.systemDefault());
   private static final String DEFAULT_CURRENT_DECLARATION_SUMMARY =
       "DEFAULT_CURRENT_DECLARATION_SUMMARY";
-  private static final LocalDateTime DEFAULT_SUBMISSION_DATE = LocalDateTime.now();
+  private static final LocalDate DEFAULT_SUBMISSION_DATE = LocalDate.of(2020, 8, 29);
   private static final String DEFAULT_FORM_ID = "my-first-cloud-object-id";
 
   private static final Boolean DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS = true;
@@ -581,7 +580,7 @@ class FormRPartBServiceImplTest {
     assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.",
         dto.getHaveCurrentUnresolvedDeclarations(),
         is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
-    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.",
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.", 
         dto.getHavePreviousUnresolvedDeclarations(),
         is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
   }

--- a/src/test/resources/forms/testFormRPartA.json
+++ b/src/test/resources/forms/testFormRPartA.json
@@ -30,7 +30,7 @@
   "startDate": "2020-01-01",
   "programmeMembershipType": "LAT",
   "wholeTimeEquivalent": "1",
-  "submissionDate": "2020-10-02T00:00",
+  "submissionDate": "2020-09-18",
   "lastModifiedDate": "2020-09-18",
   "otherImmigrationStatus": "",
   "lifecycleState": "SUBMITTED"

--- a/src/test/resources/forms/testFormRPartB.json
+++ b/src/test/resources/forms/testFormRPartB.json
@@ -39,7 +39,7 @@
   "currentDeclarations": [],
   "currentDeclarationSummary": null,
   "compliments": "",
-  "submissionDate": "2020-10-02T00:00",
+  "submissionDate": "2020-10-02",
   "lastModifiedDate": "2020-10-02",
   "lifecycleState": "SUBMITTED",
   "haveCovidDeclarations": false,


### PR DESCRIPTION
Reverts Health-Education-England/tis-trainee-forms#357

this must be reverted allong with  'Revert "Sort form Rs by date time and display time for submitted forms"' in trainee-ui after Revert "refactor: change startDate type to LocalDate from LocalDateTime" in trainee forms

this is due to the current version affecting the admins-ui not being able to open form-Rs due to the changes in the forms date types being unable to be parsed, this is also affecting trainee-ui when trying to open the older formRs