### PR TITLE
feat: migrate AbstractForm from string to UUID

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidator.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidator.java
@@ -80,7 +80,8 @@ public class FormRPartAValidator {
       if (!existingFormRPartA.isEmpty()) {
         if (existingFormRPartA.size() == 1) {
           FormRPartA formRPartA = existingFormRPartA.get(0);
-          if (formRPartADto.getId() == null || !formRPartA.getId().equals(formRPartADto.getId())) {
+          if (formRPartADto.getId() == null || !formRPartA.getId().toString()
+              .equals(formRPartADto.getId())) {
             fieldErrors.add(new FieldError(FORMR_PARTA_DTO_NAME, "lifecycleState",
                 "Draft form R Part A already exists"));
           }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartBValidator.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartBValidator.java
@@ -80,7 +80,8 @@ public class FormRPartBValidator {
       if (!existingFormRPartB.isEmpty()) {
         if (existingFormRPartB.size() == 1) {
           FormRPartB formRPartB = existingFormRPartB.get(0);
-          if (formRPartBDto.getId() == null || !formRPartB.getId().equals(formRPartBDto.getId())) {
+          if (formRPartBDto.getId() == null || !formRPartB.getId().toString()
+              .equals(formRPartBDto.getId())) {
             fieldErrors.add(new FieldError(FORMR_PARTB_DTO_NAME, "lifecycleState",
                 "Draft form R Part B already exists"));
           }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertUuidStringsToUuidObjects.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertUuidStringsToUuidObjects.java
@@ -1,0 +1,120 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.migration;
+
+import com.mongodb.client.result.DeleteResult;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import java.util.List;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractForm;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
+
+/**
+ * Convert existing UUID string based form IDs to UUID objects.
+ */
+@Slf4j
+@ChangeUnit(id = "ConvertUuidStringsToUuidObjects", order = "6")
+public class ConvertUuidStringsToUuidObjects {
+
+  private static final String ID_FIELD = "_id";
+  private final MongoTemplate mongoTemplate;
+
+  /**
+   * Convert existing UUID string based form IDs to UUID objects.
+   */
+  public ConvertUuidStringsToUuidObjects(MongoTemplate mongoTemplate) {
+    this.mongoTemplate = mongoTemplate;
+  }
+
+  /**
+   * Generate a new UUID object for each UUID string form.
+   */
+  @Execution
+  public void migrateCollections() {
+    migrateCollection(FormRPartA.class);
+    migrateCollection(FormRPartB.class);
+  }
+
+  private void migrateCollection(Class<? extends AbstractForm> formClass) {
+    String collectionName = mongoTemplate.getCollectionName(formClass);
+    log.info("Converting UUID strings to objects for forms in collection {}.", collectionName);
+
+    // Filter to only non UUID objects, so that retries can skip migrated forms on retry.
+    List<Document> allDocuments = mongoTemplate.findAll(Document.class, collectionName);
+    List<Document> uuidStringDocuments = allDocuments.stream()
+        .filter(document -> document.get(ID_FIELD) instanceof String)
+        .toList();
+    log.info("Found {} form(s) that require UUID conversion.", uuidStringDocuments.size());
+
+    for (Document document : uuidStringDocuments) {
+      String originalId = document.getString(ID_FIELD);
+      log.info("Converting form {}.", originalId);
+
+      UUID newId = UUID.fromString(originalId);
+      document.put(ID_FIELD, newId);
+
+      log.info("Saving updated form {}.", newId);
+      mongoTemplate.insert(document, collectionName);
+      log.info("Saved updated form {}.", newId);
+
+      deleteOriginalForm(originalId, collectionName);
+    }
+  }
+
+  /**
+   * Delete the original forms from the database.
+   *
+   * @param originalId     The original ID of the form to delete.
+   * @param collectionName The name of the collection to delete from.
+   */
+  private void deleteOriginalForm(String originalId, String collectionName) {
+    log.info("Deleting previous form {} from the database.", originalId);
+    Criteria originalFormCriteria = Criteria.where(ID_FIELD).is(originalId);
+    Query originalFormQuery = Query.query(originalFormCriteria);
+    DeleteResult result = mongoTemplate.remove(originalFormQuery, collectionName);
+
+    if (result.getDeletedCount() != 1) {
+      // Log an error, but do not fail the migration so that other forms can still be migrated.
+      log.error("Unexpected delete count of {} for form ID {}.", result.getDeletedCount(),
+          originalId);
+    } else {
+      log.info("Deleted previous form {} from the database.", originalId);
+    }
+  }
+
+  /**
+   * Do not attempt rollback, any successfully migrated forms should stay updated.
+   */
+  @RollbackExecution
+  public void rollback() {
+    log.warn(
+        "Rollback requested but not available for 'ConvertUuidStringsToUuidObjects' migration.");
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractForm.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractForm.java
@@ -22,6 +22,7 @@ package uk.nhs.hee.tis.trainee.forms.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
@@ -32,7 +33,7 @@ import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 public abstract class AbstractForm {
 
   @Id
-  private String id;
+  private UUID id;
   @Indexed
   @Field(value = "traineeTisId")
   private String traineeTisId;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractFormMongoEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractFormMongoEventListener.java
@@ -34,7 +34,7 @@ public class AbstractFormMongoEventListener extends AbstractMongoEventListener<A
     AbstractForm source = event.getSource();
 
     if (source.getId() == null) {
-      source.setId(UUID.randomUUID().toString());
+      source.setId(UUID.randomUUID());
     }
 
     super.onBeforeConvert(event);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,4 @@ spring:
   data:
     mongodb:
       uri: mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:forms}?authSource=admin&replicaSet=rs0&readPreference=secondaryPreferred
+      uuid-representation: standard

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidatorTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidatorTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.UUID;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,7 +48,8 @@ import uk.nhs.hee.tis.trainee.forms.repository.FormRPartARepository;
 @ExtendWith(MockitoExtension.class)
 class FormRPartAValidatorTest {
 
-  private static final String DEFAULT_ID = "DEFAULT_ID";
+  private static final UUID DEFAULT_ID = UUID.randomUUID();
+  private static final UUID ANOTHER_ID = UUID.randomUUID();
   private static final String DEFAULT_TRAINEE_TIS_ID = "DEFAULT_TRAINEE_TIS_ID";
   private static final LifecycleState DEFAULT_LIFECYCLESTATE = LifecycleState.DRAFT;
 
@@ -65,7 +67,7 @@ class FormRPartAValidatorTest {
   @BeforeEach
   public void initData() {
     formRPartADto = new FormRPartADto();
-    formRPartADto.setId(DEFAULT_ID);
+    formRPartADto.setId(DEFAULT_ID.toString());
     formRPartADto.setLifecycleState(DEFAULT_LIFECYCLESTATE);
   }
 
@@ -85,12 +87,12 @@ class FormRPartAValidatorTest {
   void validateDraftIfMultipleDraftsFound() {
     FormRPartA formRPartA1 = new FormRPartA();
     formRPartA1.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    formRPartA1.setId("ANOTHER_ID_1");
+    formRPartA1.setId(ANOTHER_ID);
     formRPartA1.setLifecycleState(LifecycleState.DRAFT);
 
     FormRPartA formRPartA2 = new FormRPartA();
     formRPartA2.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    formRPartA2.setId("ANOTHER_ID_2");
+    formRPartA2.setId(UUID.randomUUID());
     formRPartA2.setLifecycleState(LifecycleState.DRAFT);
 
     when(formRPartARepositoryMock
@@ -124,7 +126,7 @@ class FormRPartAValidatorTest {
   void validateUpdateDraftIfOneDraftWithDifferentIdFound() {
     FormRPartA formRPartA = new FormRPartA();
     formRPartA.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    formRPartA.setId("ANOTHER_ID");
+    formRPartA.setId(ANOTHER_ID);
     formRPartA.setLifecycleState(LifecycleState.DRAFT);
 
     when(formRPartARepositoryMock
@@ -144,7 +146,7 @@ class FormRPartAValidatorTest {
 
     FormRPartA formRPartA = new FormRPartA();
     formRPartA.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    formRPartA.setId("ANOTHER_ID");
+    formRPartA.setId(ANOTHER_ID);
     formRPartA.setLifecycleState(LifecycleState.DRAFT);
 
     when(formRPartARepositoryMock
@@ -162,7 +164,7 @@ class FormRPartAValidatorTest {
   void validateShouldThrowExceptionWhenValidationFails() {
     FormRPartA formRPartA = new FormRPartA();
     formRPartA.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    formRPartA.setId("ANOTHER_ID");
+    formRPartA.setId(ANOTHER_ID);
     formRPartA.setLifecycleState(LifecycleState.DRAFT);
 
     when(formRPartARepositoryMock

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartBValidatorTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartBValidatorTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.UUID;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,7 +48,8 @@ import uk.nhs.hee.tis.trainee.forms.repository.FormRPartBRepository;
 @ExtendWith(MockitoExtension.class)
 class FormRPartBValidatorTest {
 
-  private static final String DEFAULT_ID = "DEFAULT_ID";
+  private static final UUID DEFAULT_ID = UUID.randomUUID();
+  private static final UUID ANOTHER_ID = UUID.randomUUID();
   private static final String DEFAULT_TRAINEE_TIS_ID = "DEFAULT_TRAINEE_TIS_ID";
   private static final LifecycleState DEFAULT_LIFECYCLESTATE = LifecycleState.DRAFT;
 
@@ -65,7 +67,7 @@ class FormRPartBValidatorTest {
   @BeforeEach
   public void initData() {
     formRPartBDto = new FormRPartBDto();
-    formRPartBDto.setId(DEFAULT_ID);
+    formRPartBDto.setId(DEFAULT_ID.toString());
     formRPartBDto.setLifecycleState(DEFAULT_LIFECYCLESTATE);
   }
 
@@ -85,12 +87,12 @@ class FormRPartBValidatorTest {
   void validateDraftIfMultipleDraftsFound() {
     FormRPartB formRPartB1 = new FormRPartB();
     formRPartB1.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    formRPartB1.setId("ANOTHER_ID_1");
+    formRPartB1.setId(ANOTHER_ID);
     formRPartB1.setLifecycleState(LifecycleState.DRAFT);
 
     FormRPartB formRPartB2 = new FormRPartB();
     formRPartB2.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    formRPartB2.setId("ANOTHER_ID_2");
+    formRPartB2.setId(UUID.randomUUID());
     formRPartB2.setLifecycleState(LifecycleState.DRAFT);
 
     when(formRPartBRepositoryMock
@@ -124,7 +126,7 @@ class FormRPartBValidatorTest {
   void validateUpdateDraftIfOneDraftWithDifferentIdFound() {
     FormRPartB formRPartB = new FormRPartB();
     formRPartB.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    formRPartB.setId("ANOTHER_ID");
+    formRPartB.setId(ANOTHER_ID);
     formRPartB.setLifecycleState(LifecycleState.DRAFT);
 
     when(formRPartBRepositoryMock
@@ -144,7 +146,7 @@ class FormRPartBValidatorTest {
 
     FormRPartB formRPartB = new FormRPartB();
     formRPartB.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    formRPartB.setId("ANOTHER_ID");
+    formRPartB.setId(ANOTHER_ID);
     formRPartB.setLifecycleState(LifecycleState.DRAFT);
 
     when(formRPartBRepositoryMock
@@ -162,7 +164,7 @@ class FormRPartBValidatorTest {
   void validateShouldThrowExceptionWhenValidationFails() {
     FormRPartB formRPartB = new FormRPartB();
     formRPartB.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    formRPartB.setId("ANOTHER_ID");
+    formRPartB.setId(ANOTHER_ID);
     formRPartB.setLifecycleState(LifecycleState.DRAFT);
 
     when(formRPartBRepositoryMock

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertObjectIdsToUuidStringsTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertObjectIdsToUuidStringsTest.java
@@ -100,7 +100,7 @@ class ConvertObjectIdsToUuidStringsTest {
       Document document = args.getArgument(1);
 
       AbstractForm form = formClass.getConstructor().newInstance();
-      form.setId(document.get(ID_FIELD).toString());
+      form.setId(UUID.fromString(document.get(ID_FIELD).toString()));
       form.setTraineeTisId(document.getString(TRAINEE_ID_FIELD));
       return form;
     });
@@ -109,7 +109,7 @@ class ConvertObjectIdsToUuidStringsTest {
 
   @Test
   void shouldNotFailWhenNoDocumentsToMigrate() {
-    when(template.find(any(), any(), any())).thenReturn(List.of());
+    when(template.findAll(eq(Document.class), any())).thenReturn(List.of());
 
     assertDoesNotThrow(() -> migration.migrateCollections());
   }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertUuidStringsToUuidObjectsTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertUuidStringsToUuidObjectsTest.java
@@ -101,7 +101,7 @@ class ConvertUuidStringsToUuidObjectsTest {
     Document document2 = new Document();
     document2.put(ID_FIELD, ID_STRING_2);
 
-    when(template.findAll(eq(Document.class), eq(PART_A_COLLECTION_NAME))).thenReturn(
+    when(template.findAll(Document.class, PART_A_COLLECTION_NAME)).thenReturn(
         List.of(document1, document2));
     when(template.remove(any(), eq(PART_A_COLLECTION_NAME))).thenReturn(
         DeleteResult.acknowledged(1));
@@ -125,7 +125,7 @@ class ConvertUuidStringsToUuidObjectsTest {
     Document document2 = new Document();
     document2.put(ID_FIELD, ID_STRING_2);
 
-    when(template.findAll(eq(Document.class), eq(PART_B_COLLECTION_NAME))).thenReturn(
+    when(template.findAll(Document.class, PART_B_COLLECTION_NAME)).thenReturn(
         List.of(document1, document2));
     when(template.remove(any(), eq(PART_B_COLLECTION_NAME))).thenReturn(
         DeleteResult.acknowledged(1));
@@ -149,7 +149,7 @@ class ConvertUuidStringsToUuidObjectsTest {
     Document document2 = new Document();
     document2.put(ID_FIELD, ID_STRING_2);
 
-    when(template.findAll(eq(Document.class), eq(PART_A_COLLECTION_NAME))).thenReturn(
+    when(template.findAll(Document.class, PART_A_COLLECTION_NAME)).thenReturn(
         List.of(document1, document2));
 
     ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
@@ -178,7 +178,7 @@ class ConvertUuidStringsToUuidObjectsTest {
     Document document2 = new Document();
     document2.put(ID_FIELD, ID_STRING_2);
 
-    when(template.findAll(eq(Document.class), eq(PART_B_COLLECTION_NAME))).thenReturn(
+    when(template.findAll(Document.class, PART_B_COLLECTION_NAME)).thenReturn(
         List.of(document1, document2));
 
     ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertUuidStringsToUuidObjectsTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertUuidStringsToUuidObjectsTest.java
@@ -1,0 +1,225 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.migration;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.mongodb.client.result.DeleteResult;
+import java.util.List;
+import java.util.UUID;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.internal.verification.Times;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
+
+class ConvertUuidStringsToUuidObjectsTest {
+
+  private static final String ID_FIELD = "_id";
+  private static final UUID ID_UUID_1 = UUID.randomUUID();
+  private static final String ID_STRING_1 = ID_UUID_1.toString();
+  private static final UUID ID_UUID_2 = UUID.randomUUID();
+  private static final String ID_STRING_2 = ID_UUID_2.toString();
+  private static final String PART_A_COLLECTION_NAME = "part-a-collection";
+  private static final String PART_B_COLLECTION_NAME = "part-b-collection";
+
+  private ConvertUuidStringsToUuidObjects migration;
+  private MongoTemplate template;
+
+  @BeforeEach
+  void setUp() {
+    template = mock(MongoTemplate.class);
+    migration = new ConvertUuidStringsToUuidObjects(template);
+
+    when(template.getCollectionName(FormRPartA.class)).thenReturn(PART_A_COLLECTION_NAME);
+    when(template.getCollectionName(FormRPartB.class)).thenReturn(PART_B_COLLECTION_NAME);
+  }
+
+  @Test
+  void shouldNotFailWhenNoDocumentsToMigrate() {
+    when(template.findAll(eq(Document.class), any())).thenReturn(List.of());
+
+    assertDoesNotThrow(() -> migration.migrateCollections());
+  }
+
+  @Test
+  void shouldOnlyIncludeUuidStringsInMigration() {
+    Document document1 = new Document();
+    document1.put(ID_FIELD, ID_STRING_1);
+
+    Document document2 = new Document();
+    document2.put(ID_FIELD, ID_UUID_2);
+
+    when(template.findAll(eq(Document.class), any())).thenReturn(List.of(document1, document2),
+        List.of());
+    when(template.remove(any(), any(String.class))).thenReturn(DeleteResult.acknowledged(1));
+
+    migration.migrateCollections();
+
+    verify(template, new Times(1)).insert(any(Document.class), eq(PART_A_COLLECTION_NAME));
+    verify(template, new Times(1)).remove(any(), eq(PART_A_COLLECTION_NAME));
+  }
+
+  @Test
+  void shouldSaveFormRPartAsWithNewUuid() {
+    Document document1 = new Document();
+    document1.put(ID_FIELD, ID_STRING_1);
+
+    Document document2 = new Document();
+    document2.put(ID_FIELD, ID_STRING_2);
+
+    when(template.findAll(eq(Document.class), eq(PART_A_COLLECTION_NAME))).thenReturn(
+        List.of(document1, document2));
+    when(template.remove(any(), eq(PART_A_COLLECTION_NAME))).thenReturn(
+        DeleteResult.acknowledged(1));
+
+    migration.migrateCollections();
+
+    ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.forClass(Document.class);
+    verify(template, new Times(2)).insert(documentCaptor.capture(), eq(PART_A_COLLECTION_NAME));
+
+    List<Document> documents = documentCaptor.getAllValues();
+    assertThat("Unexpected document save count.", documents.size(), is(2));
+    assertThat("Unexpected document ID.", documents.get(0).get(ID_FIELD), is(ID_UUID_1));
+    assertThat("Unexpected document ID.", documents.get(1).get(ID_FIELD), is(ID_UUID_2));
+  }
+
+  @Test
+  void shouldSaveFormRPartBsWithNewUuid() {
+    Document document1 = new Document();
+    document1.put(ID_FIELD, ID_STRING_1);
+
+    Document document2 = new Document();
+    document2.put(ID_FIELD, ID_STRING_2);
+
+    when(template.findAll(eq(Document.class), eq(PART_B_COLLECTION_NAME))).thenReturn(
+        List.of(document1, document2));
+    when(template.remove(any(), eq(PART_B_COLLECTION_NAME))).thenReturn(
+        DeleteResult.acknowledged(1));
+
+    migration.migrateCollections();
+
+    ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.forClass(Document.class);
+    verify(template, new Times(2)).insert(documentCaptor.capture(), eq(PART_B_COLLECTION_NAME));
+
+    List<Document> documents = documentCaptor.getAllValues();
+    assertThat("Unexpected document save count.", documents.size(), is(2));
+    assertThat("Unexpected document ID.", documents.get(0).get(ID_FIELD), is(ID_UUID_1));
+    assertThat("Unexpected document ID.", documents.get(1).get(ID_FIELD), is(ID_UUID_2));
+  }
+
+  @Test
+  void shouldDeleteOriginalFormRPartAsFromDatabase() {
+    Document document1 = new Document();
+    document1.put(ID_FIELD, ID_STRING_1);
+
+    Document document2 = new Document();
+    document2.put(ID_FIELD, ID_STRING_2);
+
+    when(template.findAll(eq(Document.class), eq(PART_A_COLLECTION_NAME))).thenReturn(
+        List.of(document1, document2));
+
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+    when(template.remove(queryCaptor.capture(), any(String.class))).thenReturn(
+        DeleteResult.acknowledged(1));
+
+    migration.migrateCollections();
+
+    List<Query> queries = queryCaptor.getAllValues();
+    assertThat("Unexpected query count.", queries.size(), is(2));
+
+    Document queryObject = queries.get(0).getQueryObject();
+    String id = queryObject.getString("_id");
+    assertThat("Unexpected ID requirement.", id, is(ID_STRING_1));
+
+    queryObject = queries.get(1).getQueryObject();
+    id = queryObject.getString("_id");
+    assertThat("Unexpected ID requirement.", id, is(ID_STRING_2));
+  }
+
+  @Test
+  void shouldDeleteOriginalFormRPartBsFromDatabase() {
+    Document document1 = new Document();
+    document1.put(ID_FIELD, ID_STRING_1);
+
+    Document document2 = new Document();
+    document2.put(ID_FIELD, ID_STRING_2);
+
+    when(template.findAll(eq(Document.class), eq(PART_B_COLLECTION_NAME))).thenReturn(
+        List.of(document1, document2));
+
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+    when(template.remove(queryCaptor.capture(), any(String.class))).thenReturn(
+        DeleteResult.acknowledged(1));
+
+    migration.migrateCollections();
+
+    List<Query> queries = queryCaptor.getAllValues();
+    assertThat("Unexpected query count.", queries.size(), is(2));
+
+    Document queryObject = queries.get(0).getQueryObject();
+    String id = queryObject.getString("_id");
+    assertThat("Unexpected ID requirement.", id, is(ID_STRING_1));
+
+    queryObject = queries.get(1).getQueryObject();
+    id = queryObject.getString("_id");
+    assertThat("Unexpected ID requirement.", id, is(ID_STRING_2));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 2})
+  void shouldNotFailMigrationWhenDeleteFromDatabaseFails(int deletedCount) {
+    Document document1 = new Document();
+    document1.put(ID_FIELD, ID_STRING_1);
+
+    Document document2 = new Document();
+    document2.put(ID_FIELD, ID_STRING_2);
+
+    when(template.findAll(eq(Document.class), any())).thenReturn(List.of(document1),
+        List.of(document2));
+    when(template.remove(any(), any(String.class))).thenReturn(
+        DeleteResult.acknowledged(deletedCount));
+
+    assertDoesNotThrow(() -> migration.migrateCollections());
+    verify(template, new Times(2)).remove(any(), any(String.class));
+  }
+
+  @Test
+  void shouldNotAttemptRollback() {
+    migration.rollback();
+    verifyNoInteractions(template);
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/model/AbstractFormMongoEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/model/AbstractFormMongoEventListenerTest.java
@@ -24,7 +24,6 @@ package uk.nhs.hee.tis.trainee.forms.model;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,20 +46,20 @@ class AbstractFormMongoEventListenerTest {
     BeforeConvertEvent<AbstractForm> event = new BeforeConvertEvent<>(form, "StubForm");
     listener.onBeforeConvert(event);
 
-    String id = form.getId();
+    UUID id = form.getId();
     assertThat("Unexpected form ID.", id, notNullValue());
-    assertDoesNotThrow(() -> UUID.fromString(id), "Unexpected ID format.");
   }
 
   @Test
   void shouldNotModifyIdBeforeConvertWhenIdPopulated() {
     StubForm form = new StubForm();
-    form.setId("test_id");
+    UUID uuid = UUID.randomUUID();
+    form.setId(uuid);
 
     BeforeConvertEvent<AbstractForm> event = new BeforeConvertEvent<>(form, "StubForm");
     listener.onBeforeConvert(event);
 
-    assertThat("Unexpected form ID.", form.getId(), is("test_id"));
+    assertThat("Unexpected form ID.", form.getId(), is(uuid));
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartARepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartARepositoryImplTest.java
@@ -1,6 +1,5 @@
 package uk.nhs.hee.tis.trainee.forms.repository;
 
-import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -33,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,7 +54,8 @@ import uk.nhs.hee.tis.trainee.forms.service.exception.ApplicationException;
 class S3FormRPartARepositoryImplTest {
 
   private static final String KEY = "object.name";
-  private static final String DEFAULT_ID = "DEFAULT_ID";
+  private static final UUID DEFAULT_ID = UUID.randomUUID();
+  private static final String DEFAULT_ID_STRING = DEFAULT_ID.toString();
   private static final String DEFAULT_TRAINEE_TIS_ID = "1";
   private static final String DEFAULT_FORENAME = "DEFAULT_FORENAME";
   private static final String DEFAULT_SURNAME = "DEFAULT_SURNAME";
@@ -83,7 +84,7 @@ class S3FormRPartARepositoryImplTest {
   private static final LocalDateTime DEFAULT_SUBMISSION_DATE = LocalDateTime.now();
   private static final String DEFAULT_SUBMISSION_DATE_STRING = DEFAULT_SUBMISSION_DATE.format(
       DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-  private static final String DEFAULT_FORM_ID = "my-first-cloud-object-id";
+  private static final String DEFAULT_FORM_ID = UUID.randomUUID().toString();
   private static final Map<String, String> DEFAULT_UNSUBMITTED_METADATA = Map
       .of("id", DEFAULT_FORM_ID, "formtype", "inform", "lifecyclestate",
           LifecycleState.UNSUBMITTED.name(), "submissiondate",
@@ -148,9 +149,10 @@ class S3FormRPartARepositoryImplTest {
         is(String.join("/", DEFAULT_TRAINEE_TIS_ID, "forms", FormRPartAService.FORM_TYPE,
             entity.getId() + ".json")));
     Map<String, String> expectedMetadata = Map
-        .of("id", entity.getId(), "name", entity.getId() + ".json", "type", "json", "formtype",
-            FormRPartAService.FORM_TYPE, "lifecyclestate", LifecycleState.SUBMITTED.name(),
-            "submissiondate", DEFAULT_SUBMISSION_DATE_STRING, "traineeid", DEFAULT_TRAINEE_TIS_ID);
+        .of("id", entity.getId().toString(), "name", entity.getId() + ".json", "type", "json",
+            "formtype", FormRPartAService.FORM_TYPE, "lifecyclestate",
+            LifecycleState.SUBMITTED.name(), "submissiondate", DEFAULT_SUBMISSION_DATE_STRING,
+            "traineeid", DEFAULT_TRAINEE_TIS_ID);
 
     assertThat("Unexpected metadata.", actualRequest.getMetadata().getUserMetadata().entrySet(),
         containsInAnyOrder(expectedMetadata.entrySet().toArray(new Entry[0])));
@@ -189,7 +191,7 @@ class S3FormRPartARepositoryImplTest {
     assertThat("Unexpected numbers of forms.", entities.size(), is(1));
 
     FormRPartA entity = entities.get(0);
-    assertThat("Unexpected form ID.", entity.getId(), is(DEFAULT_FORM_ID));
+    assertThat("Unexpected form ID.", entity.getId(), is(UUID.fromString(DEFAULT_FORM_ID)));
     assertThat("Unexpected trainee ID.", entity.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected submitted date.", entity.getSubmissionDate(),
         is(DEFAULT_SUBMISSION_DATE));
@@ -206,7 +208,8 @@ class S3FormRPartARepositoryImplTest {
         DEFAULT_TRAINEE_TIS_ID + "/forms/formr-a/" + DEFAULT_ID + ".json"))
         .thenReturn(s3Object);
 
-    Optional<FormRPartA> actual = repo.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID);
+    Optional<FormRPartA> actual = repo.findByIdAndTraineeTisId(DEFAULT_ID_STRING,
+        DEFAULT_TRAINEE_TIS_ID);
 
     assertThat("Unexpected empty optional.", actual.isPresent());
     FormRPartA entity = actual.get();
@@ -224,19 +227,19 @@ class S3FormRPartARepositoryImplTest {
   void findByIdAndTraineeIdShouldReturnEmpty() {
     AmazonServiceException awsException = new AmazonServiceException("Expected Exception");
     awsException.setStatusCode(404);
-    when(s3Mock.getObject(bucketName, "1/forms/formr-a/DEFAULT_ID.json"))
+    when(s3Mock.getObject(bucketName, String.format("1/forms/formr-a/%s.json", DEFAULT_ID)))
         .thenThrow(awsException);
     assertThat("Unexpected Optional content.",
-        repo.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID).isEmpty());
+        repo.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID).isEmpty());
   }
 
   @ParameterizedTest
   @ValueSource(classes = {AmazonServiceException.class, SdkClientException.class})
   void findByIdAndTraineeIdShouldThrowException(Class clazz) throws Exception {
-    when(s3Mock.getObject(bucketName, "1/forms/formr-a/DEFAULT_ID.json"))
+    when(s3Mock.getObject(bucketName, String.format("1/forms/formr-a/%s.json", DEFAULT_ID)))
         .thenThrow((Exception) clazz.getDeclaredConstructor(String.class).newInstance("Expected"));
     assertThrows(ApplicationException.class,
-        () -> repo.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID));
+        () -> repo.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID));
   }
 
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceImplTest.java
@@ -29,12 +29,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,7 +55,8 @@ import uk.nhs.hee.tis.trainee.forms.service.impl.FormRPartAServiceImpl;
 @ExtendWith(MockitoExtension.class)
 class FormRPartAServiceImplTest {
 
-  private static final String DEFAULT_ID = "DEFAULT_ID";
+  private static final UUID DEFAULT_ID = UUID.randomUUID();
+  private static final String DEFAULT_ID_STRING = DEFAULT_ID.toString();
   private static final String DEFAULT_TRAINEE_TIS_ID = "1";
   private static final String DEFAULT_FORENAME = "DEFAULT_FORENAME";
   private static final String DEFAULT_SURNAME = "DEFAULT_SURNAME";
@@ -116,7 +117,7 @@ class FormRPartAServiceImplTest {
 
     FormRPartADto savedDto = service.save(dto);
 
-    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", savedDto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected forename.", savedDto.getForename(), is(DEFAULT_FORENAME));
     assertThat("Unexpected surname.", savedDto.getSurname(), is(DEFAULT_SURNAME));
@@ -148,7 +149,7 @@ class FormRPartAServiceImplTest {
 
     FormRPartADto savedDto = service.save(dto);
 
-    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", savedDto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected forename.", savedDto.getForename(), is(DEFAULT_FORENAME));
     assertThat("Unexpected surname.", savedDto.getSurname(), is(DEFAULT_SURNAME));
@@ -181,7 +182,7 @@ class FormRPartAServiceImplTest {
 
     FormRPartADto savedDto = service.save(dto);
 
-    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", savedDto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected forename.", savedDto.getForename(), is(DEFAULT_FORENAME));
     assertThat("Unexpected surname.", savedDto.getSurname(), is(DEFAULT_SURNAME));
@@ -214,7 +215,7 @@ class FormRPartAServiceImplTest {
 
     FormRPartADto savedDto = service.save(dto);
 
-    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", savedDto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected forename.", savedDto.getForename(), is(DEFAULT_FORENAME));
     assertThat("Unexpected surname.", savedDto.getSurname(), is(DEFAULT_SURNAME));
@@ -256,7 +257,7 @@ class FormRPartAServiceImplTest {
     assertThat("Unexpected numbers of forms.", dtos.size(), is(entities.size()));
 
     FormRPartSimpleDto dto = dtos.get(0);
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
   }
 
@@ -281,11 +282,11 @@ class FormRPartAServiceImplTest {
 
     FormRPartSimpleDto dto = dtos.stream().filter(
         f -> f.getLifecycleState() == LifecycleState.DRAFT).findAny().orElseThrow();
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     dto = dtos.stream().filter(
         f -> f.getLifecycleState() == LifecycleState.UNSUBMITTED).findAny().orElseThrow();
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected submitted date.", dto.getSubmissionDate(), is(DEFAULT_SUBMISSION_DATE));
     assertThat("Unexpected lifecycle state.", dto.getLifecycleState(),
@@ -295,12 +296,12 @@ class FormRPartAServiceImplTest {
   @Test
   void shouldGetFormRPartBFromCloudStorageById() {
     entity.setLifecycleState(LifecycleState.SUBMITTED);
-    when(cloudObjectRepository.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+    when(cloudObjectRepository.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID))
         .thenReturn(Optional.of(entity));
 
-    FormRPartADto dto = service.getFormRPartAById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID);
+    FormRPartADto dto = service.getFormRPartAById(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID);
 
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected forename.", dto.getForename(), is(DEFAULT_FORENAME));
     assertThat("Unexpected surname.", dto.getSurname(), is(DEFAULT_SURNAME));
@@ -310,12 +311,12 @@ class FormRPartAServiceImplTest {
 
   @Test
   void shouldGetDraftFormRPartAById() {
-    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID))
         .thenReturn(Optional.of(entity));
 
-    FormRPartADto dto = service.getFormRPartAById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID);
+    FormRPartADto dto = service.getFormRPartAById(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID);
 
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected forename.", dto.getForename(), is(DEFAULT_FORENAME));
     assertThat("Unexpected surname.", dto.getSurname(), is(DEFAULT_SURNAME));

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceImplTest.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,7 +67,8 @@ import uk.nhs.hee.tis.trainee.forms.service.impl.FormRPartBServiceImpl;
 @ExtendWith(MockitoExtension.class)
 class FormRPartBServiceImplTest {
 
-  private static final String DEFAULT_ID = "DEFAULT_ID";
+  private static final UUID DEFAULT_ID = UUID.randomUUID();
+  private static final String DEFAULT_ID_STRING = DEFAULT_ID.toString();
   private static final String DEFAULT_TRAINEE_TIS_ID = "1";
   private static final String DEFAULT_FORENAME = "DEFAULT_FORENAME";
   private static final String DEFAULT_SURNAME = "DEFAULT_SURNAME";
@@ -97,7 +99,7 @@ class FormRPartBServiceImplTest {
   private static final String DEFAULT_CURRENT_DECLARATION_SUMMARY =
       "DEFAULT_CURRENT_DECLARATION_SUMMARY";
   private static final LocalDateTime DEFAULT_SUBMISSION_DATE = LocalDateTime.now();
-  private static final String DEFAULT_FORM_ID = "my-first-cloud-object-id";
+  private static final UUID DEFAULT_FORM_ID = UUID.randomUUID();
 
   private static final Boolean DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS = true;
   private static final Boolean DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS = true;
@@ -264,7 +266,7 @@ class FormRPartBServiceImplTest {
 
     FormRPartBDto savedDto = service.save(dto);
 
-    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", savedDto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected forename.", savedDto.getForename(), is(DEFAULT_FORENAME));
     assertThat("Unexpected surname.", savedDto.getSurname(), is(DEFAULT_SURNAME));
@@ -315,7 +317,7 @@ class FormRPartBServiceImplTest {
 
     FormRPartBDto savedDto = service.save(dto);
 
-    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", savedDto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected forename.", savedDto.getForename(), is(DEFAULT_FORENAME));
     assertThat("Unexpected surname.", savedDto.getSurname(), is(DEFAULT_SURNAME));
@@ -365,7 +367,7 @@ class FormRPartBServiceImplTest {
 
     FormRPartBDto savedDto = service.save(dto);
 
-    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", savedDto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected forename.", savedDto.getForename(), is(DEFAULT_FORENAME));
     assertThat("Unexpected surname.", savedDto.getSurname(), is(DEFAULT_SURNAME));
@@ -415,7 +417,7 @@ class FormRPartBServiceImplTest {
     });
 
     FormRPartBDto savedDto = service.save(dto);
-    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", savedDto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", savedDto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected forename.", savedDto.getForename(), is(DEFAULT_FORENAME));
     assertThat("Unexpected surname.", savedDto.getSurname(), is(DEFAULT_SURNAME));
@@ -473,7 +475,7 @@ class FormRPartBServiceImplTest {
 
     assertThat("Unexpected numbers of forms.", dtos.size(), is(entities.size()));
     FormRPartSimpleDto dto = dtos.get(0);
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
   }
 
@@ -498,11 +500,11 @@ class FormRPartBServiceImplTest {
 
     FormRPartSimpleDto dto = dtos.stream().filter(
         f -> f.getLifecycleState() == LifecycleState.DRAFT).findAny().orElseThrow();
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     dto = dtos.stream().filter(
         f -> f.getLifecycleState() == LifecycleState.UNSUBMITTED).findAny().orElseThrow();
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_FORM_ID));
+    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_FORM_ID.toString()));
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected submitted date.", dto.getSubmissionDate(), is(DEFAULT_SUBMISSION_DATE));
     assertThat("Unexpected lifecycle state.", dto.getLifecycleState(),
@@ -512,13 +514,13 @@ class FormRPartBServiceImplTest {
   @Test
   void shouldGetFormRPartBFromCloudStorageById() {
     entity.setLifecycleState(LifecycleState.SUBMITTED);
-    when(s3FormRPartBRepository.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+    when(s3FormRPartBRepository.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID))
         .thenReturn(Optional.of(entity));
 
-    FormRPartBDto dto = service.getFormRPartBById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID);
+    FormRPartBDto dto = service.getFormRPartBById(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID);
 
     verifyNoInteractions(repositoryMock);
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected forename.", dto.getForename(), is(DEFAULT_FORENAME));
     assertThat("Unexpected surname.", dto.getSurname(), is(DEFAULT_SURNAME));
@@ -551,12 +553,12 @@ class FormRPartBServiceImplTest {
 
   @Test
   void shouldGetDraftFormRPartBById() {
-    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID))
         .thenReturn(Optional.of(entity));
 
-    FormRPartBDto dto = service.getFormRPartBById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID);
+    FormRPartBDto dto = service.getFormRPartBById(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID);
 
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected forename.", dto.getForename(), is(DEFAULT_FORENAME));
     assertThat("Unexpected surname.", dto.getSurname(), is(DEFAULT_SURNAME));

--- a/src/test/resources/forms/testFormRPartA.json
+++ b/src/test/resources/forms/testFormRPartA.json
@@ -1,5 +1,5 @@
 {
-  "id": "5f64d2fe542db447563070b2",
+  "id": "4e41356d-77a6-4c23-b58b-c340c2ba4bf9",
   "traineeTisId": "47165",
   "forename": "Jim",
   "surname": "Williams",

--- a/src/test/resources/forms/testFormRPartB.json
+++ b/src/test/resources/forms/testFormRPartB.json
@@ -1,5 +1,5 @@
 {
-  "id": "5f75c3ad82bdd02299202349",
+  "id": "2552fad7-72ad-4331-aaae-872414db5d27",
   "traineeTisId": "47165",
   "forename": "John",
   "surname": "Roper",


### PR DESCRIPTION
Migrate the AbstractForm's `id` field from String to UUID based. Create a Mongock migration to find all String based IDs and perform the conversion to UUIDs in the database.

Modify the entity to use UUID and update the required classes and tests.

TIS21-4006
TIS21-4027