### PR TITLE
feat(formr): add linked PM and isARCP flag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.17.0"
+version = "0.18.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartADto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartADto.java
@@ -30,6 +30,7 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.Data;
 import uk.nhs.hee.tis.trainee.forms.annotations.LegalAgeValidation;
 import uk.nhs.hee.tis.trainee.forms.annotations.MaxDateValidation;
@@ -50,8 +51,9 @@ import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 public class FormRPartADto {
 
   private String id;
-
   private String traineeTisId;
+  private UUID programmeMembershipId;
+  private Boolean isArcp;
 
   @NotNull
   @Size(min = 1, max = 100)

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartBDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartBDto.java
@@ -32,6 +32,7 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import lombok.Data;
 import uk.nhs.hee.tis.trainee.forms.annotations.NotEmptyIfAnotherFieldHasValueValidation;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
@@ -79,8 +80,9 @@ import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 public class FormRPartBDto {
 
   private String id;
-
   private String traineeTisId;
+  private UUID programmeMembershipId;
+  private Boolean isArcp;
 
   @NotNull
   @Size(min = 1, max = 100)

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartSimpleDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FormRPartSimpleDto.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.forms.dto;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.Data;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 
@@ -30,6 +31,7 @@ public class FormRPartSimpleDto {
 
   private String id;
   private String traineeTisId;
+  private UUID programmeMembershipId;
   private LocalDateTime submissionDate;
   private LifecycleState lifecycleState;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormRPartA.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormRPartA.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.forms.model;
 
 import java.time.LocalDate;
+import java.util.UUID;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -32,6 +33,9 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class FormRPartA extends AbstractForm {
+
+  private UUID programmeMembershipId;
+  private Boolean isArcp;
 
   private String forename;
   private String surname;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormRPartB.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormRPartB.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.trainee.forms.model;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -33,6 +34,9 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class FormRPartB extends AbstractForm {
+
+  private UUID programmeMembershipId;
+  private Boolean isArcp;
 
   private String forename;
   private String surname;

--- a/src/test/resources/forms/testFormRPartA.json
+++ b/src/test/resources/forms/testFormRPartA.json
@@ -1,6 +1,8 @@
 {
   "id": "4e41356d-77a6-4c23-b58b-c340c2ba4bf9",
   "traineeTisId": "47165",
+  "programmeMembershipId": "155844d3-eb12-4fa2-9833-2401437a4aa0",
+  "isArcp": true,
   "forename": "Jim",
   "surname": "Williams",
   "gmcNumber": "11111111",

--- a/src/test/resources/forms/testFormRPartB.json
+++ b/src/test/resources/forms/testFormRPartB.json
@@ -1,6 +1,8 @@
 {
   "id": "2552fad7-72ad-4331-aaae-872414db5d27",
   "traineeTisId": "47165",
+  "programmeMembershipId": "155844d3-eb12-4fa2-9833-2401437a4aa0",
+  "isArcp": true,
   "forename": "John",
   "surname": "Roper",
   "gmcNumber": "8999999",


### PR DESCRIPTION
Update Form R Part A and Part B to allow a programme membership ID to be stored against the form, this will show which PM the form is being submitted for. Also include a new `isArcp` flag so the user can specify whether their submission is towards ARCP or not.

TIS21-5611
TIS21-6280