### PR TITLE
feat: partial delete form

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -27,6 +27,10 @@
         {
           "name": "APPLICATION_FILESTORE_BUCKET",
           "valueFrom": "tis-trainee-forms-bucket-${environment}"
+        },
+        {
+          "name": "DELETE_EVENT_QUEUE",
+          "valueFrom": "/tis/trainee/${environment}/queue-url/form-delete-event"
         }
       ],
       "logConfiguration": {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.6.1"
+version = "0.7.0"
 
 configurations {
   compileOnly {

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 
   // Sentry reporting
   implementation "io.sentry:sentry-spring-boot-starter:6.11.0"
+
+  // SQS
+  implementation "io.awspring.cloud:spring-cloud-starter-aws-messaging:2.3.2"
 }
 
 checkstyle {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/DeleteEventDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/DeleteEventDto.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2023 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,12 +19,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.trainee.forms.dto.enumeration;
+package uk.nhs.hee.tis.trainee.forms.dto;
 
-public enum LifecycleState {
-  DRAFT,
-  SUBMITTED,
-  UNSUBMITTED,
-  DELETED
+import lombok.Data;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.DeleteType;
+
+/**
+ * A DTO for delete event notification from queue.
+ */
+@Data
+public class DeleteEventDto {
+
+  private String bucket;
+  private String key;
+  private DeleteType deleteType;
+  private String[] fixedFields;
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/enumeration/DeleteType.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/enumeration/DeleteType.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2023 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,10 +21,11 @@
 
 package uk.nhs.hee.tis.trainee.forms.dto.enumeration;
 
-public enum LifecycleState {
-  DRAFT,
-  SUBMITTED,
-  UNSUBMITTED,
-  DELETED
+/**
+ * An enumeration for object delete type.
+ */
+public enum DeleteType {
+
+  HARD, PARTIAL, SOFT;
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/event/FormDeleteEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/event/FormDeleteEventListener.java
@@ -46,7 +46,7 @@ public class FormDeleteEventListener {
   }
 
   /**
-   * Listener for receiving form delete event from SQS queue
+   * Listener for receiving form delete event from SQS queue.
    */
   @SqsListener("${application.aws.sqs.delete-event}")
   public void getFormDeleteEvent(String message) throws IOException {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/event/FormDeleteEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/event/FormDeleteEventListener.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.messaging.listener.annotation.SqsListener;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.forms.dto.DeleteEventDto;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.DeleteType;
+import uk.nhs.hee.tis.trainee.forms.service.FormRPartAService;
+import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
+import uk.nhs.hee.tis.trainee.forms.service.exception.ApplicationException;
+
+@Slf4j
+@Component
+public class FormDeleteEventListener {
+
+  private final FormRPartAService formRPartAService;
+  private final FormRPartBService formRPartBService;
+
+  FormDeleteEventListener(FormRPartAService formRPartAService,
+      FormRPartBService formRPartBService) {
+    this.formRPartAService = formRPartAService;
+    this.formRPartBService = formRPartBService;
+  }
+
+  /**
+   * Listener for receiving form delete event from SQS queue
+   */
+  @SqsListener("${application.aws.sqs.delete-event}")
+  public void getFormDeleteEvent(String message) throws IOException {
+    try {
+      log.info("Form delete event received: {}", message);
+      ObjectMapper objectMapper = new ObjectMapper();
+      DeleteEventDto deleteEvent = objectMapper.readValue(message, DeleteEventDto.class);
+
+
+      if (deleteEvent.getDeleteType() == DeleteType.PARTIAL) {
+        final var eventDetails =
+            deleteEvent.getKey().split("/");
+        final var formId = eventDetails[3].split(".json")[0];
+        final var traineeTisId = eventDetails[0];
+        final var fixFields = deleteEvent.getFixedFields();
+
+        if (eventDetails[2].equals("formr-a")) {
+          formRPartAService.partialDeleteFormRPartAById(formId, traineeTisId, fixFields);
+          log.info("Partial delete successfully for trainee {} with form Id {} (FormRPartA)",
+              traineeTisId, formId);
+        } else if (eventDetails[2].equals("formr-b")) {
+          log.info("trainee: {}, Form B", eventDetails[0]);
+          formRPartBService.partialDeleteFormRPartBById(formId, traineeTisId, fixFields);
+          log.info("Partial delete successfully for trainee {} with form Id {} (FormRPartB)",
+              traineeTisId, formId);
+        }
+      } else {
+        log.error("Unexpected deleteType of form: {}" + deleteEvent.getDeleteType());
+        throw new ApplicationException("Unexpected deleteType of form: "
+            + deleteEvent.getDeleteType());
+      }
+    } catch (Exception e) {
+      log.error("Fail to delete form: {}", e);
+      throw new ApplicationException("Fail to delete form:", e);
+    }
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/event/FormDeleteEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/event/FormDeleteEventListener.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT)
+ * The MIT License (MIT).
  *
  * Copyright 2023 Crown Copyright (Health Education England)
  *
@@ -32,6 +32,9 @@ import uk.nhs.hee.tis.trainee.forms.service.FormRPartAService;
 import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
 import uk.nhs.hee.tis.trainee.forms.service.exception.ApplicationException;
 
+/**
+ * Listener for receiving form delete event from SQS queue.
+ */
 @Slf4j
 @Component
 public class FormDeleteEventListener {
@@ -46,10 +49,10 @@ public class FormDeleteEventListener {
   }
 
   /**
-   * Listener for receiving form delete event from SQS queue.
+   * Listener for handling form delete form event.
    */
   @SqsListener("${application.aws.sqs.delete-event}")
-  public void getFormDeleteEvent(String message) throws IOException {
+  public void handleFormDeleteEvent(String message) throws IOException {
     try {
       log.info("Form delete event received: {}", message);
       ObjectMapper objectMapper = new ObjectMapper();
@@ -68,7 +71,6 @@ public class FormDeleteEventListener {
           log.info("Partial delete successfully for trainee {} with form Id {} (FormRPartA)",
               traineeTisId, formId);
         } else if (eventDetails[2].equals("formr-b")) {
-          log.info("trainee: {}, Form B", eventDetails[0]);
           formRPartBService.partialDeleteFormRPartBById(formId, traineeTisId, fixFields);
           log.info("Partial delete successfully for trainee {} with form Id {} (FormRPartB)",
               traineeTisId, formId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/AddPartialDeleteMetadataToS3.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/AddPartialDeleteMetadataToS3.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.migration;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.DeleteType;
+
+/**
+ * Add partial delete related metadata to existing forms on S3.
+ */
+@Slf4j
+@ChangeUnit(id = "AddPartialDeleteMetadataToS3", order = "7")
+public class AddPartialDeleteMetadataToS3 {
+
+  private final AmazonS3 amazonS3;
+  private final String bucketName;
+
+  private static final String FIXED_FIELDS =
+      "id,traineeTisId,lifecycleState,submissionDate,lastModifiedDate";
+
+  /**
+   * Add partial delete related metadata to existing forms on S3.
+   */
+  public AddPartialDeleteMetadataToS3(AmazonS3 amazonS3, Environment env) {
+    this.amazonS3 = amazonS3;
+    this.bucketName = env.getProperty("application.file-store.bucket");
+  }
+
+  /**
+   * Find all object on S3 and add metadata.
+   */
+  @Execution
+  public void migrate() {
+    log.info("Starting migration to add partial delete related metadata to existing forms on S3.");
+
+    try {
+      List<S3ObjectSummary> keyList = new ArrayList<>();
+      var objects = amazonS3.listObjects(bucketName);
+      keyList.addAll(objects.getObjectSummaries());
+
+      while (objects.isTruncated()) {
+        objects = amazonS3.listNextBatchOfObjects(objects);
+        keyList.addAll(objects.getObjectSummaries());
+      }
+      log.info("Updating {} objects in the bucket {}", keyList.size(), bucketName);
+
+      for (var obj : keyList) {
+        final var object = amazonS3.getObject(bucketName, obj.getKey());
+
+        var metadata = object.getObjectMetadata();
+        metadata.addUserMetadata("deletetype", DeleteType.PARTIAL.name());
+        metadata.addUserMetadata("fixedfields", FIXED_FIELDS);
+
+        final var request = new PutObjectRequest(
+            bucketName, obj.getKey(), object.getObjectContent(), metadata);
+        amazonS3.putObject(request);
+      }
+
+      log.info("Finish migration");
+    }
+    catch (Exception e) {
+      log.error("Fail to add metadata to existing forms in bucket " + bucketName + ": ", e);
+    }
+  }
+
+  /**
+   * Do not attempt rollback, any successfully added metadata should stay.
+   */
+  @RollbackExecution
+  public void rollback() {
+    log.warn("Rollback requested but not available for 'AddPartialDeleteMetadataToS3' migration.");
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
@@ -40,6 +40,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.DeleteType;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.AbstractForm;
 import uk.nhs.hee.tis.trainee.forms.service.exception.ApplicationException;
@@ -54,6 +55,8 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
 
   private LocalDateTime localDateTime;
   private static final String SUBMISSION_DATE = "submissiondate";
+  private static final String FIXED_FIELDS =
+      "id,traineeTisId,lifecycleState,submissionDate,lastModifiedDate";
 
   protected String bucketName;
 
@@ -86,6 +89,8 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
       metadata.addUserMetadata(SUBMISSION_DATE,
           form.getSubmissionDate().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
       metadata.addUserMetadata("traineeid", form.getTraineeTisId());
+      metadata.addUserMetadata("deletetype", DeleteType.PARTIAL.name());
+      metadata.addUserMetadata("fixedfields", FIXED_FIELDS);
 
       PutObjectRequest request = new PutObjectRequest(bucketName, key,
           new ByteArrayInputStream(objectMapper.writeValueAsBytes(form)), metadata);

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
@@ -62,5 +62,6 @@ public interface FormRPartAService {
    * @param traineeTisId The ID of the trainee to partial delete for.
    * @return The updated form.
    */
-  FormRPartADto partialDeleteFormRPartAById(String id, String traineeTisId, Set<String> fixedFields);
+  FormRPartADto partialDeleteFormRPartAById(
+      String id, String traineeTisId, Set<String> fixedFields);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.forms.service;
 
 import java.util.List;
+import java.util.Set;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartADto;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartSimpleDto;
 
@@ -61,5 +62,5 @@ public interface FormRPartAService {
    * @param traineeTisId The ID of the trainee to partial delete for.
    * @return The updated form.
    */
-  FormRPartADto partialDeleteFormRPartAById(String id, String traineeTisId, String[] fixedFields);
+  FormRPartADto partialDeleteFormRPartAById(String id, String traineeTisId, Set<String> fixedFields);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
@@ -53,4 +53,13 @@ public interface FormRPartAService {
    * @return The retrieved form.
    */
   FormRPartADto getFormRPartAById(String id, String traineeTisId);
+
+  /**
+   * Partial delete a form by id.
+   *
+   * @param id           The ID of the form.
+   * @param traineeTisId The ID of the trainee to partial delete for.
+   * @return The updated form.
+   */
+  FormRPartADto partialDeleteFormRPartAById(String id, String traineeTisId, String[] fixedFields);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
@@ -52,4 +52,13 @@ public interface FormRPartBService {
    * @return The retrieved form.
    */
   FormRPartBDto getFormRPartBById(String id, String traineeTisId);
+
+  /**
+   * Partial delete a form by id.
+   *
+   * @param id           The ID of the form.
+   * @param traineeTisId The ID of the trainee to partial delete for.
+   * @return The updated form.
+   */
+  FormRPartBDto partialDeleteFormRPartBById(String id, String traineeTisId, String[] fixedFields);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
@@ -61,5 +61,6 @@ public interface FormRPartBService {
    * @param traineeTisId The ID of the trainee to partial delete for.
    * @return The updated form.
    */
-  FormRPartBDto partialDeleteFormRPartBById(String id, String traineeTisId, Set<String> fixedFields);
+  FormRPartBDto partialDeleteFormRPartBById(
+      String id, String traineeTisId, Set<String> fixedFields);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
@@ -21,6 +21,7 @@
 package uk.nhs.hee.tis.trainee.forms.service;
 
 import java.util.List;
+import java.util.Set;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartBDto;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartSimpleDto;
 
@@ -60,5 +61,5 @@ public interface FormRPartBService {
    * @param traineeTisId The ID of the trainee to partial delete for.
    * @return The updated form.
    */
-  FormRPartBDto partialDeleteFormRPartBById(String id, String traineeTisId, String[] fixedFields);
+  FormRPartBDto partialDeleteFormRPartBById(String id, String traineeTisId, Set<String> fixedFields);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartAServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartAServiceImpl.java
@@ -149,10 +149,12 @@ public class FormRPartAServiceImpl implements FormRPartAService {
         formRPartA = objectMapper.convertValue(jsonForm, FormRPartA.class);
 
         repository.save(formRPartA);
+        log.info("Partial delete successfully for trainee {} with form Id {} (FormRPartA)",
+            traineeTisId, id);
+      } else {
+        log.error("FormR PartB with ID '{}' not found", id);
       }
 
-      log.info("Partial delete successfully for trainee {} with form Id {} (FormRPartA)",
-          traineeTisId, id);
       return mapper.toDto(formRPartA);
 
     } catch (Exception e) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartBServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartBServiceImpl.java
@@ -20,7 +20,12 @@
 
 package uk.nhs.hee.tis.trainee.forms.service.impl;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,11 +39,14 @@ import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
 import uk.nhs.hee.tis.trainee.forms.repository.FormRPartBRepository;
 import uk.nhs.hee.tis.trainee.forms.repository.S3FormRPartBRepositoryImpl;
 import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
+import uk.nhs.hee.tis.trainee.forms.service.exception.ApplicationException;
 
 @Slf4j
 @Service
 @Transactional
 public class FormRPartBServiceImpl implements FormRPartBService {
+
+  private static final String ATTRIBUTE_NAME_LIFE_CYCLE_STATE = "lifecycleState";
 
   private final FormRPartBMapper formRPartBMapper;
 
@@ -51,7 +59,7 @@ public class FormRPartBServiceImpl implements FormRPartBService {
 
 
   /**
-   * Constructor for a FormR PartA service.
+   * Constructor for a FormR PartB service.
    *
    * @param formRPartBRepository spring data repository
    * @param s3ObjectRepository   S3 Repository for forms
@@ -104,5 +112,43 @@ public class FormRPartBServiceImpl implements FormRPartBService {
         .or(() -> formRPartBRepository.findByIdAndTraineeTisId(UUID.fromString(id), traineeTisId))
         .orElse(null);
     return formRPartBMapper.toDto(formRPartB);
+  }
+
+  /**
+   * Partial delete a form by id.
+   */
+  @Override
+  public FormRPartBDto partialDeleteFormRPartBById(
+      String id, String traineeTisId, String[] fixedFields) {
+    log.info("Request to partial delete FormRPartB by id : {}", id);
+
+    try {
+      FormRPartB formRPartB = formRPartBRepository
+          .findByIdAndTraineeTisId(UUID.fromString(id), traineeTisId)
+          .orElse(null);
+
+      if (formRPartB != null) {
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        JsonNode jsonForm = objectMapper.valueToTree(formRPartB);
+
+        for (Iterator<String> fieldIterator = jsonForm.fieldNames(); fieldIterator.hasNext(); ) {
+          String fieldName = fieldIterator.next();
+
+          if (!Set.of(fixedFields).contains(fieldName)) {
+            fieldIterator.remove();
+          }
+        }
+        ((ObjectNode) jsonForm).put(ATTRIBUTE_NAME_LIFE_CYCLE_STATE,
+            LifecycleState.DELETED.name());
+        formRPartB = objectMapper.convertValue(jsonForm, FormRPartB.class);
+
+        formRPartBRepository.save(formRPartB);
+      }
+      return formRPartBMapper.toDto(formRPartB);
+
+    } catch (Exception e) {
+      log.error("Fail to partial delete FormR PartB: {}", e);
+      throw new ApplicationException("Fail to partial delete FormR PartB:", e);
+    }
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartBServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/impl/FormRPartBServiceImpl.java
@@ -147,10 +147,12 @@ public class FormRPartBServiceImpl implements FormRPartBService {
         formRPartB = objectMapper.convertValue(jsonForm, FormRPartB.class);
 
         formRPartBRepository.save(formRPartB);
+        log.info("Partial delete successfully for trainee {} with form Id {} (FormRPartB)",
+            traineeTisId, id);
+      } else {
+        log.error("FormR PartB with ID '{}' not found", id);
       }
 
-      log.info("Partial delete successfully for trainee {} with form Id {} (FormRPartB)",
-          traineeTisId, id);
       return formRPartBMapper.toDto(formRPartB);
 
     } catch (Exception e) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,9 @@ application:
   file-store:
     always-store: ${APPLICATION_FILESTORE_ALWAYSSTORE:false}
     bucket: ${APPLICATION_FILESTORE_BUCKET:}
+  aws:
+    sqs:
+      delete-event: ${DELETE_EVENT_QUEUE:}
 
 features:
   formr-partb:

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/event/FormDeleteEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/event/FormDeleteEventListenerTest.java
@@ -56,16 +56,16 @@ class FormDeleteEventListenerTest {
 
   @Test
   void shouldPartialDeleteFormA() throws IOException {
-    final String MESSAGE = """
-      {
+    final String message = """
+        {
         "deleteType": "PARTIAL",
         "bucket": "document-upload",
         "key": "1/forms/formr-a/1000a.json",
         "fixedFields": ["id", "traineeTisId"]
-      }
-    """;
+        }
+        """;
 
-    listener.handleFormDeleteEvent(MESSAGE);
+    listener.handleFormDeleteEvent(message);
 
     verify(formRPartAService).partialDeleteFormRPartAById(
         "1000a", "1", Set.of("id", "traineeTisId"));
@@ -73,16 +73,16 @@ class FormDeleteEventListenerTest {
 
   @Test
   void shouldPartialDeleteFormB() throws IOException {
-    final String MESSAGE = """
-      {
+    final String message = """
+        {
         "deleteType": "PARTIAL",
         "bucket": "document-upload",
         "key": "1/forms/formr-b/2000b.json",
         "fixedFields": ["id", "traineeTisId"]
-      }
-    """;
+        }
+        """;
 
-    listener.handleFormDeleteEvent(MESSAGE);
+    listener.handleFormDeleteEvent(message);
 
     verify(formRPartBService).partialDeleteFormRPartBById(
         "2000b", "1", Set.of("id", "traineeTisId"));
@@ -90,16 +90,16 @@ class FormDeleteEventListenerTest {
 
   @Test
   void shouldNotPartialDeleteFormsIfFormNameNotMatch() throws IOException {
-    final String MESSAGE = """
-      {
+    final String message = """
+        {
         "deleteType": "PARTIAL",
         "bucket": "document-upload",
         "key": "1/forms/formr-c/1000a.json",
         "fixedFields": ["id", "traineeTisId"]
-      }
-    """;
+        }
+        """;
 
-    listener.handleFormDeleteEvent(MESSAGE);
+    listener.handleFormDeleteEvent(message);
 
     verifyNoInteractions(formRPartAService);
     verifyNoInteractions(formRPartBService);
@@ -107,33 +107,33 @@ class FormDeleteEventListenerTest {
 
   @Test
   void shouldThrowExceptionWhenDeleteTypeNotPartial() throws IOException {
-    final String MESSAGE = """
-      {
+    final String message = """
+        {
         "deleteType": "HARD",
         "bucket": "document-upload",
         "key": "1/forms/formr-a/1000a.json",
         "fixedFields": ["id", "traineeTisId"]
-      }
-    """;
+        }
+        """;
 
     verifyNoInteractions(formRPartAService);
     verifyNoInteractions(formRPartBService);
-    assertThrows(ApplicationException.class, () -> listener.handleFormDeleteEvent(MESSAGE));
+    assertThrows(ApplicationException.class, () -> listener.handleFormDeleteEvent(message));
   }
 
   @Test
   void shouldThrowExceptionWhenFailToPartialDeleteForm() throws IOException {
-    final String MESSAGE = """
-      {
+    final String message = """
+        {
         "deleteType": "HARD",
         "bucket": "document-upload",
         "key": "1/forms/formr-a/1000a.json",
         "fixedFields": ["id", "traineeTisId"]
-      }
-    """;
+        }
+        """;
 
     doThrow(ApplicationException.class)
         .when(formRPartAService).partialDeleteFormRPartAById(any(), any(), any());
-    assertThrows(ApplicationException.class, () -> listener.handleFormDeleteEvent(MESSAGE));
+    assertThrows(ApplicationException.class, () -> listener.handleFormDeleteEvent(message));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/event/FormDeleteEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/event/FormDeleteEventListenerTest.java
@@ -1,0 +1,116 @@
+/*
+ * The MIT License (MIT).
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.event;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.trainee.forms.service.FormRPartAService;
+import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
+import uk.nhs.hee.tis.trainee.forms.service.exception.ApplicationException;
+
+@ExtendWith(MockitoExtension.class)
+class FormDeleteEventListenerTest {
+
+  private FormDeleteEventListener listener;
+  private FormRPartAService formRPartAService;
+  private FormRPartBService formRPartBService;
+
+  @BeforeEach
+  void setUp() {
+    formRPartAService = mock(FormRPartAService.class);
+    formRPartBService = mock(FormRPartBService.class);
+    listener = new FormDeleteEventListener(formRPartAService, formRPartBService);
+  }
+
+  @Test
+  void shouldPartialDeleteFormA() throws IOException {
+    final String MESSAGE = "{\"deleteType\":\"PARTIAL\","
+        + "\"bucket\":\"document-upload\","
+        + "\"key\":\"1/forms/formr-a/1000a.json\","
+        + "\"fixedFields\":[\"id\",\"traineeTisId\"]}";
+
+    listener.handleFormDeleteEvent(MESSAGE);
+
+    verify(formRPartAService).partialDeleteFormRPartAById(
+        "1000a", "1", new String[]{"id", "traineeTisId"});
+  }
+
+  @Test
+  void shouldPartialDeleteFormB() throws IOException {
+    final String MESSAGE = "{\"deleteType\":\"PARTIAL\","
+        + "\"bucket\":\"document-upload\","
+        + "\"key\":\"1/forms/formr-b/2000b.json\","
+        + "\"fixedFields\":[\"id\",\"traineeTisId\"]}";
+
+    listener.handleFormDeleteEvent(MESSAGE);
+
+    verify(formRPartBService).partialDeleteFormRPartBById(
+        "2000b", "1", new String[]{"id", "traineeTisId"});
+  }
+
+  @Test
+  void shouldNotPartialDeleteFormsIfFormNameNotMatch() throws IOException {
+    final String MESSAGE = "{\"deleteType\":\"PARTIAL\","
+        + "\"bucket\":\"document-upload\","
+        + "\"key\":\"1/forms/formr-c/2000b.json\","
+        + "\"fixedFields\":[\"id\",\"traineeTisId\"]}";
+
+    listener.handleFormDeleteEvent(MESSAGE);
+
+    verifyNoInteractions(formRPartAService);
+    verifyNoInteractions(formRPartBService);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenDeleteTypeNotPartial() throws IOException {
+    final String MESSAGE = "{\"deleteType\":\"HARD\","
+        + "\"bucket\":\"document-upload\","
+        + "\"key\":\"1/forms/formr-a/1000a.json\","
+        + "\"fixedFields\":[\"id\",\"traineeTisId\"]}";
+
+    verifyNoInteractions(formRPartAService);
+    verifyNoInteractions(formRPartBService);
+    assertThrows(ApplicationException.class, () -> listener.handleFormDeleteEvent(MESSAGE));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenFailToPartialDeleteForm() throws IOException {
+    final String MESSAGE = "{\"deleteType\":\"PARTIAL\","
+        + "\"bucket\":\"document-upload\","
+        + "\"key\":\"1/forms/formr-a/1000a.json\","
+        + "\"fixedFields\":[\"id\",\"traineeTisId\"]}";
+
+    doThrow(ApplicationException.class)
+        .when(formRPartAService).partialDeleteFormRPartAById(any(), any(), any());
+    assertThrows(ApplicationException.class, () -> listener.handleFormDeleteEvent(MESSAGE));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/AddPartialDeleteMetadataToS3Test.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/AddPartialDeleteMetadataToS3Test.java
@@ -1,0 +1,195 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.migration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.client.result.DeleteResult;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import org.bson.Document;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.internal.verification.Times;
+import org.springframework.core.env.Environment;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.DeleteType;
+
+class AddPartialDeleteMetadataToS3Test {
+
+  private static final String BUCKET_NAME = "test-bucket";
+  private static final String FIXED_FIELDS =
+      "id,traineeTisId,lifecycleState,submissionDate,lastModifiedDate";
+
+  private AddPartialDeleteMetadataToS3 migration;
+  private ArgumentCaptor<PutObjectRequest> putRequestCaptor;
+  private AmazonS3 s3;
+  private ObjectListing objects;
+  private ObjectListing objects2;
+  private S3ObjectSummary objectSummary1;
+  private S3ObjectSummary objectSummary2;
+  private S3ObjectSummary objectSummary3;
+  private S3Object object1;
+  private S3Object object2;
+  private S3Object object3;
+  private InputStream objectContent1;
+  private InputStream objectContent2;
+  private InputStream objectContent3;
+  private ObjectMetadata metadata;
+
+  @BeforeEach
+  void setUp() {
+    s3 = mock(AmazonS3.class);
+    putRequestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+    Environment env = mock(Environment.class);
+    when(env.getProperty("application.file-store.bucket")).thenReturn(BUCKET_NAME);
+    migration = new AddPartialDeleteMetadataToS3(s3, env);
+
+    // set up ObjectListing
+    objectSummary1 = new S3ObjectSummary();
+    objectSummary1.setKey("1");
+    objectSummary2 = new S3ObjectSummary();
+    objectSummary2.setKey("2");
+    objectSummary3 = new S3ObjectSummary();
+    objectSummary3.setKey("3");
+
+    objects = new ObjectListing();
+    objects.setTruncated(true);
+    List<S3ObjectSummary> objectSummaries = objects.getObjectSummaries();
+    objectSummaries.add(objectSummary1);
+    objectSummaries.add(objectSummary2);
+
+    objects2 = new ObjectListing();
+    objects2.setTruncated(false);
+    List<S3ObjectSummary> objectSummaries2 = objects2.getObjectSummaries();
+    objectSummaries2.add(objectSummary3);
+
+    // set up S3Objects
+    objectContent1 = new ByteArrayInputStream("{\"id\":\"1\"}".getBytes());
+    objectContent2 = new ByteArrayInputStream("{\"id\":\"2\"}".getBytes());
+    objectContent3 = new ByteArrayInputStream("{\"id\":\"3\"}".getBytes());
+
+    metadata = new ObjectMetadata();
+    metadata.addUserMetadata("metaName1", "mataValue1");
+    metadata.addUserMetadata("metaName2", "mataValue2");
+    metadata.addUserMetadata("metaName3", "mataValue3");
+
+    object1 = new S3Object();
+    object1.setBucketName(BUCKET_NAME);
+    object1.setKey("1");
+    object1.setObjectContent(objectContent1);
+    object1.setObjectMetadata(metadata);
+
+    object2 = new S3Object();
+    object2.setBucketName(BUCKET_NAME);
+    object2.setKey("2");
+    object2.setObjectContent(objectContent2);
+    object2.setObjectMetadata(metadata);
+
+    object3 = new S3Object();
+    object3.setBucketName(BUCKET_NAME);
+    object3.setKey("3");
+    object3.setObjectContent(objectContent3);
+    object3.setObjectMetadata(metadata);
+  }
+
+  @Test
+  void shouldAddMetadataToObject() throws IOException {
+    when(s3.listObjects(BUCKET_NAME)).thenReturn(objects);
+    when(s3.listNextBatchOfObjects(objects)).thenReturn(objects2);
+    when(s3.getObject(BUCKET_NAME, "1")).thenReturn(object1);
+    when(s3.getObject(BUCKET_NAME, "2")).thenReturn(object2);
+    when(s3.getObject(BUCKET_NAME, "3")).thenReturn(object3);
+
+    migration.migrate();
+
+    verify(s3, times(3)).putObject(putRequestCaptor.capture());
+    List<PutObjectRequest> putObjectRequests = putRequestCaptor.getAllValues();
+    assertThat("Unexpected put object request count.",
+        putObjectRequests.size(), CoreMatchers.is(3));
+
+    var assertId = 1;
+    for (var putObjectRequest : putObjectRequests) {
+      assertThat("Unexpected bucket.",
+          putObjectRequest.getBucketName(), is(BUCKET_NAME));
+      assertThat("Unexpected key.",
+          putObjectRequest.getKey(), is(Integer.toString(assertId)));
+      final var resultInputStream = putObjectRequest.getInputStream();
+      ObjectMapper mapper = new ObjectMapper();
+      Map<String, Object> resultJsonMap = mapper.readValue(resultInputStream, Map.class);
+      assertThat("Unexpected input stream.",
+          resultJsonMap.get("id"), is(Integer.toString(assertId)));
+
+      final var resultUserMetadata =
+          putObjectRequest.getMetadata().getUserMetadata();
+      metadata.getUserMetadata().entrySet().stream()
+          .forEach(entry -> assertThat(resultUserMetadata.entrySet(), hasItem(entry)));
+      assertThat("Unexpected deletetype in object Metadata.",
+          resultUserMetadata.get("deletetype"), is(DeleteType.PARTIAL.name()));
+      assertThat("Unexpected fixedfields in object Metadata.",
+          resultUserMetadata.get("fixedfields"), is(FIXED_FIELDS));
+
+      assertId++;
+    }
+  }
+
+  @Test
+  void shouldNotFailMigrationWhenAddMetadataFails() {
+    when(s3.listObjects(BUCKET_NAME)).thenReturn(objects);
+    when(s3.listNextBatchOfObjects(objects)).thenReturn(objects2);
+    when(s3.getObject(BUCKET_NAME, "1")).thenReturn(object1);
+    when(s3.getObject(BUCKET_NAME, "2")).thenReturn(object2);
+    when(s3.getObject(BUCKET_NAME, "3")).thenReturn(object3);
+
+    doThrow(RuntimeException.class).when(s3).putObject(any());
+
+    assertDoesNotThrow(() -> migration.migrate());
+  }
+
+  @Test
+  void shouldNotAttemptRollback() {
+    migration.rollback();
+    verifyNoInteractions(s3);
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartARepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartARepositoryImplTest.java
@@ -43,6 +43,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.DeleteType;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.Declaration;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
@@ -90,6 +91,9 @@ class S3FormRPartARepositoryImplTest {
           LifecycleState.UNSUBMITTED.name(), "submissiondate",
           DEFAULT_SUBMISSION_DATE_STRING, "traineeid",
           DEFAULT_TRAINEE_TIS_ID);
+  private static final String FIXED_FIELDS =
+      "id,traineeTisId,lifecycleState,submissionDate,lastModifiedDate";
+
   private static ObjectMapper objectMapper;
   private S3FormRPartARepositoryImpl repo;
   @Mock
@@ -149,10 +153,15 @@ class S3FormRPartARepositoryImplTest {
         is(String.join("/", DEFAULT_TRAINEE_TIS_ID, "forms", FormRPartAService.FORM_TYPE,
             entity.getId() + ".json")));
     Map<String, String> expectedMetadata = Map
-        .of("id", entity.getId().toString(), "name", entity.getId() + ".json", "type", "json",
-            "formtype", FormRPartAService.FORM_TYPE, "lifecyclestate",
-            LifecycleState.SUBMITTED.name(), "submissiondate", DEFAULT_SUBMISSION_DATE_STRING,
-            "traineeid", DEFAULT_TRAINEE_TIS_ID);
+        .of("id", entity.getId().toString(), "name",
+            entity.getId() + ".json",
+            "type", "json",
+            "formtype", FormRPartAService.FORM_TYPE,
+            "lifecyclestate", LifecycleState.SUBMITTED.name(),
+            "submissiondate", DEFAULT_SUBMISSION_DATE_STRING,
+            "traineeid", DEFAULT_TRAINEE_TIS_ID,
+            "deletetype", DeleteType.PARTIAL.name(),
+            "fixedfields", FIXED_FIELDS);
 
     assertThat("Unexpected metadata.", actualRequest.getMetadata().getUserMetadata().entrySet(),
         containsInAnyOrder(expectedMetadata.entrySet().toArray(new Entry[0])));

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
@@ -46,6 +46,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.DeleteType;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.Declaration;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
@@ -104,6 +105,8 @@ class S3FormRPartBRepositoryImplTest {
           "traineeid", DEFAULT_TRAINEE_TIS_ID);
   private static final Boolean DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS = true;
   private static final Boolean DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS = true;
+  private static final String FIXED_FIELDS =
+      "id,traineeTisId,lifecycleState,submissionDate,lastModifiedDate";
   private static ObjectMapper objectMapper;
   private S3FormRPartBRepositoryImpl repo;
   @Mock
@@ -213,10 +216,15 @@ class S3FormRPartBRepositoryImplTest {
         is(String.join("/", DEFAULT_TRAINEE_TIS_ID, "forms", FormRPartBService.FORM_TYPE,
             entity.getId() + ".json")));
     Map<String, String> expectedMetadata = Map
-        .of("id", entity.getId().toString(), "name", entity.getId() + ".json", "type", "json",
-            "formtype", FormRPartBService.FORM_TYPE, "lifecyclestate",
-            LifecycleState.SUBMITTED.name(), "submissiondate", DEFAULT_SUBMISSION_DATE_STRING,
-            "traineeid", DEFAULT_TRAINEE_TIS_ID);
+        .of("id", entity.getId().toString(),
+            "name", entity.getId() + ".json",
+            "type", "json",
+            "formtype", FormRPartBService.FORM_TYPE,
+            "lifecyclestate", LifecycleState.SUBMITTED.name(),
+            "submissiondate", DEFAULT_SUBMISSION_DATE_STRING,
+            "traineeid", DEFAULT_TRAINEE_TIS_ID,
+            "deletetype", DeleteType.PARTIAL.name(),
+            "fixedfields", FIXED_FIELDS);
 
     assertThat("Unexpected metadata.", actualRequest.getMetadata().getUserMetadata().entrySet(),
         containsInAnyOrder(expectedMetadata.entrySet().toArray(new Entry[0])));

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceImplTest.java
@@ -21,9 +21,12 @@
 package uk.nhs.hee.tis.trainee.forms.service;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -103,6 +106,8 @@ class FormRPartBServiceImplTest {
 
   private static final Boolean DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS = true;
   private static final Boolean DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS = true;
+  private static final String[] FIXED_FIELDS =
+      new String[]{"id", "traineeTisId", "lifecycleState"};
 
 
   private FormRPartBServiceImpl service;
@@ -115,6 +120,8 @@ class FormRPartBServiceImplTest {
 
   @Captor
   private ArgumentCaptor<PutObjectRequest> putRequestCaptor;
+  @Captor
+  private ArgumentCaptor<FormRPartB> formRPartBCaptor;
 
   private FormRPartBMapper mapper;
 
@@ -586,5 +593,66 @@ class FormRPartBServiceImplTest {
     assertThat("Unexpected havePreviousUnresolvedDeclarations flag.",
         dto.getHavePreviousUnresolvedDeclarations(),
         is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
+  }
+
+  @Test
+  void shouldPartialDeleteFormRPartBById() {
+    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(Optional.of(entity));
+
+    service.partialDeleteFormRPartBById(
+        DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID, FIXED_FIELDS);
+
+    verify(repositoryMock).save(formRPartBCaptor.capture());
+    FormRPartB dto = formRPartBCaptor.getValue();
+    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID));
+    assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
+    assertThat("Unexpected lifecycle states.",
+        dto.getLifecycleState(), is(LifecycleState.DELETED));
+    assertThat("Unexpected forename.", dto.getForename(), is(nullValue()));
+    assertThat("Unexpected surname.", dto.getSurname(), is(nullValue()));
+    assertThat("Unexpected work.", dto.getWork(), is(Collections.emptyList()));
+    assertThat("Unexpected total leave.", dto.getTotalLeave(), is(nullValue()));
+    assertThat("Unexpected isHonest flag.", dto.getIsHonest(), is(nullValue()));
+    assertThat("Unexpected isHealthy flag.", dto.getIsHealthy(), is(nullValue()));
+    assertThat("Unexpected health statement.", dto.getHealthStatement(),
+        is(nullValue()));
+    assertThat("Unexpected havePreviousDeclarations flag.", dto.getHavePreviousDeclarations(),
+        is(nullValue()));
+    assertThat("Unexpected previous declarations.", dto.getPreviousDeclarations(),
+        is(Collections.emptyList()));
+    assertThat("Unexpected previous declaration summary.", dto.getPreviousDeclarationSummary(),
+        is(nullValue()));
+    assertThat("Unexpected haveCurrentDeclarations flag.", dto.getHaveCurrentDeclarations(),
+        is(nullValue()));
+    assertThat("Unexpected current declarations.", dto.getCurrentDeclarations(),
+        is(Collections.emptyList()));
+    assertThat("Unexpected current declaration summary.", dto.getCurrentDeclarationSummary(),
+        is(nullValue()));
+    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.",
+        dto.getHaveCurrentUnresolvedDeclarations(),
+        is(nullValue()));
+    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.",
+        dto.getHavePreviousUnresolvedDeclarations(),
+        is(nullValue()));
+  }
+
+  @Test
+  void shouldNotPartialDeleteWhenFormRPartBNotFoundInDb() {
+    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(Optional.ofNullable(null));
+
+    service.partialDeleteFormRPartBById(
+        DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID, FIXED_FIELDS);
+
+    verify(repositoryMock, never()).save(formRPartBCaptor.capture());
+  }
+
+  @Test
+  void shouldThrowExceptionWhenFailToPartialDeleteFormRPartB() throws ApplicationException {
+    doThrow(IllegalArgumentException.class)
+        .when(repositoryMock).findByIdAndTraineeTisId(any(), any());
+    assertThrows(ApplicationException.class, () -> service.partialDeleteFormRPartBById(
+        DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID, FIXED_FIELDS));
   }
 }


### PR DESCRIPTION
- listen to the delete event queue to handle partial delete in DB
- add `deleteType` and `fixedFields` in S3 Metadata when new forms are saved
- Mongock migration to bulk add `deleteType` and `fixedFields` to Metadata of all the existing forms

TIS21-4009
TIS21-4019
TIS21-4077
TIS21-4023