### PR TITLE
chore: local application property defaults

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.21.1"
+version = "0.21.2"
 
 configurations {
   compileOnly {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,26 @@
+application:
+  environment: local
+  file-store:
+    bucket: tis-trainee-documents-upload-local
+  aws:
+    sqs:
+      coj-received: ${local.sqs-path}/tis-trainee-local-form-coj-received
+      delete-event: ${local.sqs-path}/tis-trainee-local-form-delete-event
+  signature:
+    secret-key: ${SIGNATURE_SECRET_KEY:not-very-secret-plain-text-value}
+
+local:
+  account-id: "000000000000"
+  sqs-path: ${spring.cloud.aws.endpoint}/${local.account-id}
+
+spring:
+  cloud:
+    aws:
+      credentials:
+        access-key: ${local.account-id}
+        secret-key: ${local.account-id}
+      endpoint: http://${LOCALSTACK_HOST:localhost}:4566
+      region:
+        static: eu-west-2
+      s3:
+        path-style-access-enabled: true


### PR DESCRIPTION
Create an `application-local.yml` file with sensible defaults for running this service locally.
The profile should be activated by setting
`SPRING_PROFILES_ACTIVE=local` in the env vars when running this service. No other env vars need to be set if everything is running directly on localhost, but `DB_HOST` and `LOCALSTACK_HOST` should still be set when running inside a container.
`SIGNATURE_SECRET_KEY` can still be used to ensure services all match, but a default value is provided.

There is still a pre-requisite that the queues and buckets listed in `application-local.yml` are created in the localstack instance.

NO-TICKET