### PR TITLE
fix: incorrect decoder used for JWT token

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtil.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtil.java
@@ -51,7 +51,7 @@ public class AuthTokenUtil {
    */
   public static String getTraineeTisId(String token) throws IOException {
     String[] tokenSections = token.split("\\.");
-    byte[] payloadBytes = Base64.getDecoder()
+    byte[] payloadBytes = Base64.getUrlDecoder()
         .decode(tokenSections[1].getBytes(StandardCharsets.UTF_8));
 
     Map<?, ?> payload = mapper.readValue(payloadBytes, Map.class);

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtilTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtilTest.java
@@ -24,6 +24,7 @@ package uk.nhs.hee.tis.trainee.forms.api.util;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -37,6 +38,16 @@ import org.springframework.http.ResponseEntity;
 class AuthTokenUtilTest {
 
   private static final String TIS_ID_ATTRIBUTE = "custom:tisId";
+
+  @Test
+  void getShouldHandleUrlCharactersInToken() {
+    // The payload is specifically crafted to include an underscore, the ID is 12.
+    String token = "aGVhZGVy.eyJjdXN0b206dGlzSWQiOiAiMTIiLCJuYW1lIjogIkpvaG4gRG_DqyJ9.c2lnbmF0dXJl";
+
+    String tisId = assertDoesNotThrow(() -> AuthTokenUtil.getTraineeTisId(token));
+
+    assertThat("Unexpected trainee TIS ID.", tisId, is("12"));
+  }
 
   @Test
   void getTraineeTisIdShouldThrowExceptionWhenTokenPayloadNotMap() {


### PR DESCRIPTION
The JWT is encoded using a URL variant of Base64, which replaces `/` with `_` to avoid using reserved URL characters. AuthTokenUtil is using the standard decoder, which throws an exception when an underscore is encountered.

TIS21-4414