### PR TITLE
fix: incorrect timestamp

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.20.0"
+version = "0.20.1"
 
 configurations {
   compileOnly {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,7 @@ application:
     sqs:
       coj-received: ${COJ_RECEIVED_QUEUE:}
       delete-event: ${DELETE_EVENT_QUEUE:}
+  timezone: Europe/London
 
 features:
   formr-partb:

--- a/src/main/resources/templates/conditions-of-joining/gg10.html
+++ b/src/main/resources/templates/conditions-of-joining/gg10.html
@@ -379,7 +379,7 @@
           <dd class="nhsuk-summary-list__value">
             Signed On:
             <th:block
-              th:text="${#temporals.format(event.conditionsOfJoining.signedAt, 'dd MMMM yyyy hh:mm (z)')}"
+              th:text="${#temporals.format(event.conditionsOfJoining.signedAt, 'dd MMMM yyyy HH:mm (z)', timezone)}"
             >
               (signed date/time missing)
             </th:block>

--- a/src/main/resources/templates/conditions-of-joining/gg9.html
+++ b/src/main/resources/templates/conditions-of-joining/gg9.html
@@ -368,7 +368,7 @@
           <dd class="nhsuk-summary-list__value">
             Signed On:
             <th:block
-              th:text="${#temporals.format(event.conditionsOfJoining.signedAt, 'dd MMMM yyyy hh:mm (z)')}"
+              th:text="${#temporals.format(event.conditionsOfJoining.signedAt, 'dd MMMM yyyy HH:mm (z)', timezone)}"
             >
               (signed date/time missing)
             </th:block>

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/PdfPublisherServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/PdfPublisherServiceTest.java
@@ -38,6 +38,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -65,6 +66,8 @@ class PdfPublisherServiceTest {
   private static final UUID PROGRAMME_MEMBERSHIP_ID = UUID.randomUUID();
   private static final String PROGRAMME_NAME = "Test Programme";
 
+  private static final ZoneId TIMEZONE = ZoneId.of("Europe/London");
+
   private PdfPublisherService service;
 
   private TemplateEngine templateEngine;
@@ -80,7 +83,7 @@ class PdfPublisherServiceTest {
     snsTemplate = mock(SnsTemplate.class);
 
     service = new PdfPublisherService(templateEngine, s3Template, BUCKET_NAME, snsTemplate,
-        TOPIC_ARN);
+        TOPIC_ARN, TIMEZONE);
   }
 
   @ParameterizedTest
@@ -107,11 +110,12 @@ class PdfPublisherServiceTest {
         templateSpec.getTemplateResolutionAttributes(), nullValue());
 
     Context context = contextCaptor.getValue();
-    assertThat("Unexpected locale.", context.getLocale(), is(Locale.getDefault()));
+    assertThat("Unexpected locale.", context.getLocale(), is(Locale.ENGLISH));
 
     Set<String> variableNames = context.getVariableNames();
-    assertThat("Unexpected variable count.", variableNames.size(), is(1));
-    assertThat("Unexpected variable value.", context.getVariable("event"), is(event));
+    assertThat("Unexpected variable count.", variableNames.size(), is(2));
+    assertThat("Unexpected event value.", context.getVariable("event"), is(event));
+    assertThat("Unexpected timezone value.", context.getVariable("timezone"), is(TIMEZONE.getId()));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
The timestamp is incorrect for several reasons

 1. The default timezone is used, which is UTC when deployed, but should use London time instead.
 2. The timestamp can be out by 12 hours when the time is between 12:01 and 23:59

Add a timezone property to the application.properties, this should be defaulted to Europe/London and passed to the template engine.

Update the COJ templates to use `HH:mm` instead of `hh:mm` for the time format, eliminating the 12 hour error due to 12-hour vs 24-hour clock formatting. The timezone should also be included so the timestamp is always using London time.

TIS21-6106
TIS21-6121