### PR TITLE
refactor: alter the expectedMetadata map for formr's to include isArc…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.18.1"
+version = "0.18.3"
 
 configurations {
   compileOnly {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.18.3"
+version = "0.19.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractForm.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractForm.java
@@ -37,9 +37,7 @@ public abstract class AbstractForm {
   @Indexed
   @Field(value = "traineeTisId")
   private String traineeTisId;
-  private Boolean isArcp;
 
-  private UUID programmeMembershipId;
   private LifecycleState lifecycleState;
   private LocalDateTime submissionDate;
   private LocalDateTime lastModifiedDate;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractForm.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractForm.java
@@ -37,7 +37,9 @@ public abstract class AbstractForm {
   @Indexed
   @Field(value = "traineeTisId")
   private String traineeTisId;
+  private Boolean isArcp;
 
+  private UUID programmeMembershipId;
   private LifecycleState lifecycleState;
   private LocalDateTime submissionDate;
   private LocalDateTime lastModifiedDate;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
@@ -20,6 +20,8 @@
 
 package uk.nhs.hee.tis.trainee.forms.repository;
 
+import static java.util.Map.entry;
+
 import com.amazonaws.AmazonServiceException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.ParameterizedType;
@@ -91,17 +93,18 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
       PutObjectRequest request = PutObjectRequest.builder()
           .bucket(bucketName)
           .key(key)
-          .metadata(Map.of(
-              "id", form.getId().toString(),
-              "name", fileName,
-              "type", "json",
-              "formtype", form.getFormType(),
-              "lifecyclestate", form.getLifecycleState().name(),
-              SUBMISSION_DATE,
-              form.getSubmissionDate().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
-              "traineeid", form.getTraineeTisId(),
-              "deletetype", DeleteType.PARTIAL.name(),
-              "fixedfields", FIXED_FIELDS
+          .metadata(Map.ofEntries(
+              entry("id", form.getId().toString()),
+              entry("name", fileName),
+              entry("type", "json"),
+              entry("isarcp", form.getIsArcp().toString()),
+              entry("programmemembershipid", form.getProgrammeMembershipId().toString()),
+              entry("formtype", form.getFormType()),
+              entry("lifecyclestate", form.getLifecycleState().name()),
+              entry(SUBMISSION_DATE, form.getSubmissionDate().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)),
+              entry("traineeid", form.getTraineeTisId()),
+              entry("deletetype", DeleteType.PARTIAL.name()),
+              entry("fixedfields", FIXED_FIELDS)
           ))
           .build();
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
@@ -101,7 +101,8 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
               entry("programmemembershipid", form.getProgrammeMembershipId().toString()),
               entry("formtype", form.getFormType()),
               entry("lifecyclestate", form.getLifecycleState().name()),
-              entry(SUBMISSION_DATE, form.getSubmissionDate().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)),
+              entry(SUBMISSION_DATE, form.getSubmissionDate()
+                  .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)),
               entry("traineeid", form.getTraineeTisId()),
               entry("deletetype", DeleteType.PARTIAL.name()),
               entry("fixedfields", FIXED_FIELDS)

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
@@ -66,6 +66,8 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
 
   private LocalDateTime localDateTime;
   private static final String SUBMISSION_DATE = "submissiondate";
+  private static final String LIFECYCLE_STATE = "lifecyclestate";
+  private static final String TRAINEE_ID = "traineeid";
   private static final String FIXED_FIELDS =
       "id,traineeTisId,lifecycleState,submissionDate,lastModifiedDate";
 
@@ -98,9 +100,10 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
           entry("name", fileName),
           entry("type", "json"),
           entry("formtype", form.getFormType()),
-          entry("lifecyclestate", form.getLifecycleState().name()),
-          entry(SUBMISSION_DATE, form.getSubmissionDate().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)),
-          entry("traineeid", form.getTraineeTisId()),
+          entry(LIFECYCLE_STATE, form.getLifecycleState().name()),
+          entry(SUBMISSION_DATE, form.getSubmissionDate()
+              .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)),
+          entry(TRAINEE_ID, form.getTraineeTisId()),
           entry("deletetype", DeleteType.PARTIAL.name()),
           entry("fixedfields", FIXED_FIELDS)
       );
@@ -125,16 +128,16 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
             entry("name", fileName),
             entry("type", "json"),
             entry("isarcp", isArcp != null ? isArcp.toString() : ""),
-            entry("programmemembershipid", programmeMembershipId != null ? programmeMembershipId.toString() : ""),
+            entry("programmemembershipid", programmeMembershipId != null
+                ? programmeMembershipId.toString() : ""),
             entry("formtype", form.getFormType()),
-            entry("lifecyclestate", form.getLifecycleState().name()),
-            entry(SUBMISSION_DATE, form.getSubmissionDate().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)),
-            entry("traineeid", form.getTraineeTisId()),
+            entry(LIFECYCLE_STATE, form.getLifecycleState().name()),
+            entry(SUBMISSION_DATE, form.getSubmissionDate()
+                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)),
+            entry(TRAINEE_ID, form.getTraineeTisId()),
             entry("deletetype", DeleteType.PARTIAL.name()),
             entry("fixedfields", FIXED_FIELDS)
         );
-      } else {
-
       }
 
       PutObjectRequest request = PutObjectRequest.builder()
@@ -175,7 +178,7 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
         Map<String, String> metadata = headObject.metadata();
         T form = getTypeClass().getConstructor().newInstance();
         form.setId(UUID.fromString(metadata.get("id")));
