### PR TITLE
feat: allow deletion of draft forms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.10.0"
+version = "0.11.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResource.java
@@ -31,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -68,7 +69,7 @@ public class FormRPartAResource {
    * @param dto   the dto to create
    * @param token The authorization token from the request header.
    * @return the ResponseEntity with status 201 (Created) and with body the new dto, or with status
-   *     400 (Bad Request) if the formRPartA has already an ID
+   * 400 (Bad Request) if the formRPartA has already an ID
    * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PostMapping("/formr-parta")
@@ -99,8 +100,8 @@ public class FormRPartAResource {
    * @param dto   the dto to update
    * @param token The authorization token from the request header.
    * @return the ResponseEntity with status 200 and with body the new dto, or with status 500
-   *     (Internal Server Error) if the formRPartBDto couldn't be updated. If the id is not
-   *     provided, will create a new FormRPartA
+   * (Internal Server Error) if the formRPartBDto couldn't be updated. If the id is not provided,
+   * will create a new FormRPartA
    * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PutMapping("/formr-parta")
@@ -169,5 +170,41 @@ public class FormRPartAResource {
 
     FormRPartADto formRPartADto = service.getFormRPartAById(id, traineeTisId);
     return ResponseEntity.of(Optional.ofNullable(formRPartADto));
+  }
+
+  /**
+   * DELETE: /formr-parta/:id.
+   *
+   * @param id    The ID of the form
+   * @param token The authorization token from the request header.
+   * @return the status of the deletion.
+   */
+  @DeleteMapping("/formr-parta/{id}")
+  public ResponseEntity<Void> deleteFormRPartAById(@PathVariable String id,
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+    log.info("Delete FormR-PartA by id {}", id);
+
+    String traineeTisId;
+    try {
+      traineeTisId = AuthTokenUtil.getTraineeTisId(token);
+    } catch (IOException e) {
+      log.warn("Unable to read tisId from token.", e);
+      return ResponseEntity.badRequest().build();
+    }
+
+    boolean deleted;
+
+    try {
+      deleted = service.deleteFormRPartAById(id, traineeTisId);
+    } catch (IllegalArgumentException e) {
+      log.error(e.getMessage());
+      return ResponseEntity.badRequest().build();
+    }
+
+    if (deleted) {
+      return ResponseEntity.noContent().build();
+    } else {
+      return ResponseEntity.notFound().build();
+    }
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResource.java
@@ -30,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -67,7 +68,7 @@ public class FormRPartBResource {
    * @param dto   the dto to create
    * @param token The authorization token from the request header.
    * @return the ResponseEntity with status 201 (Created) and with body the new dto, or with status
-   *     400 (Bad Request) if the formRPartB has already an ID
+   * 400 (Bad Request) if the formRPartB has already an ID
    * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PostMapping("/formr-partb")
@@ -99,8 +100,8 @@ public class FormRPartBResource {
    * @param dto   the dto to update
    * @param token The authorization token from the request header.
    * @return the ResponseEntity with status 200 and with body the new dto, or with status 500
-   *     (Internal Server Error) if the dto couldn't be updated. If the id is not provided, will
-   *     create a new FormRPartB
+   * (Internal Server Error) if the dto couldn't be updated. If the id is not provided, will create
+   * a new FormRPartB
    * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PutMapping("/formr-partb")
@@ -169,5 +170,41 @@ public class FormRPartBResource {
 
     FormRPartBDto formRPartBDto = service.getFormRPartBById(id, traineeTisId);
     return ResponseEntity.of(Optional.ofNullable(formRPartBDto));
+  }
+
+  /**
+   * DELETE: /formr-partb/:id.
+   *
+   * @param id    The ID of the form
+   * @param token The authorization token from the request header.
+   * @return the status of the deletion.
+   */
+  @DeleteMapping("/formr-partb/{id}")
+  public ResponseEntity<Void> deleteFormRPartBById(@PathVariable String id,
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+    log.info("Delete FormR-PartB by id {}", id);
+
+    String traineeTisId;
+    try {
+      traineeTisId = AuthTokenUtil.getTraineeTisId(token);
+    } catch (IOException e) {
+      log.warn("Unable to read tisId from token.", e);
+      return ResponseEntity.badRequest().build();
+    }
+
+    boolean deleted;
+
+    try {
+      deleted = service.deleteFormRPartBById(id, traineeTisId);
+    } catch (IllegalArgumentException e) {
+      log.error(e.getMessage());
+      return ResponseEntity.badRequest().build();
+    }
+
+    if (deleted) {
+      return ResponseEntity.noContent().build();
+    } else {
+      return ResponseEntity.notFound().build();
+    }
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -120,6 +121,38 @@ public class FormRPartAService {
         .or(() -> repository.findByIdAndTraineeTisId(UUID.fromString(id), traineeTisId))
         .orElse(null);
     return mapper.toDto(formRPartA);
+  }
+
+  /**
+   * Delete the form for the given ID and trainee ID, only DRAFT forms are supported.
+   *
+   * @param id           The ID of the form to delete.
+   * @param traineeTisId The ID of the trainee to delete the form for.
+   * @return true if the form was found and deleted, false if not found.
+   */
+  public boolean deleteFormRPartAById(String id, String traineeTisId) {
+    log.info("Request to delete FormRPartA by id : {}", id);
+    Optional<FormRPartA> optionalForm = repository.findByIdAndTraineeTisId(UUID.fromString(id),
+        traineeTisId);
+
+    if (optionalForm.isEmpty()) {
+      log.info("FormRPartA {} did not exist.", id);
+      return false;
+    }
+
+    FormRPartA form = optionalForm.get();
+    LifecycleState state = form.getLifecycleState();
+
+    if (!state.equals(LifecycleState.DRAFT)) {
+      String message = String.format("Unable to delete forms with lifecycle state %s.", state);
+      log.warn(message);
+      throw new IllegalArgumentException(message);
+    }
+
+    repository.delete(form);
+    log.info("Deleted FormRPartA {}", id);
+
+    return true;
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -127,8 +128,8 @@ class FormRPartAResourceTest {
   void postShouldNotCreateFormWhenNoToken() throws Exception {
     dto.setId(null);
     mockMvc.perform(post("/api/formr-parta")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto)))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto)))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -138,9 +139,9 @@ class FormRPartAResourceTest {
   void postShouldNotCreateFormWhenTokenIsInvalid() throws Exception {
     dto.setId(null);
     mockMvc.perform(post("/api/formr-parta")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -149,9 +150,9 @@ class FormRPartAResourceTest {
   @Test
   void postShouldNotCreateFormWhenFormExists() throws Exception {
     mockMvc.perform(post("/api/formr-parta")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -170,9 +171,9 @@ class FormRPartAResourceTest {
     doThrow(exception).when(validator).validate(dto);
 
     mockMvc.perform(post("/api/formr-parta")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -188,9 +189,9 @@ class FormRPartAResourceTest {
     when(service.save(dto)).thenReturn(createdDto);
 
     mockMvc.perform(put("/api/formr-parta")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isCreated())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(header().string(HttpHeaders.LOCATION, "/api/formr-parta/" + DEFAULT_ID))
@@ -201,8 +202,8 @@ class FormRPartAResourceTest {
   @Test
   void putShouldNotUpdateFormWhenNoToken() throws Exception {
     mockMvc.perform(put("/api/formr-parta")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto)))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto)))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -211,9 +212,9 @@ class FormRPartAResourceTest {
   @Test
   void putShouldNotUpdateFormWhenTokenIsInvalid() throws Exception {
     mockMvc.perform(put("/api/formr-parta")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -230,9 +231,9 @@ class FormRPartAResourceTest {
     doThrow(exception).when(validator).validate(dto);
 
     mockMvc.perform(put("/api/formr-parta")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -247,9 +248,9 @@ class FormRPartAResourceTest {
     when(service.save(dto)).thenReturn(savedDto);
 
     mockMvc.perform(put("/api/formr-parta")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value(DEFAULT_ID))
@@ -266,9 +267,9 @@ class FormRPartAResourceTest {
     when(service.save(dto)).thenReturn(createdDto);
 
     mockMvc.perform(put("/api/formr-parta")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isCreated())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(header().string(HttpHeaders.LOCATION, "/api/formr-parta/" + DEFAULT_ID))
@@ -279,7 +280,7 @@ class FormRPartAResourceTest {
   @Test
   void getShouldNotReturnTraineesFormsWhenNoToken() throws Exception {
     mockMvc.perform(get("/api/formr-partas")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -288,8 +289,8 @@ class FormRPartAResourceTest {
   @Test
   void getShouldNotReturnTraineesFormsWhenTokenHasNoTraineeId() throws Exception {
     mockMvc.perform(get("/api/formr-partas")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -301,8 +302,8 @@ class FormRPartAResourceTest {
         .thenReturn(Collections.singletonList(simpleDto));
 
     mockMvc.perform(get("/api/formr-partas")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$").value(hasSize(1)))
@@ -314,7 +315,7 @@ class FormRPartAResourceTest {
   @Test
   void getByIdShouldNotReturnFormWhenNoToken() throws Exception {
     mockMvc.perform(get("/api/formr-parta/" + DEFAULT_ID)
-        .contentType(TestUtil.APPLICATION_JSON_UTF8))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -323,8 +324,8 @@ class FormRPartAResourceTest {
   @Test
   void getByIdShouldNotReturnFormWhenTokenHasNoTraineeId() throws Exception {
     mockMvc.perform(get("/api/formr-parta/" + DEFAULT_ID)
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -334,8 +335,8 @@ class FormRPartAResourceTest {
   void getByIdShouldNotReturnFormWhenFormIsNotTrainees() throws Exception {
     when(service.getFormRPartAById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID)).thenReturn(null);
     mockMvc.perform(get("/api/formr-parta/" + DEFAULT_ID)
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isNotFound());
   }
 
@@ -344,8 +345,8 @@ class FormRPartAResourceTest {
     when(service.getFormRPartAById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
         .thenReturn(dto);
     mockMvc.perform(get("/api/formr-parta/" + DEFAULT_ID)
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value(DEFAULT_ID))
@@ -353,5 +354,42 @@ class FormRPartAResourceTest {
         .andExpect(jsonPath("$.forename").value(DEFAULT_FORENAME))
         .andExpect(jsonPath("$.surname").value(DEFAULT_SURNAME))
         .andExpect(jsonPath("$.lifecycleState").value(DEFAULT_LIFECYCLESTATE.name()));
+  }
+
+  @Test
+  void deleteByIdShouldNotDeleteFormWhenNoToken() throws Exception {
+    mockMvc.perform(delete("/api/formr-parta/" + DEFAULT_ID)
+            .contentType(TestUtil.APPLICATION_JSON_UTF8))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void deleteByIdShouldNotDeleteFormWhenTokenHasNoTraineeId() throws Exception {
+    mockMvc.perform(delete("/api/formr-parta/" + DEFAULT_ID)
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void deleteByIdShouldReturnNotFoundWhenFormIsNotDeleted() throws Exception {
+    when(service.deleteFormRPartAById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID)).thenReturn(false);
+    mockMvc.perform(delete("/api/formr-parta/" + DEFAULT_ID)
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void deleteByIdShouldReturnNoContentWhenFormIsDeleted() throws Exception {
+    when(service.deleteFormRPartAById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID)).thenReturn(true);
+    mockMvc.perform(delete("/api/formr-parta/" + DEFAULT_ID)
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isNoContent());
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResourceTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -127,8 +128,8 @@ class FormRPartBResourceTest {
   void postShouldNotCreateFormWhenNoToken() throws Exception {
     dto.setId(null);
     mockMvc.perform(post("/api/formr-partb")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto)))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto)))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -138,9 +139,9 @@ class FormRPartBResourceTest {
   void postShouldNotCreateFormWhenTokenIsInvalid() throws Exception {
     dto.setId(null);
     mockMvc.perform(post("/api/formr-partb")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -149,9 +150,9 @@ class FormRPartBResourceTest {
   @Test
   void postShouldNotCreateFormWhenFormExists() throws Exception {
     mockMvc.perform(post("/api/formr-partb")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -170,9 +171,9 @@ class FormRPartBResourceTest {
     doThrow(exception).when(validator).validate(dto);
 
     mockMvc.perform(post("/api/formr-partb")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -188,9 +189,9 @@ class FormRPartBResourceTest {
     when(service.save(dto)).thenReturn(createdDto);
 
     mockMvc.perform(put("/api/formr-partb")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isCreated())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(header().string(HttpHeaders.LOCATION, "/api/formr-partb/" + DEFAULT_ID))
@@ -201,8 +202,8 @@ class FormRPartBResourceTest {
   @Test
   void putShouldNotUpdateFormWhenNoToken() throws Exception {
     mockMvc.perform(put("/api/formr-partb")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto)))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto)))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -211,9 +212,9 @@ class FormRPartBResourceTest {
   @Test
   void putShouldNotUpdateFormWhenTokenIsInvalid() throws Exception {
     mockMvc.perform(put("/api/formr-partb")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -230,9 +231,9 @@ class FormRPartBResourceTest {
     doThrow(exception).when(validator).validate(dto);
 
     mockMvc.perform(put("/api/formr-partb")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -247,9 +248,9 @@ class FormRPartBResourceTest {
     when(service.save(dto)).thenReturn(savedDto);
 
     mockMvc.perform(put("/api/formr-partb")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value(DEFAULT_ID))
@@ -266,9 +267,9 @@ class FormRPartBResourceTest {
     when(service.save(dto)).thenReturn(createdDto);
 
     mockMvc.perform(put("/api/formr-partb")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .content(TestUtil.convertObjectToJsonBytes(dto))
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .content(TestUtil.convertObjectToJsonBytes(dto))
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isCreated())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(header().string(HttpHeaders.LOCATION, "/api/formr-partb/" + DEFAULT_ID))
@@ -279,7 +280,7 @@ class FormRPartBResourceTest {
   @Test
   void getShouldNotReturnTraineesFormsWhenNoToken() throws Exception {
     mockMvc.perform(get("/api/formr-partbs")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -288,8 +289,8 @@ class FormRPartBResourceTest {
   @Test
   void getShouldNotReturnTraineesFormsWhenTokenHasNoTraineeId() throws Exception {
     mockMvc.perform(get("/api/formr-partbs")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -301,8 +302,8 @@ class FormRPartBResourceTest {
         .thenReturn(Collections.singletonList(simpleDto));
 
     mockMvc.perform(get("/api/formr-partbs")
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$").value(hasSize(1)))
@@ -314,7 +315,7 @@ class FormRPartBResourceTest {
   @Test
   void getByIdShouldNotReturnFormWhenNoToken() throws Exception {
     mockMvc.perform(get("/api/formr-partb/" + DEFAULT_ID)
-        .contentType(TestUtil.APPLICATION_JSON_UTF8))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -323,8 +324,8 @@ class FormRPartBResourceTest {
   @Test
   void getByIdShouldNotReturnFormWhenTokenHasNoTraineeId() throws Exception {
     mockMvc.perform(get("/api/formr-partb/" + DEFAULT_ID)
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
@@ -334,8 +335,8 @@ class FormRPartBResourceTest {
   void getByIdShouldNotReturnFormWhenFormIsNotTrainees() throws Exception {
     when(service.getFormRPartBById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID)).thenReturn(null);
     mockMvc.perform(get("/api/formr-partb/" + DEFAULT_ID)
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isNotFound());
   }
 
@@ -344,8 +345,8 @@ class FormRPartBResourceTest {
     when(service.getFormRPartBById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
         .thenReturn(dto);
     mockMvc.perform(get("/api/formr-partb/" + DEFAULT_ID)
-        .contentType(TestUtil.APPLICATION_JSON_UTF8)
-        .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value(DEFAULT_ID))
@@ -353,5 +354,42 @@ class FormRPartBResourceTest {
         .andExpect(jsonPath("$.forename").value(DEFAULT_FORENAME))
         .andExpect(jsonPath("$.surname").value(DEFAULT_SURNAME))
         .andExpect(jsonPath("$.lifecycleState").value(DEFAULT_LIFECYCLESTATE.name()));
+  }
+
+  @Test
+  void deleteByIdShouldNotDeleteFormWhenNoToken() throws Exception {
+    mockMvc.perform(delete("/api/formr-partb/" + DEFAULT_ID)
+            .contentType(TestUtil.APPLICATION_JSON_UTF8))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void deleteByIdShouldNotDeleteFormWhenTokenHasNoTraineeId() throws Exception {
+    mockMvc.perform(delete("/api/formr-partb/" + DEFAULT_ID)
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, "aa.bb.cc"))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void deleteByIdShouldReturnNotFoundWhenFormIsNotDeleted() throws Exception {
+    when(service.deleteFormRPartBById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID)).thenReturn(false);
+    mockMvc.perform(delete("/api/formr-partb/" + DEFAULT_ID)
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void deleteByIdShouldReturnNoContentWhenFormIsDeleted() throws Exception {
+    when(service.deleteFormRPartBById(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID)).thenReturn(true);
+    mockMvc.perform(delete("/api/formr-partb/" + DEFAULT_ID)
+            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+            .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN))
+        .andExpect(status().isNoContent());
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceTest.java
@@ -41,6 +41,9 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -332,6 +335,42 @@ class FormRPartAServiceTest {
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected forename.", dto.getForename(), is(DEFAULT_FORENAME));
     assertThat("Unexpected surname.", dto.getSurname(), is(DEFAULT_SURNAME));
+  }
+
+  @Test
+  void shouldReturnTrueWhenDeletingDraft() {
+    entity.setLifecycleState(LifecycleState.DRAFT);
+
+    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(Optional.of(entity));
+
+    boolean deleted = service.deleteFormRPartAById(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID);
+
+    assertThat("Unexpected delete result.", deleted, is(true));
+  }
+
+  @Test
+  void shouldReturnFalseWhenFormToDeleteNotFound() {
+    entity.setLifecycleState(LifecycleState.DRAFT);
+
+    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(Optional.empty());
+
+    boolean deleted = service.deleteFormRPartAById(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID);
+
+    assertThat("Unexpected delete result.", deleted, is(false));
+  }
+
+  @ParameterizedTest(name = "Should throw exception when deleting form with {0} state")
+  @EnumSource(names = {"DRAFT"}, mode = Mode.EXCLUDE)
+  void shouldThrowExceptionWhenDeletingNonDraftForm(LifecycleState state) {
+    entity.setLifecycleState(state);
+
+    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(Optional.of(entity));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> service.deleteFormRPartAById(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceTest.java
@@ -44,6 +44,9 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -598,6 +601,42 @@ class FormRPartBServiceTest {
     assertThat("Unexpected havePreviousUnresolvedDeclarations flag.",
         dto.getHavePreviousUnresolvedDeclarations(),
         is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
+  }
+
+  @Test
+  void shouldReturnTrueWhenDeletingDraft() {
+    entity.setLifecycleState(LifecycleState.DRAFT);
+
+    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(Optional.of(entity));
+
+    boolean deleted = service.deleteFormRPartBById(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID);
+
+    assertThat("Unexpected delete result.", deleted, is(true));
+  }
+
+  @Test
+  void shouldReturnFalseWhenFormToDeleteNotFound() {
+    entity.setLifecycleState(LifecycleState.DRAFT);
+
+    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(Optional.empty());
+
+    boolean deleted = service.deleteFormRPartBById(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID);
+
+    assertThat("Unexpected delete result.", deleted, is(false));
+  }
+
+  @ParameterizedTest(name = "Should throw exception when deleting form with {0} state")
+  @EnumSource(names = {"DRAFT"}, mode = Mode.EXCLUDE)
+  void shouldThrowExceptionWhenDeletingNonDraftForm(LifecycleState state) {
+    entity.setLifecycleState(state);
+
+    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(Optional.of(entity));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> service.deleteFormRPartBById(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID));
   }
 
   @Test


### PR DESCRIPTION
In order to support the discarding of a draft form, the user must be allowed to delete any draft forms that they have created. Create a new DELETE endpoint with supporting service methods for both Part-A and Part-B forms.

TIS21-4922
TIS21-4877