### PR TITLE
feat: add LTFT count endpoint for admins

### DIFF
--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/DockerImageNames.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/DockerImageNames.java
@@ -19,35 +19,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.trainee.forms.repository;
+package uk.nhs.hee.tis.trainee.forms;
 
-import java.util.List;
-import java.util.Set;
-import org.bson.types.ObjectId;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.stereotype.Repository;
-import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
-import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
+import org.testcontainers.utility.DockerImageName;
 
 /**
- * A repository for LTFT forms.
+ * Constants for {@link DockerImageName} values used in tests to ensure consistency.
  */
-@Repository
-public interface LtftFormRepository extends MongoRepository<LtftForm, ObjectId> {
+public class DockerImageNames {
 
-  /**
-   * Find all LTFT forms belonging to the given trainee, ordered by last modified.
-   *
-   * @param traineeId The ID of the trainee.
-   * @return A list of found LTFT forms.
-   */
-  List<LtftForm> findByTraineeIdOrderByLastModified(String traineeId);
-
-  /**
-   * Count all LTFT forms with one of the given states.
-   *
-   * @param states The states to include in the count.
-   * @return The number of found LTFT forms.
-   */
-  long countByStatusIn(Set<LifecycleState> states);
+  public static final DockerImageName MONGO = DockerImageName.parse("mongo:5");
 }

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
@@ -1,0 +1,134 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.forms.DockerImageNames;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
+import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+class AdminLtftResourceIntegrationTest {
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate template;
+
+  @AfterEach
+  void tearDown() {
+    template.findAllAndRemove(new Query(), LtftForm.class);
+  }
+
+  @Test
+  void shouldReturnErrorWhenInvalidStatusFilter() throws Exception {
+    mockMvc.perform(get("/api/admin/ltft/count")
+            .param("status", "INVALID_FILTER"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldCountZeroWhenNoLtfts(String statusFilter) throws Exception {
+    mockMvc.perform(get("/api/admin/ltft/count")
+            .param("status", statusFilter))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.TEXT_PLAIN))
+        .andExpect(content().string("0"));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldCountAllLtftsWhenNoStatusFilter(String statusFilter) throws Exception {
+    List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
+        .map(s -> LtftForm.builder().status(s).build())
+        .toList();
+    template.insertAll(ltfts);
+    template.insert(LtftForm.builder().status(LifecycleState.SUBMITTED).build());
+
+    mockMvc.perform(get("/api/admin/ltft/count")
+            .param("status", statusFilter))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.TEXT_PLAIN))
+        .andExpect(content().string(String.valueOf(LifecycleState.values().length + 1)));
+  }
+
+  @ParameterizedTest
+  @EnumSource(LifecycleState.class)
+  void shouldCountMatchingLtftsWhenHasStatusFilter(LifecycleState status) throws Exception {
+    List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
+        .map(s -> LtftForm.builder().status(s).build())
+        .toList();
+    template.insertAll(ltfts);
+
+    mockMvc.perform(get("/api/admin/ltft/count")
+            .param("status", status.toString()))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.TEXT_PLAIN))
+        .andExpect(content().string(String.valueOf(1)));
+  }
+
+  @Test
+  void shouldCountMatchingLtftsWhenMultipleStatusFilters() throws Exception {
+    List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
+        .map(s -> LtftForm.builder().status(s).build())
+        .toList();
+    template.insertAll(ltfts);
+    template.insert(LtftForm.builder().status(LifecycleState.SUBMITTED).build());
+
+    String statusFilter = "%s,%s".formatted(LifecycleState.SUBMITTED, LifecycleState.UNSUBMITTED);
+    mockMvc.perform(get("/api/admin/ltft/count")
+            .param("status", statusFilter))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.TEXT_PLAIN))
+        .andExpect(content().string(String.valueOf(3)));
+  }
+}

--- a/src/integrationTest/resources/application-test.yml
+++ b/src/integrationTest/resources/application-test.yml
@@ -1,0 +1,14 @@
+application:
+  signature:
+    secret-key: test-secret-key
+
+mongock:
+  enabled: false
+
+spring:
+  cloud:
+    aws:
+      region:
+        static: eu-west-2
+      sqs:
+        enabled: false

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
@@ -19,35 +19,45 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.trainee.forms.repository;
+package uk.nhs.hee.tis.trainee.forms.api;
 
-import java.util.List;
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.Set;
-import org.bson.types.ObjectId;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.stereotype.Repository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
-import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
+import uk.nhs.hee.tis.trainee.forms.service.LtftService;
 
 /**
- * A repository for LTFT forms.
+ * A controller for admin facing Less Than Full-time (LTFT) endpoints.
  */