-        form.setTraineeTisId(metadata.get("traineeid"));
+        form.setTraineeTisId(metadata.get(TRAINEE_ID));
         try {
           form.setSubmissionDate(LocalDateTime.parse(metadata.get(SUBMISSION_DATE)));
         } catch (DateTimeParseException e) {
@@ -186,7 +189,7 @@ public abstract class AbstractCloudRepository<T extends AbstractForm> {
           form.setSubmissionDate(localDateTime);
         }
         form.setLifecycleState(
-            LifecycleState.valueOf(metadata.get("lifecyclestate")
+            LifecycleState.valueOf(metadata.get(LIFECYCLE_STATE)
                 .toUpperCase()));
         return form;
       } catch (Exception e) {

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartARepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartARepositoryImplTest.java
@@ -1,5 +1,6 @@
 package uk.nhs.hee.tis.trainee.forms.repository;
 
+import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -65,6 +66,8 @@ class S3FormRPartARepositoryImplTest {
   private static final String DEFAULT_FORENAME = "DEFAULT_FORENAME";
   private static final String DEFAULT_SURNAME = "DEFAULT_SURNAME";
   private static final LocalDateTime DEFAULT_SUBMISSION_DATE = LocalDateTime.now();
+  private static final Boolean DEFAULT_IS_ARCP = false;
+  private static final String DEFAULT_PROGRAMME_MEMBERSHIP_ID = UUID.randomUUID().toString();
   private static final String DEFAULT_SUBMISSION_DATE_STRING = DEFAULT_SUBMISSION_DATE.format(
       DateTimeFormatter.ISO_LOCAL_DATE_TIME);
   private static final String DEFAULT_FORM_ID = UUID.randomUUID().toString();
@@ -122,6 +125,8 @@ class S3FormRPartARepositoryImplTest {
     entity.setId(null);
     entity.setLifecycleState(LifecycleState.SUBMITTED);
     entity.setSubmissionDate(DEFAULT_SUBMISSION_DATE);
+    entity.setIsArcp(DEFAULT_IS_ARCP);
+    entity.setProgrammeMembershipId(UUID.fromString(DEFAULT_PROGRAMME_MEMBERSHIP_ID));
 
     FormRPartA actual = repo.save(entity);
     assertThat("Unexpected form ID.", actual.getId(), notNullValue());
@@ -131,16 +136,20 @@ class S3FormRPartARepositoryImplTest {
     assertThat("Unexpected Object Key.", actualRequest.key(),
         is(String.join("/", DEFAULT_TRAINEE_TIS_ID, "forms", FormRPartAService.FORM_TYPE,
             entity.getId() + ".json")));
-    Map<String, String> expectedMetadata = Map
-        .of("id", entity.getId().toString(), "name",
-            entity.getId() + ".json",
-            "type", "json",
-            "formtype", FormRPartAService.FORM_TYPE,
-            "lifecyclestate", LifecycleState.SUBMITTED.name(),
-            "submissiondate", DEFAULT_SUBMISSION_DATE_STRING,
-            "traineeid", DEFAULT_TRAINEE_TIS_ID,
-            "deletetype", DeleteType.PARTIAL.name(),
-            "fixedfields", FIXED_FIELDS);
+
+    Map<String, String> expectedMetadata = Map.ofEntries(
+        entry("id", entity.getId().toString()),
+        entry("name", entity.getId() + ".json"),
+        entry("type", "json"),
+        entry("isarcp", DEFAULT_IS_ARCP.toString()),
+        entry("programmemembershipid", DEFAULT_PROGRAMME_MEMBERSHIP_ID.toString()),
+        entry("formtype", FormRPartAService.FORM_TYPE),
+        entry("lifecyclestate", LifecycleState.SUBMITTED.name()),
+        entry("submissiondate", DEFAULT_SUBMISSION_DATE_STRING),
+        entry("traineeid", DEFAULT_TRAINEE_TIS_ID),
+        entry("deletetype", DeleteType.PARTIAL.name()),
+        entry("fixedfields", FIXED_FIELDS)
+    );
 
     assertThat("Unexpected metadata.", actualRequest.metadata().entrySet(),
         containsInAnyOrder(expectedMetadata.entrySet().toArray(new Entry[0])));
@@ -150,6 +159,8 @@ class S3FormRPartARepositoryImplTest {
   void shouldThrowExceptionWhenFormRPartANotSaved() {
     entity.setLifecycleState(LifecycleState.SUBMITTED);
     entity.setSubmissionDate(DEFAULT_SUBMISSION_DATE);
+    entity.setIsArcp(DEFAULT_IS_ARCP);
+    entity.setProgrammeMembershipId(UUID.fromString(DEFAULT_PROGRAMME_MEMBERSHIP_ID));
     when(s3Mock.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenThrow(
         new AmazonServiceException("Expected Exception"));
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
@@ -60,7 +60,6 @@ import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.Declaration;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
 import uk.nhs.hee.tis.trainee.forms.model.Work;
-import uk.nhs.hee.tis.trainee.forms.service.FormRPartAService;
 import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
 import uk.nhs.hee.tis.trainee.forms.service.exception.ApplicationException;
 


### PR DESCRIPTION
…p and programmeMembershipID

in order to make the isArcp flag and programmeMembershipId tied to each formr available on the FE of admins-ui these need to be within the custom-metadata. the Map.of was updated to a Map.ofEntries as there was a limit of 10 objects for Map.of which is increaded for Map.ofEntries and should have no affect on structure or utility

TICKET TIS21-6201