### PR TITLE
feat: filter admin LTFT count by DBCs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-
-version = "0.25.0"
+version = "0.26.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
@@ -47,6 +47,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -60,6 +61,7 @@ import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent.Discussions;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @Testcontainers
 @AutoConfigureMockMvc
 class LtftResourceIntegrationTest {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartARepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartARepositoryIntegrationTest.java
@@ -46,6 +46,7 @@ import org.springframework.data.mongodb.core.index.IndexField;
 import org.springframework.data.mongodb.core.index.IndexInfo;
 import org.springframework.data.mongodb.core.index.IndexOperations;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -53,6 +54,7 @@ import uk.nhs.hee.tis.trainee.forms.DockerImageNames;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @Testcontainers
 class FormRPartARepositoryIntegrationTest {
 

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartBRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartBRepositoryIntegrationTest.java
@@ -46,6 +46,7 @@ import org.springframework.data.mongodb.core.index.IndexField;
 import org.springframework.data.mongodb.core.index.IndexInfo;
 import org.springframework.data.mongodb.core.index.IndexOperations;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -53,6 +54,7 @@ import uk.nhs.hee.tis.trainee.forms.DockerImageNames;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @Testcontainers
 class FormRPartBRepositoryIntegrationTest {
 

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/LtftRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/LtftRepositoryIntegrationTest.java
@@ -49,6 +49,7 @@ import org.springframework.data.mongodb.core.index.IndexField;
 import org.springframework.data.mongodb.core.index.IndexInfo;
 import org.springframework.data.mongodb.core.index.IndexOperations;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -57,6 +58,7 @@ import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @Testcontainers
 class LtftRepositoryIntegrationTest {
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
@@ -45,12 +45,21 @@ public interface LtftFormRepository extends MongoRepository<LtftForm, UUID> {
   List<LtftForm> findByTraineeTisIdOrderByLastModified(String traineeId);
 
   /**
-   * Count all LTFT forms with one of the given current states.
+   * Count all LTFT forms with one of the given DBCs.
+   *
+   * @param dbcs The designated body codes to include in the count.
+   * @return The number of found LTFT forms.
+   */
+  long countByContent_ProgrammeMembership_DesignatedBodyCodeIn(Set<String> dbcs);
+
+  /**
+   * Count all LTFT forms with one of the given current states and DBCs.
    *
    * @param states The states to include in the count.
    * @return The number of found LTFT forms.
    */
-  long countByStatus_Current_StateIn(Set<LifecycleState> states);
+  long countByStatus_Current_StateInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+      Set<LifecycleState> states, Set<String> dbcs);
 
   /**
    * Find the LTFT form with the given id that belongs to the given trainee.


### PR DESCRIPTION
Filter the result of the admin LTFT count endpoint based on the DBCs that the admin user is assigned to.
The DBCs are set as a Cognito group and added to the auth token as `cognito:groups`.
This may include non-DBC groups at some point, but those should never match a PM's DBC anyway.

TIS21-6599
TIS21-6938