### PR TITLE
fix(formr): include PM ID in forms list

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.18.0"
+version = "0.18.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartARepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartARepository.java
@@ -35,7 +35,9 @@ public interface FormRPartARepository extends MongoRepository<FormRPartA, UUID> 
 
   Optional<FormRPartA> findByIdAndTraineeTisId(UUID id, String traineeTisId);
 
-  @Query(fields = "{traineeTisId:1, id:1, submissionDate:1, lifecycleState:1}")
+  @Query(
+      fields = "{traineeTisId:1, id:1, programmeMembershipId:1, submissionDate:1, lifecycleState:1}"
+  )
   List<FormRPartA> findByTraineeTisIdAndLifecycleState(String traineeTisId,
       LifecycleState lifecycleState);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartBRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartBRepository.java
@@ -34,7 +34,9 @@ public interface FormRPartBRepository extends MongoRepository<FormRPartB, UUID> 
 
   Optional<FormRPartB> findByIdAndTraineeTisId(UUID id, String traineeTisId);
 
-  @Query(fields = "{traineeTisId:1, id:1, submissionDate:1, lifecycleState:1}")
+  @Query(
+      fields = "{traineeTisId:1, id:1, programmeMembershipId:1, submissionDate:1, lifecycleState:1}"
+  )
   List<FormRPartB> findByTraineeTisIdAndLifecycleState(String traineeTisId,
       LifecycleState lifecycleState);
 }


### PR DESCRIPTION
The `programmeMembershipId` field is not included when looking up the simple DTOs for form lists.
Add `programmeMembershipId` to the list of query fields.

TIS21-5611