### PR TITLE
fix: allow empty SiteKnownAs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.15.4"
+version = "0.15.5"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/WorkDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/WorkDto.java
@@ -63,6 +63,6 @@ public class WorkDto {
   @Size(min = 1, max = 100)
   private String siteLocation;
 
-  @Size(min = 1, max = 100)
+  @Size(max = 100)
   private String siteKnownAs;
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormFieldValidationServicePartBTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormFieldValidationServicePartBTest.java
@@ -426,7 +426,6 @@ class FormFieldValidationServicePartBTest {
   }
 
   @ParameterizedTest
-  @EmptySource
   @ValueSource(strings = {STRING_128_CHARS})
   void whenWorkSiteKnownAsIsInvalidThenThrowsException(String str) {
     FormRPartBDto input = validForm();


### PR DESCRIPTION
Validation on the FE for this field uses StringValidationSchemaOptional (its the only field that uses this). Empty strings should be accepted.

NO-TICKET