### PR TITLE
refactor: make UUID migrator use generic document

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.6.0"
+version = "0.6.1"
 
 configurations {
   compileOnly {


### PR DESCRIPTION
The migrator was based on using AbstractForm type to update the form ID, however the follow up changes to make the ID field use UUID will be a breaking change to this migrator.
Refactor the migrator to use generic Documents instead, this will avoid having to fix the implementation later. The test's will still fail to compile and will need further modification during the next steps.

TIS21-4006
TIS21-4026