### PR TITLE
fix: don't move form when the form is already attached to the target trainee

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.15.0"
+version = "0.15.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRelocateService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRelocateService.java
@@ -82,6 +82,13 @@ public class FormRelocateService {
     else {
       AbstractForm form = optionalForm.get();
       String sourceTrainee = form.getTraineeTisId();
+
+      if (sourceTrainee.equals(targetTrainee)) {
+        log.error("The form is attached to the trainee " + targetTrainee + " already.");
+        throw new ApplicationException(
+            "The form is attached to the trainee " + targetTrainee + " already.");
+      }
+
       try {
         performRelocate(form, sourceTrainee, targetTrainee);
       } catch (Exception e) {
@@ -145,13 +152,13 @@ public class FormRelocateService {
       log.info("Form " + formId + " in S3 relocated from "
           + sourceTrainee + " to " + targetTrainee);
       abstractCloudRepositoryA.delete(formId, sourceTrainee);
-      log.info("Form " + formId + " in S3 deleted.");
+      log.info("Form " + formId + " in S3 deleted from " + sourceTrainee + ".");
     } else if (abstractForm instanceof FormRPartB formRPartB) {
       abstractCloudRepositoryB.save(formRPartB);
       log.info("Form " + formId + " in S3 relocated from "
           + sourceTrainee + " to " + targetTrainee);
       abstractCloudRepositoryB.delete(formId, sourceTrainee);
-      log.info("Form " + formId + " in S3 deleted.");
+      log.info("Form " + formId + " in S3 deleted from " + sourceTrainee + ".");
     }
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRelocateServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRelocateServiceTest.java
@@ -199,6 +199,19 @@ class FormRelocateServiceTest {
   }
 
   @Test
+  void shouldNotUpdateDbAndS3WhenSourceTraineeIsSameAsTargetTrainee() throws IOException {
+    formRPartA.setTraineeTisId(TARGET_TRAINEE);
+    when(formRPartARepositoryMock.findById(FORM_ID)).thenReturn(Optional.of(formRPartA));
+
+    assertThrows(ApplicationException.class, () ->
+        service.relocateForm(FORM_ID_STRING, TARGET_TRAINEE));
+
+    verify(formRPartARepositoryMock, never()).save(any());
+    verify(formRPartBRepositoryMock, never()).save(any());
+    verifyNoInteractions(amazonS3Mock);
+  }
+
+  @Test
   void shouldRollBackAndThrowExceptionWhenMoveDraftFormInDbFail() throws IOException {
     when(formRPartARepositoryMock.findById(FORM_ID)).thenReturn(Optional.of(formRPartA));
     when(formRPartARepositoryMock.save(formRPartA))


### PR DESCRIPTION
to avoid unwanted form deletion in S3 during rollback due to form not found