### PR TITLE
fix: set created date when updating form

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.24.1"
+version = "0.24.2"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
@@ -34,6 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -323,7 +324,6 @@ class LtftResourceIntegrationTest {
     formToUpdate.setTraineeTisId(TRAINEE_ID);
     formToUpdate.setId(savedId);
     formToUpdate.setName("updated");
-    formToUpdate.setCreated(formSaved.getCreated()); //otherwise it is assumed to be a new form
 
     String formToUpdateJson = mapper.writeValueAsString(formToUpdate);
     String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
@@ -336,7 +336,7 @@ class LtftResourceIntegrationTest {
         .andExpect(jsonPath("$.traineeTisId").value(TRAINEE_ID))
         .andExpect(jsonPath("$.name").value("updated"))
         .andExpect(jsonPath("$.created").value(
-            formSaved.getCreated().toString()))
+            formSaved.getCreated().truncatedTo(ChronoUnit.MILLIS).toString()))
         .andExpect(jsonPath("$.lastModified",
             greaterThan(formSaved.getLastModified().toString())));
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -156,6 +156,7 @@ public class LtftService {
           formId, traineeId);
       return Optional.empty();
     }
+    form.setCreated(existingForm.get().getCreated()); //explicitly set otherwise form saved as 'new'
     LtftForm savedForm = ltftFormRepository.save(form);
     return Optional.of(mapper.toDto(savedForm));
   }


### PR DESCRIPTION
HACK

Without success I've tried the suggested workarounds on https://github.com/spring-projects/spring-data-rest/issues/1565  (`@JsonIgnore` or `@JsonProperty(access = JsonProperty.Access.READ_ONLY)` on the created field. Making the field final introduced other issues with inheritance, so I didn't pursue it. Using `@Version` on a new field and changing the `isNew()` code to refer to this made no difference either. 

(We don't actually use spring-data-rest specifically, but it seemed the clearest explanation of the issue from much googling around).

Heroic efforts by the author here: https://stackoverflow.com/questions/68441685/spring-data-mongodb-how-to-avoid-createdby-and-createddate-fields-update - but I'm not sure how much we want to pervert the MongoTemplate to our own base desires.

Likewise, using spring-data-jdbc might offer some slightly lower-level interventions (e.g. `@InsertOnlyProperty`) but I don't know if we want to go there. It seems we might still have to better control whether mongo uses full updates / partial updates (if I'm understanding the comments on https://stackoverflow.com/questions/73051733/createddate-set-to-null-on-update-spring-data-jdbc correctly).

TIS21-6792