### PR TITLE
fix: add backend logging for validation errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.15.3"
+version = "0.15.4"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidator.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartAValidator.java
@@ -69,6 +69,7 @@ public class FormRPartAValidator {
           new BeanPropertyBindingResult(formRPartADto, FORMR_PARTA_DTO_NAME);
       fieldErrors.forEach(bindingResult::addError);
       Method method = this.getClass().getMethods()[0];
+      log.warn("Form R Part A validation failed: {}", bindingResult);
       throw new MethodArgumentNotValidException(new MethodParameter(method, 0), bindingResult);
     }
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartBValidator.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartBValidator.java
@@ -71,6 +71,7 @@ public class FormRPartBValidator {
           new BeanPropertyBindingResult(formRPartBDto, FORMR_PARTB_DTO_NAME);
       fieldErrors.forEach(bindingResult::addError);
       Method method = this.getClass().getMethods()[0];
+      log.warn("Form R Part B validation failed: {}", bindingResult);
       throw new MethodArgumentNotValidException(new MethodParameter(method, 0), bindingResult);
     }
   }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartBValidatorTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartBValidatorTest.java
@@ -50,8 +50,11 @@ import org.junit.jupiter.params.provider.EnumSource.Mode;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import uk.nhs.hee.tis.trainee.forms.dto.FormRPartADto;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartBDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
@@ -253,6 +256,34 @@ class FormRPartBValidatorTest {
         is(dottedPath));
     assertThat("Should include the invalid value", fieldError.getRejectedValue(),
         is("invalid value"));
+  }
+
+
+  @ExtendWith(OutputCaptureExtension.class)
+  @Test
+  void validationErrorsAreLogged(CapturedOutput output) {
+    String violationMessage = "Constraint violation";
+    String dottedPath = "class.instance.field";
+    String invalidValue = "invalid value";
+
+    ConstraintViolation<FormRPartBDto> cv
+        = createDummyConstraintViolation(violationMessage, dottedPath, invalidValue);
+
+    ConstraintViolationException e
+        = new ConstraintViolationException("violation message", Set.of(cv));
+    doThrow(e).when(formFieldValidationServiceMock).validateFormRPartB(any());
+
+    formRPartBDto.setLifecycleState(LifecycleState.SUBMITTED);
+
+    assertThrows(MethodArgumentNotValidException.class,
+        () -> validator.validate(formRPartBDto)).getMessage();
+
+    assertThat("Validation errors should be logged",
+        output.getOut().contains("Field error in object 'FormRPartBDto' "
+            + "on field 'class.instance.field': "
+            + "rejected value [invalid value]; "
+            + "codes []; arguments []; "
+            + "default message [Constraint violation]"), is(true));
   }
 
   private ConstraintViolation<FormRPartBDto> createDummyConstraintViolation(String message,

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartBValidatorTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/validation/FormRPartBValidatorTest.java
@@ -54,7 +54,6 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import uk.nhs.hee.tis.trainee.forms.dto.FormRPartADto;
 import uk.nhs.hee.tis.trainee.forms.dto.FormRPartBDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;


### PR DESCRIPTION
The validation errors are included in the response to the front-end, but since we are not doing anything with them there, and for ease of resolving any issues, it makes sense to log them here. An example log entry:

```
2024-01-24 09:50:09.834 ERROR 34216 --- [nio-8207-exec-3] u.n.h.t.t.f.a.v.FormRPartAValidator      : Validation failed: org.springframework.validation.BeanPropertyBindingResult: 3 errors
Field error in object 'FormRPartADto' on field 'validateFormRPartA.formRPartADto.cctSpecialty1': rejected value [FormRPartADto(id=071d95bd-01c2-4da1-9fb9-5cfbc524f467, traineeTisId=47165, forename=afgasflhsashfaspolhfoashf;lasfklashfklhasfasfasfasfasfasfasfasfasfasfasfasfasfasfasfkljhaslhflashfkklhfslkhasflkhasfklhasfklhasfklh, surname=null, gmcNumber=8999999, localOfficeName=Health Education England Thames Valley, dateOfBirth=1943-10-09, gender=Male, immigrationStatus=Dependent - other immigration category, qualification=Degree, dateAttained=1997-10-05, medicalSchool=Sheffield University, address1=3rd Floor, address2=3 Piccadilly Place, address3=Manchester, address4=null, postCode=M1 3BN, telephoneNumber=0161 625 7379, mobileNumber=+441234565431, email=dsgfasdgasg@dsgdsg.com, declarationType=I have been appointed to a programme leading to award of CCT, isLeadingToCct=null, programmeSpecialty=Geriatric Medicine, cctSpecialty1=null, cctSpecialty2=GP Returner, college=Faculty of Intensive Care Medicine, completionDate=2027-07-03, trainingGrade=Dental Core Training Year 1, startDate=2024-01-09, programmeMembershipType=Visitor, wholeTimeEquivalent=1, submissionDate=2024-01-24T09:50:07.188, lastModifiedDate=2024-01-24T09:50:07.188, otherImmigrationStatus=, lifecycleState=SUBMITTED)]; codes []; arguments []; default message [This declaration type requires a CCT specialty to be selected]
Field error in object 'FormRPartADto' on field 'validateFormRPartA.formRPartADto.surname': rejected value [null]; codes []; arguments []; default message [must not be null]
Field error in object 'FormRPartADto' on field 'validateFormRPartA.formRPartADto.forename': rejected value [afgasflhsashfaspolhfoashf;lasfklashfklhasfasfasfasfasfasfasfasfasfasfasfasfasfasfasfkljhaslhflashfkklhfslkhasflkhasfklhasfklhasfklh]; codes []; arguments []; default message [size must be between 1 and 100]
```


TIS21-5578