### PR TITLE
refactor: form inheritance

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.23.0"
+version = "0.23.1"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
@@ -89,10 +89,17 @@ class AdminLtftResourceIntegrationTest {
   @NullAndEmptySource
   void shouldCountAllLtftsWhenNoStatusFilter(String statusFilter) throws Exception {
     List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
-        .map(s -> LtftForm.builder().status(s).build())
+        .map(s -> {
+          LtftForm ltft = new LtftForm();
+          ltft.setStatus(s);
+          return ltft;
+        })
         .toList();
     template.insertAll(ltfts);
-    template.insert(LtftForm.builder().status(LifecycleState.SUBMITTED).build());
+
+    LtftForm ltft = new LtftForm();
+    ltft.setStatus(LifecycleState.SUBMITTED);
+    template.insert(ltft);
 
     mockMvc.perform(get("/api/admin/ltft/count")
             .param("status", statusFilter))
@@ -105,7 +112,11 @@ class AdminLtftResourceIntegrationTest {
   @EnumSource(LifecycleState.class)
   void shouldCountMatchingLtftsWhenHasStatusFilter(LifecycleState status) throws Exception {
     List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
-        .map(s -> LtftForm.builder().status(s).build())
+        .map(s -> {
+          LtftForm ltft = new LtftForm();
+          ltft.setStatus(s);
+          return ltft;
+        })
         .toList();
     template.insertAll(ltfts);
 
@@ -119,10 +130,17 @@ class AdminLtftResourceIntegrationTest {
   @Test
   void shouldCountMatchingLtftsWhenMultipleStatusFilters() throws Exception {
     List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
-        .map(s -> LtftForm.builder().status(s).build())
+        .map(s -> {
+          LtftForm ltft = new LtftForm();
+          ltft.setStatus(s);
+          return ltft;
+        })
         .toList();
     template.insertAll(ltfts);
-    template.insert(LtftForm.builder().status(LifecycleState.SUBMITTED).build());
+
+    LtftForm ltft = new LtftForm();
+    ltft.setStatus(LifecycleState.SUBMITTED);
+    template.insert(ltft);
 
     String statusFilter = "%s,%s".formatted(LifecycleState.SUBMITTED, LifecycleState.UNSUBMITTED);
     mockMvc.perform(get("/api/admin/ltft/count")

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftSummaryDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftSummaryDto.java
@@ -21,12 +21,9 @@
 
 package uk.nhs.hee.tis.trainee.forms.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
-import org.bson.types.ObjectId;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 
 /**
@@ -34,8 +31,7 @@ import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
  */
 @Builder
 public record LtftSummaryDto(
-    @JsonSerialize(using = ToStringSerializer.class)
-    ObjectId id,
+    UUID id,
 
     String name,
     UUID programmeMembershipId,

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractAuditedForm.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractAuditedForm.java
@@ -22,60 +22,20 @@
 package uk.nhs.hee.tis.trainee.forms.model;
 
 import java.time.Instant;
-import java.time.LocalDate;
-import java.util.UUID;
-import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.mongodb.core.index.Indexed;
-import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.data.mongodb.core.mapping.Field;
-import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 
-/**
- * A LTFT form entity.
- */
-@Document("LtftForm")
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class LtftForm extends AbstractAuditedForm {
+public abstract class AbstractAuditedForm extends AbstractForm {
 
-  String name;
-  LtftProgrammeMembership programmeMembership;
-  LifecycleState status;
+  @CreatedDate
+  Instant created;
 
-  @Override
-  public String getFormType() {
-    return "ltft";
-  }
-
-  @Override
-  public LifecycleState getLifecycleState() {
-    return status;
-  }
-
-  /**
-   * Programme membership data for a calculation.
-   *
-   * @param id        The ID of the programme membership.
-   * @param name      The name of the programme.
-   * @param startDate The start date of the programme.
-   * @param endDate   The end date of the programme.
-   * @param wte       The whole time equivalent of the programme membership.
-   */
-  @Builder
-  public record LtftProgrammeMembership(
-      @Indexed
-      @Field("id")
-      UUID id,
-      String name,
-      LocalDate startDate,
-      LocalDate endDate,
-      double wte) {
-
-  }
+  @LastModifiedDate
+  Instant lastModified;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractForm.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractForm.java
@@ -21,7 +21,6 @@
 package uk.nhs.hee.tis.trainee.forms.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
@@ -38,10 +37,8 @@ public abstract class AbstractForm {
   @Field(value = "traineeTisId")
   private String traineeTisId;
 
-  private LifecycleState lifecycleState;
-  private LocalDateTime submissionDate;
-  private LocalDateTime lastModifiedDate;
-
   @JsonIgnore
   public abstract String getFormType();
+
+  public abstract LifecycleState getLifecycleState();
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractFormR.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractFormR.java
@@ -21,61 +21,21 @@
 
 package uk.nhs.hee.tis.trainee.forms.model;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.util.UUID;
-import lombok.Builder;
+import java.time.LocalDateTime;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.mongodb.core.index.Indexed;
-import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.data.mongodb.core.mapping.Field;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 
-/**
- * A LTFT form entity.
- */
-@Document("LtftForm")
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class LtftForm extends AbstractAuditedForm {
+public abstract class AbstractFormR extends AbstractForm {
 
-  String name;
-  LtftProgrammeMembership programmeMembership;
-  LifecycleState status;
+  @Setter
+  private LifecycleState lifecycleState;
+  private LocalDateTime submissionDate;
+  private LocalDateTime lastModifiedDate;
 
-  @Override
-  public String getFormType() {
-    return "ltft";
-  }
-
-  @Override
-  public LifecycleState getLifecycleState() {
-    return status;
-  }
-
-  /**
-   * Programme membership data for a calculation.
-   *
-   * @param id        The ID of the programme membership.
-   * @param name      The name of the programme.
-   * @param startDate The start date of the programme.
-   * @param endDate   The end date of the programme.
-   * @param wte       The whole time equivalent of the programme membership.
-   */
-  @Builder
-  public record LtftProgrammeMembership(
-      @Indexed
-      @Field("id")
-      UUID id,
-      String name,
-      LocalDate startDate,
-      LocalDate endDate,
-      double wte) {
-
-  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormRPartA.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormRPartA.java
@@ -32,7 +32,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class FormRPartA extends AbstractForm {
+public class FormRPartA extends AbstractFormR {
 
   private UUID programmeMembershipId;
   private Boolean isArcp;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormRPartB.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormRPartB.java
@@ -33,7 +33,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class FormRPartB extends AbstractForm {
+public class FormRPartB extends AbstractFormR {
 
   private UUID programmeMembershipId;
   private Boolean isArcp;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
@@ -51,14 +51,14 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.DeleteType;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
-import uk.nhs.hee.tis.trainee.forms.model.AbstractForm;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractFormR;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
 import uk.nhs.hee.tis.trainee.forms.service.exception.ApplicationException;
 
 @Slf4j
 @Transactional
-public abstract class AbstractCloudRepository<T extends AbstractForm> {
+public abstract class AbstractCloudRepository<T extends AbstractFormR> {
 
   protected final S3Client s3Client;
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
@@ -41,7 +41,7 @@ public interface LtftFormRepository extends MongoRepository<LtftForm, ObjectId> 
    * @param traineeId The ID of the trainee.
    * @return A list of found LTFT forms.
    */
-  List<LtftForm> findByTraineeIdOrderByLastModified(String traineeId);
+  List<LtftForm> findByTraineeTisIdOrderByLastModified(String traineeId);
 
   /**
    * Count all LTFT forms with one of the given states.

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -68,7 +68,7 @@ public class LtftService {
     String traineeId = traineeIdentity.getTraineeId();
     log.info("Getting LTFT forms for trainee [{}]", traineeId);
 
-    List<LtftForm> entities = ltftFormRepository.findByTraineeIdOrderByLastModified(
+    List<LtftForm> entities = ltftFormRepository.findByTraineeTisIdOrderByLastModified(
         traineeId);
     log.info("Found {} LTFT forms for trainee [{}]", entities.size(), traineeId);
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.OK;
 
 import java.util.List;
-import org.bson.types.ObjectId;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
@@ -59,12 +59,12 @@ class LtftResourceTest {
 
   @Test
   void shouldGetLtftSummariesWhenLtftFormsExist() {
-    ObjectId id1 = ObjectId.get();
+    UUID id1 = UUID.randomUUID();
     LtftSummaryDto dto1 = LtftSummaryDto.builder()
         .id(id1)
         .name("Test LTFT 1")
         .build();
-    ObjectId id2 = ObjectId.get();
+    UUID id2 = UUID.randomUUID();
     LtftSummaryDto dto2 = LtftSummaryDto.builder()
         .id(id2)
         .name("Test LTFT 2")

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/model/AbstractFormMongoEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/model/AbstractFormMongoEventListenerTest.java
@@ -65,7 +65,7 @@ class AbstractFormMongoEventListenerTest {
   /**
    * A stub for testing the behaviour of the AbstractForm event listener.
    */
-  private static class StubForm extends AbstractForm {
+  private static class StubForm extends AbstractFormR {
 
     @Override
     public String getFormType() {

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -34,7 +34,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -66,7 +65,7 @@ class LtftServiceTest {
 
   @Test
   void shouldReturnEmptyGettingLtftFormsWhenNotFound() {
-    when(ltftRepository.findByTraineeIdOrderByLastModified(TRAINEE_ID)).thenReturn(
+    when(ltftRepository.findByTraineeTisIdOrderByLastModified(TRAINEE_ID)).thenReturn(
         List.of());
 
     List<LtftSummaryDto> result = service.getLtftSummaries();
@@ -76,39 +75,37 @@ class LtftServiceTest {
 
   @Test
   void shouldGetLtftFormsWhenFound() {
-    ObjectId ltftId1 = ObjectId.get();
+    UUID ltftId1 = UUID.randomUUID();
     UUID pmId1 = UUID.randomUUID();
     Instant created1 = Instant.now().minus(Duration.ofDays(1));
     Instant lastModified1 = Instant.now().plus(Duration.ofDays(1));
 
-    LtftForm entity1 = LtftForm.builder()
-        .id(ltftId1)
-        .traineeId(TRAINEE_ID)
-        .name("Test LTFT form 1")
-        .programmeMembership(LtftProgrammeMembership.builder()
-            .id(pmId1)
-            .build())
-        .created(created1)
-        .lastModified(lastModified1)
-        .build();
+    LtftForm entity1 = new LtftForm();
+    entity1.setId(ltftId1);
+    entity1.setTraineeTisId(TRAINEE_ID);
+    entity1.setName("Test LTFT form 1");
+    entity1.setProgrammeMembership(LtftProgrammeMembership.builder()
+        .id(pmId1)
+        .build());
+    entity1.setCreated(created1);
+    entity1.setLastModified(lastModified1);
 
-    ObjectId ltftId2 = ObjectId.get();
+    UUID ltftId2 = UUID.randomUUID();
     UUID pmId2 = UUID.randomUUID();
     Instant created2 = Instant.now().minus(Duration.ofDays(2));
     Instant lastModified2 = Instant.now().plus(Duration.ofDays(2));
 
-    LtftForm entity2 = LtftForm.builder()
-        .id(ltftId2)
-        .traineeId(TRAINEE_ID)
-        .name("Test LTFT form 2")
-        .programmeMembership(LtftProgrammeMembership.builder()
-            .id(pmId2)
-            .build())
-        .created(created2)
-        .lastModified(lastModified2)
-        .build();
+    LtftForm entity2 = new LtftForm();
+    entity2.setId(ltftId2);
+    entity2.setTraineeTisId(TRAINEE_ID);
+    entity2.setName("Test LTFT form 2");
+    entity2.setProgrammeMembership(LtftProgrammeMembership.builder()
+        .id(pmId2)
+        .build());
+    entity2.setCreated(created2);
+    entity2.setLastModified(lastModified2);
 
-    when(ltftRepository.findByTraineeIdOrderByLastModified(TRAINEE_ID)).thenReturn(
+    when(ltftRepository.findByTraineeTisIdOrderByLastModified(TRAINEE_ID)).thenReturn(
         List.of(entity1, entity2));
 
     List<LtftSummaryDto> result = service.getLtftSummaries();


### PR DESCRIPTION
Refactor the AbstractForm, Form Rs and LtftForm in to a shared, more consistent hierarchy.
Since LTFT will have a state audit history included the structure for lifecycle state and submission date will change, so those should be moved to an abstract class shared by just the existing forms (FormR Part A and B). Additionally the lastModified field will be an Instant instead of LocalDateTime, so that field should also be moved so it is only used by FormRs in its current form.

The LTFT form has been refactored to follow the conventions set by FormR, so the builder has been removed until the forms can be refactored again in sync.

NO-TICKET