### PR TITLE
chore: keep mapstruct versions in sync

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,10 @@ dependencies {
   annotationProcessor "org.projectlombok:lombok"
 
   // MapStruct
-  implementation "org.mapstruct:mapstruct:1.4.2.Final"
-  annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
-  testAnnotationProcessor "org.mapstruct:mapstruct-processor:1.3.1.Final"
+  ext.mapstructVersion = "1.5.2.Final"
+  implementation "org.mapstruct:mapstruct:${mapstructVersion}"
+  annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
+  testAnnotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
 
   ext.mongockVersion = "5.1.0"
   implementation "io.mongock:mongock-springboot:${mongockVersion}"


### PR DESCRIPTION
Update the Mapstruct dependency versioning to use a shared variable.

TIS21-SHED