### PR TITLE
fix: create consistent form ids

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.5.5"
+version = "0.5.6"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractFormMongoEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractFormMongoEventListener.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2022 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.model;
+
+import java.util.UUID;
+import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
+import org.springframework.data.mongodb.core.mapping.event.BeforeConvertEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AbstractFormMongoEventListener extends AbstractMongoEventListener<AbstractForm> {
+
+  @Override
+  public void onBeforeConvert(BeforeConvertEvent<AbstractForm> event) {
+    AbstractForm source = event.getSource();
+
+    if (source.getId() == null) {
+      source.setId(UUID.randomUUID().toString());
+    }
+
+    super.onBeforeConvert(event);
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/model/AbstractFormMongoEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/model/AbstractFormMongoEventListenerTest.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.model;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.mapping.event.BeforeConvertEvent;
+
+class AbstractFormMongoEventListenerTest {
+
+  private AbstractFormMongoEventListener listener;
+
+  @BeforeEach
+  void setUp() {
+    listener = new AbstractFormMongoEventListener();
+  }
+
+  @Test
+  void shouldPopulateIdBeforeConvertWhenIdNull() {
+    StubForm form = new StubForm();
+
+    BeforeConvertEvent<AbstractForm> event = new BeforeConvertEvent<>(form, "StubForm");
+    listener.onBeforeConvert(event);
+
+    String id = form.getId();
+    assertThat("Unexpected form ID.", id, notNullValue());
+    assertDoesNotThrow(() -> UUID.fromString(id), "Unexpected ID format.");
+  }
+
+  @Test
+  void shouldNotModifyIdBeforeConvertWhenIdPopulated() {
+    StubForm form = new StubForm();
+    form.setId("test_id");
+
+    BeforeConvertEvent<AbstractForm> event = new BeforeConvertEvent<>(form, "StubForm");
+    listener.onBeforeConvert(event);
+
+    assertThat("Unexpected form ID.", form.getId(), is("test_id"));
+  }
+
+  /**
+   * A stub for testing the behaviour of the AbstractForm event listener.
+   */
+  private static class StubForm extends AbstractForm {
+
+    @Override
+    public String getFormType() {
+      return "test-form";
+    }
+  }
+}


### PR DESCRIPTION
The form ID number is a different format depending on whether the form The form ID number is a different format depending on whether the form was ever saved as a draft or not, direct submission results in a UUID style ID e.g. c95f2312-a08c-46d4-8e0c-5c13215c96d0 but if the form was saved as a draft before later submitting the ID will be in the ObjectId style e.g. 63a3376e7199d510f8f56808

Use an event listener to populate the form ID with a UUID string representation before converting it to a document, this avoids Mongo from setting the ObjectId automatically.
A follow up submission will migrate the existing ObjectIds to the new standardised UUID string format.

TIS21-4006

[TIS21-4006]: https://hee-tis.atlassian.net/browse/TIS21-4006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