-@Repository
-public interface LtftFormRepository extends MongoRepository<LtftForm, ObjectId> {
+@Slf4j
+@RestController
+@RequestMapping("/api/admin/ltft")
+@XRayEnabled
+public class AdminLtftResource {
+
+  private final LtftService service;
+
+  public AdminLtftResource(LtftService service) {
+    this.service = service;
+  }
 
   /**
-   * Find all LTFT forms belonging to the given trainee, ordered by last modified.
-   *
-   * @param traineeId The ID of the trainee.
-   * @return A list of found LTFT forms.
-   */
-  List<LtftForm> findByTraineeIdOrderByLastModified(String traineeId);
-
-  /**
-   * Count all LTFT forms with one of the given states.
+   * Get a count of LTFT applications associated with the admin's local office.
    *
    * @param states The states to include in the count.
-   * @return The number of found LTFT forms.
+   * @return The number of LTFT applications found meeting the criteria.
    */
-  long countByStatusIn(Set<LifecycleState> states);
+  @GetMapping("/count")
+  public ResponseEntity<String> getAdminLtftCount(
+      @RequestParam(value = "status", required = false) Set<LifecycleState> states) {
+    long count = service.getAdminLtftCount(states);
+    return ResponseEntity.ok().contentType(MediaType.TEXT_PLAIN).body(String.valueOf(count));
+  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -23,10 +23,12 @@ package uk.nhs.hee.tis.trainee.forms.service;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.List;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.TraineeIdentity;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.mapper.LtftMapper;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 import uk.nhs.hee.tis.trainee.forms.repository.LtftFormRepository;
@@ -71,5 +73,20 @@ public class LtftService {
     log.info("Found {} LTFT forms for trainee [{}]", entities.size(), traineeId);
 
     return mapper.toSummaryDtos(entities);
+  }
+
+  /**
+   * Count all LTFT forms associated with the admin's local office.
+   *
+   * @param states The states to include in the count.
+   * @return The number of found LTFT forms.
+   */
+  public long getAdminLtftCount(Set<LifecycleState> states) {
+    if (states == null || states.isEmpty()) {
+      log.debug("No status filter provided, counting all LTFTs.");
+      return ltftFormRepository.count();
+    }
+
+    return ltftFormRepository.countByStatusIn(states);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.TEXT_PLAIN;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMITTED;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.UNSUBMITTED;
+
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.ResponseEntity;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
+import uk.nhs.hee.tis.trainee.forms.service.LtftService;
+
+class AdminLtftResourceTest {
+
+  private AdminLtftResource controller;
+  private LtftService service;
+
+  @BeforeEach
+  void setUp() {
+    service = mock(LtftService.class);
+    controller = new AdminLtftResource(service);
+  }
+
+  @Test
+  void shouldGetCountUsingStatusFilter() {
+    Set<LifecycleState> states = Set.of(UNSUBMITTED, SUBMITTED);
+
+    controller.getAdminLtftCount(states);
+
+    ArgumentCaptor<Set<LifecycleState>> statesCaptor = ArgumentCaptor.captor();
+    verify(service).getAdminLtftCount(statesCaptor.capture());
+
+    Set<LifecycleState> capturedStates = statesCaptor.getValue();
+    assertThat("Unexpected filter state count.", capturedStates, hasSize(2));
+    assertThat("Unexpected filter states.", capturedStates, hasItems(UNSUBMITTED, SUBMITTED));
+  }
+
+  @Test
+  void shouldGetCountResponse() {
+    when(service.getAdminLtftCount(any())).thenReturn(40L);
+
+    ResponseEntity<String> response = controller.getAdminLtftCount(Set.of());
+
+    assertThat("Unexpected response code.", response.getStatusCode().value(), is(200));
+    assertThat("Unexpected response body.", response.getBody(), is("40"));
+    assertThat("Unexpected response type.", response.getHeaders().getContentType(), is(TEXT_PLAIN));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.TEXT_PLAIN;
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMITTED;
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.UNSUBMITTED;
@@ -72,7 +73,7 @@ class AdminLtftResourceTest {
 
     ResponseEntity<String> response = controller.getAdminLtftCount(Set.of());
 
-    assertThat("Unexpected response code.", response.getStatusCode().value(), is(200));
+    assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
     assertThat("Unexpected response body.", response.getBody(), is("40"));
     assertThat("Unexpected response type.", response.getHeaders().getContentType(), is(TEXT_PLAIN));
   }


### PR DESCRIPTION
Add an endpoint `/api/admin/ltft/count` which will return a count of LTFT applications that are associated with an admin's local office. The result should be filterable on status, but passing a URL parameter such `status=UNSUBMITTED,SUBMITTED`.

Local office filtering will follow, only status filtering will be supported at this point.

Refactor the Gradle build script to create an integration test suite separate from the existing test suite. This integration suite will make full use of test containers to allow testing of several layers, from API, through service, to repository.
Existing integration tests have not been moved yet.

TIS21-6599
TIS21-6938