### PR TITLE
feat(ltft): admin summary endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.26.0"
+version = "0.27.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
@@ -21,20 +21,30 @@
 
 package uk.nhs.hee.tis.trainee.forms.api;
 
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.DRAFT;
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMITTED;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.UNSUBMITTED;
 
+import java.net.URI;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -42,6 +52,7 @@ import org.springframework.boot.testcontainers.service.connection.ServiceConnect
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -54,8 +65,13 @@ import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status;
 import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status.StatusInfo;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
+import uk.nhs.hee.tis.trainee.forms.model.Person;
+import uk.nhs.hee.tis.trainee.forms.model.content.CctChange;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
+import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent.Discussions;
+import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent.PersonalDetails;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent.ProgrammeMembership;
+import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent.Reasons;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -82,35 +98,51 @@ class AdminLtftResourceIntegrationTest {
     template.findAllAndRemove(new Query(), LtftForm.class);
   }
 
-  @Test
-  void shouldReturnForbiddenForCountWhenNoToken() throws Exception {
-    mockMvc.perform(get("/api/admin/ltft/count"))
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      GET | /api/admin/ltft
+      GET | /api/admin/ltft/count
+      """)
+  void shouldReturnForbiddenWhenNoToken(HttpMethod method, URI uri) throws Exception {
+    mockMvc.perform(request(method, uri))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$").doesNotExist());
   }
 
-  @Test
-  void shouldReturnForbiddenForCountWhenEmptyToken() throws Exception {
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      GET | /api/admin/ltft
+      GET | /api/admin/ltft/count
+      """)
+  void shouldReturnForbiddenWhenEmptyToken(HttpMethod method, URI uri) throws Exception {
     String token = TestJwtUtil.generateToken("{}");
-    mockMvc.perform(get("/api/admin/ltft/count")
+    mockMvc.perform(request(method, uri)
             .header(HttpHeaders.AUTHORIZATION, token))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$").doesNotExist());
   }
 
-  @Test
-  void shouldReturnForbiddenForCountWhenNoGroupsInToken() throws Exception {
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      GET | /api/admin/ltft
+      GET | /api/admin/ltft/count
+      """)
+  void shouldReturnForbiddenWhenNoGroupsInToken(HttpMethod method, URI uri) throws Exception {
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of());
-    mockMvc.perform(get("/api/admin/ltft/count")
+    mockMvc.perform(request(method, uri)
             .header(HttpHeaders.AUTHORIZATION, token))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$").doesNotExist());
   }
 
-  @Test
-  void shouldReturnBadRequestForCountWhenInvalidStatusFilter() throws Exception {
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      GET | /api/admin/ltft
+      GET | /api/admin/ltft/count
+      """)
+  void shouldReturnBadRequestWhenInvalidStatusFilter(HttpMethod method, URI uri) throws Exception {
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
-    mockMvc.perform(get("/api/admin/ltft/count")
+    mockMvc.perform(request(method, uri)
             .header(HttpHeaders.AUTHORIZATION, token)
             .param("status", "INVALID_FILTER"))
         .andExpect(status().isBadRequest());
@@ -216,6 +248,301 @@ class AdminLtftResourceIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.TEXT_PLAIN))
         .andExpect(content().string(String.valueOf(3)));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldReturnNoSummariesWhenNoLtfts(String statusFilter) throws Exception {
+    String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
+    mockMvc.perform(get("/api/admin/ltft")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .param("status", statusFilter))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content", hasSize(0)))
+        .andExpect(jsonPath("$.page", aMapWithSize(4)))
+        .andExpect(jsonPath("$.page.size", is(2000)))
+        .andExpect(jsonPath("$.page.number", is(0)))
+        .andExpect(jsonPath("$.page.totalElements", is(0)))
+        .andExpect(jsonPath("$.page.totalPages", is(0)));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldReturnNoSummariesWhenNoLtftsWithMatchingDbc(String statusFilter) throws Exception {
+    template.insert(createLtftForm(SUBMITTED, DBC_2));
+
+    String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
+    mockMvc.perform(get("/api/admin/ltft")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .param("status", statusFilter))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content", hasSize(0)))
+        .andExpect(jsonPath("$.page", aMapWithSize(4)))
+        .andExpect(jsonPath("$.page.size", is(2000)))
+        .andExpect(jsonPath("$.page.number", is(0)))
+        .andExpect(jsonPath("$.page.totalElements", is(0)))
+        .andExpect(jsonPath("$.page.totalPages", is(0)));
+  }
+
+  @Test
+  void shouldReturnSummaryContentWhenLtftWithMatchingDbc() throws Exception {
+    LocalDate startDate = LocalDate.now().plusWeeks(20);
+
+    LtftForm form = new LtftForm();
+    form.setTraineeTisId("47165");
+
+    LtftContent content = LtftContent.builder()
+        .personalDetails(PersonalDetails.builder()
+            .forenames("Anthony").surname("Gilliam").gmcNumber("1234567").gdcNumber("D123456")
+            .build())
+        .programmeMembership(ProgrammeMembership.builder()
+            .name("General Practice").designatedBodyCode(DBC_1)
+            .build())
+        .change(CctChange.builder()
+            .startDate(startDate)
+            .build())
+        .reasons(Reasons.builder()
+            .selected(List.of("Caring responsibilities"))
+            .build())
+        .discussions(Discussions.builder()
+            .tpdEmail("tpd@example.com")
+            .build())
+        .assignedAdmin(Person.builder()
+            .name("Ad Min").email("ad.min@example.com").role("ADMIN")
+            .build())
+        .build();
+    form.setContent(content);
+
+    StatusInfo statusInfo = StatusInfo.builder()
+        .state(SUBMITTED).timestamp(Instant.now())
+        .build();
+    form.setStatus(Status.builder()
+        .current(statusInfo).history(List.of(statusInfo))
+        .build()
+    );
+
+    form = template.insert(form);
+
+    String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
+    mockMvc.perform(get("/api/admin/ltft")
+            .header(HttpHeaders.AUTHORIZATION, token))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.content[0].id", is(form.getId().toString())))
+        .andExpect(jsonPath("$.content[0].personalDetails.id", is("47165")))
+        .andExpect(jsonPath("$.content[0].personalDetails.forenames", is("Anthony")))
+        .andExpect(jsonPath("$.content[0].personalDetails.surname", is("Gilliam")))
+        .andExpect(jsonPath("$.content[0].personalDetails.gmcNumber", is("1234567")))
+        .andExpect(jsonPath("$.content[0].personalDetails.gdcNumber", is("D123456")))
+        .andExpect(jsonPath("$.content[0].programmeName", is("General Practice")))
+        .andExpect(jsonPath("$.content[0].proposedStartDate", is(startDate.toString())))
+        .andExpect(jsonPath("$.content[0].submissionDate", is(LocalDate.now().toString())))
+        .andExpect(jsonPath("$.content[0].reason", is("TODO")))
+        .andExpect(jsonPath("$.content[0].daysToStart", is(40)))
+        .andExpect(jsonPath("$.content[0].shortNotice", is(false)))
+        .andExpect(jsonPath("$.content[0].tpd.email", is("tpd@example.com")))
+        .andExpect(jsonPath("$.content[0].tpd.emailStatus", is("TODO")))
+        .andExpect(jsonPath("$.content[0].status", is(SUBMITTED.name())))
+        .andExpect(jsonPath("$.content[0].assignedAdmin.name", is("Ad Min")))
+        .andExpect(jsonPath("$.content[0].assignedAdmin.email", is("ad.min@example.com")))
+        .andExpect(jsonPath("$.content[0].assignedAdmin.role").doesNotExist())
+        .andExpect(jsonPath("$.page", aMapWithSize(4)))
+        .andExpect(jsonPath("$.page.size", is(2000)))
+        .andExpect(jsonPath("$.page.number", is(0)))
+        .andExpect(jsonPath("$.page.totalElements", is(1)))
+        .andExpect(jsonPath("$.page.totalPages", is(1)));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldOnlyReturnSummariesWithMatchingDbcWhenNoStatusFilter(String statusFilter)
+      throws Exception {
+    List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
+        .map(s -> createLtftForm(s, DBC_1))
+        .toList();
+    template.insertAll(ltfts);
+
+    template.insert(createLtftForm(SUBMITTED, DBC_1));
+    template.insert(createLtftForm(SUBMITTED, DBC_2));
+
+    int expectedCount = LifecycleState.values().length + 1;
+
+    String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
+    mockMvc.perform(get("/api/admin/ltft")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .param("status", statusFilter))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content", hasSize(expectedCount)))
+        .andExpect(jsonPath("$.page", aMapWithSize(4)))
+        .andExpect(jsonPath("$.page.size", is(2000)))
+        .andExpect(jsonPath("$.page.number", is(0)))
+        .andExpect(jsonPath("$.page.totalElements", is(expectedCount)))
+        .andExpect(jsonPath("$.page.totalPages", is(1)));
+  }
+
+  @ParameterizedTest
+  @EnumSource(LifecycleState.class)
+  void shouldOnlyReturnSummariesWithMatchingDbcWhenHasStatusFilter(LifecycleState status)
+      throws Exception {
+    List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
+        .map(s -> createLtftForm(s, DBC_1))
+        .toList();
+    template.insertAll(ltfts);
+
+    template.insert(createLtftForm(status, DBC_2));
+
+    String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
+    mockMvc.perform(get("/api/admin/ltft")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .param("status", status.toString()))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.content[0].status", is(status.toString())))
+        .andExpect(jsonPath("$.page", aMapWithSize(4)))
+        .andExpect(jsonPath("$.page.size", is(2000)))
+        .andExpect(jsonPath("$.page.number", is(0)))
+        .andExpect(jsonPath("$.page.totalElements", is(1)))
+        .andExpect(jsonPath("$.page.totalPages", is(1)));
+  }
+
+  @Test
+  void shouldReturnMatchingLtftSummariesWhenMultipleDbcs() throws Exception {
+    List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
+        .map(s -> createLtftForm(s, DBC_1))
+        .toList();
+    template.insertAll(ltfts);
+
+    template.insert(createLtftForm(SUBMITTED, DBC_2));
+
+    int expectedCount = LifecycleState.values().length + 1;
+
+    String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1, DBC_2));
+    mockMvc.perform(get("/api/admin/ltft")
+            .header(HttpHeaders.AUTHORIZATION, token))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content", hasSize(expectedCount)))
+        .andExpect(jsonPath("$.page", aMapWithSize(4)))
+        .andExpect(jsonPath("$.page.size", is(2000)))
+        .andExpect(jsonPath("$.page.number", is(0)))
+        .andExpect(jsonPath("$.page.totalElements", is(expectedCount)))
+        .andExpect(jsonPath("$.page.totalPages", is(1)));
+  }
+
+  @Test
+  void shouldReturnMatchingLtftSummariesWhenMultipleStatusFilters() throws Exception {
+    List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
+        .map(s -> createLtftForm(s, DBC_1))
+        .toList();
+    template.insertAll(ltfts);
+
+    template.insert(createLtftForm(SUBMITTED, DBC_1));
+
+    String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
+    String statusFilter = "%s,%s".formatted(SUBMITTED, LifecycleState.UNSUBMITTED);
+    mockMvc.perform(get("/api/admin/ltft")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .param("status", statusFilter))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content", hasSize(3)))
+        .andExpect(jsonPath("$.content[0].status", is(SUBMITTED.toString())))
+        .andExpect(jsonPath("$.content[1].status", is(UNSUBMITTED.toString())))
+        .andExpect(jsonPath("$.content[2].status", is(SUBMITTED.toString())))
+        .andExpect(jsonPath("$.page", aMapWithSize(4)))
+        .andExpect(jsonPath("$.page.size", is(2000)))
+        .andExpect(jsonPath("$.page.number", is(0)))
+        .andExpect(jsonPath("$.page.totalElements", is(3)))
+        .andExpect(jsonPath("$.page.totalPages", is(1)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 2})
+  void shouldPageLtftSummariesWhenTooManyResults(int pageNumber) throws Exception {
+    List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
+        .map(s -> createLtftForm(s, DBC_1))
+        .toList();
+    template.insertAll(ltfts);
+
+    template.insert(createLtftForm(SUBMITTED, DBC_1));
+
+    String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
+    String statusFilter = "%s,%s".formatted(SUBMITTED, LifecycleState.UNSUBMITTED);
+    mockMvc.perform(get("/api/admin/ltft")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .param("status", statusFilter)
+            .param("size", "1")
+            .param("page", String.valueOf(pageNumber)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.page", aMapWithSize(4)))
+        .andExpect(jsonPath("$.page.size", is(1)))
+        .andExpect(jsonPath("$.page.number", is(pageNumber)))
+        .andExpect(jsonPath("$.page.totalElements", is(3)))
+        .andExpect(jsonPath("$.page.totalPages", is(3)));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldSortLtftSummariesByCreatedWhenNoSortProvided(String sort) throws Exception {
+    LtftForm form1 = template.insert(createLtftForm(SUBMITTED, DBC_1));
+    LtftForm form2 = template.insert(createLtftForm(SUBMITTED, DBC_1));
+    LtftForm form3 = template.insert(createLtftForm(SUBMITTED, DBC_1));
+
+    String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
+    mockMvc.perform(get("/api/admin/ltft")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .param("sort", sort))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content", hasSize(3)))
+        .andExpect(jsonPath("$.content[0].id", is(form1.getId().toString())))
+        .andExpect(jsonPath("$.content[1].id", is(form2.getId().toString())))
+        .andExpect(jsonPath("$.content[2].id", is(form3.getId().toString())))
+        .andExpect(jsonPath("$.page", aMapWithSize(4)))
+        .andExpect(jsonPath("$.page.size", is(2000)))
+        .andExpect(jsonPath("$.page.number", is(0)))
+        .andExpect(jsonPath("$.page.totalElements", is(3)))
+        .andExpect(jsonPath("$.page.totalPages", is(1)));
+  }
+
+  @Test
+  void shouldSortLtftSummariesByProvidedSortWhenSortProvided() throws Exception {
+    LtftForm form1 = template.insert(createLtftForm(UNSUBMITTED, DBC_1));
+    LtftForm form2 = template.insert(createLtftForm(SUBMITTED, DBC_1));
+    LtftForm form3 = template.insert(createLtftForm(DRAFT, DBC_1));
+
+    String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
+    mockMvc.perform(get("/api/admin/ltft")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .param("sort", "status.current.state"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content", hasSize(3)))
+        .andExpect(jsonPath("$.content[0].id", is(form3.getId().toString())))
+        .andExpect(jsonPath("$.content[1].id", is(form2.getId().toString())))
+        .andExpect(jsonPath("$.content[2].id", is(form1.getId().toString())))
+        .andExpect(jsonPath("$.page", aMapWithSize(4)))
+        .andExpect(jsonPath("$.page.size", is(2000)))
+        .andExpect(jsonPath("$.page.number", is(0)))
+        .andExpect(jsonPath("$.page.totalElements", is(3)))
+        .andExpect(jsonPath("$.page.totalPages", is(1)));
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
@@ -24,12 +24,18 @@ package uk.nhs.hee.tis.trainee.forms.api;
 import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.PagedModel;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.service.LtftService;
 
@@ -59,5 +65,21 @@ public class AdminLtftResource {
       @RequestParam(value = "status", required = false) Set<LifecycleState> states) {
     long count = service.getAdminLtftCount(states);
     return ResponseEntity.ok().contentType(MediaType.TEXT_PLAIN).body(String.valueOf(count));
+  }
+
+  /**
+   * Get the LTFT application summaries associated with the admin's local office.
+   *
+   * @param pageable The desired paging and sorting details, defaults to all records sorted by
+   *                 submission date.
+   * @return A page of LTFT summaries meeting the criteria.
+   */
+  @GetMapping
+  ResponseEntity<PagedModel<LtftAdminSummaryDto>> getLtftAdminSummaries(
+      @RequestParam(value = "status", required = false) Set<LifecycleState> states,
+      @PageableDefault(size = Integer.MAX_VALUE, sort = "created", direction = Direction.ASC)
+      Pageable pageable) {
+    Page<LtftAdminSummaryDto> page = service.getAdminLtftSummaries(states, pageable);
+    return ResponseEntity.ok(new PagedModel<>(page));
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftAdminSummaryDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftAdminSummaryDto.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.dto;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.Builder;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
+
+/**
+ * A DTO for an admin-focused LTFT summary record.
+ *
+ * @param id                The identifier of the LTFT application.
+ * @param personalDetails   The personal details of the applicant.
+ * @param programmeName     The programme name associated with the LTFT application.
+ * @param proposedStartDate The proposed start date of the LTFT change.
+ * @param submissionDate    The date the LTFT application was submitted.
+ * @param reason            The reason given for applying for LTFT.
+ * @param daysToStart       How many days until the start of the LTFT change.
+ * @param shortNotice       Whether the LTFT application was submitted at short notice.
+ * @param tpd               The details of the notification sent to the TPD.
+ * @param status            The current status of the LTFT application.
+ * @param assignedAdmin     The admin assigned to process the LTFT application.
+ */
+@Builder
+public record LtftAdminSummaryDto(
+    UUID id,
+    LtftAdminPersonalDetailsDto personalDetails,
+    String programmeName,
+    LocalDate proposedStartDate,
+    LocalDate submissionDate,
+    String reason,
+    int daysToStart,
+    boolean shortNotice,
+    LtftAdminNotificationDto tpd,
+    LifecycleState status,
+    PersonDto assignedAdmin) {
+
+  /**
+   * Trainee personal details for the admin view.
+   */
+  @Builder
+  public record LtftAdminPersonalDetailsDto(
+      String id,
+      String forenames,
+      String surname,
+      String gmcNumber,
+      String gdcNumber) {
+
+  }
+
+  /**
+   * The details of a notified person.
+   *
+   * @param email       The email the notification was sent to.
+   * @param emailStatus The current status of the email, if known.
+   */
+  @Builder
+  public record LtftAdminNotificationDto(String email, String emailStatus) {
+
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/PersonDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/PersonDto.java
@@ -1,0 +1,39 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.dto;
+
+import lombok.Builder;
+
+/**
+ * Details of a person and their role.
+ *
+ * @param name  The person's name.
+ * @param email The person's contact email.
+ * @param role  The person's role, context dependent.
+ */
+@Builder
+public record PersonDto(
+    String name,
+    String email,
+    String role) {
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
@@ -27,6 +27,8 @@ import java.util.List;
 import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto.LtftAdminPersonalDetailsDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
@@ -34,8 +36,38 @@ import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 /**
  * A mapper to convert between LTFT related entities and DTOs.
  */
-@Mapper(componentModel = SPRING)
+@Mapper(componentModel = SPRING, uses = TemporalMapper.class)
 public interface LtftMapper {
+
+  /**
+   * Convert a {@link LtftForm} entity to a {@link LtftAdminSummaryDto} DTO.
+   *
+   * @param entity The entity to convert to a DTO.
+   * @return The equivalent admin summary DTO.
+   */
+  @Mapping(target = "personalDetails", source = "entity")
+  @Mapping(target = "programmeName", source = "content.programmeMembership.name")
+  @Mapping(target = "proposedStartDate", source = "content.change.startDate")
+  @Mapping(target = "submissionDate", source = "created") //TODO: original or latest submission?
+  @Mapping(target = "reason", constant = "TODO") //TODO: which reason to show?
+  @Mapping(target = "daysToStart", constant = "40") //TODO: calculate
+  @Mapping(target = "shortNotice", constant = "false") //TODO: calculate from submission date
+  @Mapping(target = "tpd.email", source = "content.discussions.tpdEmail")
+  @Mapping(target = "tpd.emailStatus", constant = "TODO") // TODO: not available.
+  @Mapping(target = "status", source = "status.current.state")
+  @Mapping(target = "assignedAdmin.name", source = "content.assignedAdmin.name")
+  @Mapping(target = "assignedAdmin.email", source = "content.assignedAdmin.email")
+  LtftAdminSummaryDto toAdminSummaryDto(LtftForm entity);
+
+  /**
+   * Build a {@link LtftAdminPersonalDetailsDto} from an {@link LtftForm}.
+   *
+   * @param entity The entity to build personal details from.
+   * @return The built personal details.
+   */
+  @Mapping(target = "id", source = "traineeTisId")
+  @Mapping(target = ".", source = "content.personalDetails")
+  LtftAdminPersonalDetailsDto buildPersonalDetails(LtftForm entity);
 
   /**
    * Convert a {@link LtftForm} entity to a {@link LtftSummaryDto} DTO.

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/TemporalMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/TemporalMapper.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.mapper;
+
+import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.mapstruct.Mapper;
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * A mapper for temporal types.
+ */
+@Mapper(componentModel = SPRING)
+public abstract class TemporalMapper {
+
+  @Value("${application.timezone}")
+  ZoneId zoneId;
+
+  /**
+   * Convert an {@link Instant} to a {@link LocalDate}.
+   *
+   * @param instant The instant to convert.
+   * @return The zoned LocalDate, based on the application's timezone.
+   */
+  public LocalDate toLocalDate(Instant instant) {
+    return instant == null ? null : LocalDate.ofInstant(instant, zoneId);
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/LtftContent.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/LtftContent.java
@@ -58,6 +58,7 @@ public record LtftContent(
    * @param title                   The trainee's title.
    * @param forenames               The trainee's forenames or given name.
    * @param surname                 The trainee's surname or family name.
+   * @param email                   The trainee's email address.
    * @param telephoneNumber         The trainee's contact telephone number.
    * @param mobileNumber            The trainee's contact mobile number.
    * @param gmcNumber               The trainee's GMC registration number.
@@ -69,6 +70,7 @@ public record LtftContent(
       String title,
       String forenames,
       String surname,
+      String email,
       String telephoneNumber,
       String mobileNumber,
       String gmcNumber,

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
@@ -35,14 +37,6 @@ import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
  */
 @Repository
 public interface LtftFormRepository extends MongoRepository<LtftForm, UUID> {
-
-  /**
-   * Find all LTFT forms belonging to the given trainee, ordered by last modified.
-   *
-   * @param traineeId The ID of the trainee.
-   * @return A list of found LTFT forms.
-   */
-  List<LtftForm> findByTraineeTisIdOrderByLastModified(String traineeId);
 
   /**
    * Count all LTFT forms with one of the given DBCs.
@@ -56,10 +50,19 @@ public interface LtftFormRepository extends MongoRepository<LtftForm, UUID> {
    * Count all LTFT forms with one of the given current states and DBCs.
    *
    * @param states The states to include in the count.
+   * @param dbcs   The designated body codes to include in the count.
    * @return The number of found LTFT forms.
    */
   long countByStatus_Current_StateInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
       Set<LifecycleState> states, Set<String> dbcs);
+
+  /**
+   * Find all LTFT forms belonging to the given trainee, ordered by last modified.
+   *
+   * @param traineeId The ID of the trainee.
+   * @return A list of found LTFT forms.
+   */
+  List<LtftForm> findByTraineeTisIdOrderByLastModified(String traineeId);
 
   /**
    * Find the LTFT form with the given id that belongs to the given trainee.
@@ -70,4 +73,24 @@ public interface LtftFormRepository extends MongoRepository<LtftForm, UUID> {
    */
   Optional<LtftForm> findByTraineeTisIdAndId(String traineeId, UUID id);
 
+  /**
+   * Find all LTFT forms with one of the given DBCs.
+   *
+   * @param dbcs     The designated body codes to include in the search.
+   * @param pageable Page information to apply to the search.
+   * @return A page of found LTFT forms.
+   */
+  Page<LtftForm> findByContent_ProgrammeMembership_DesignatedBodyCodeIn(Set<String> dbcs,
+      Pageable pageable);
+
+  /**
+   * Find all LTFT forms with one of the given current states and DBCs.
+   *
+   * @param states   The states to include in the search.
+   * @param dbcs     The designated body codes to include in the search.
+   * @param pageable Page information to apply to the search.
+   * @return A page of found LTFT forms.
+   */
+  Page<LtftForm> findByStatus_Current_StateInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+      Set<LifecycleState> states, Set<String> dbcs, Pageable pageable);
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/mapper/TemporalMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/mapper/TemporalMapperTest.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.mapper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TemporalMapperTest {
+
+  private TemporalMapperImpl mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new TemporalMapperImpl();
+  }
+
+  @Test
+  void shouldConvertNullInstantToNullLocalDate() {
+    LocalDate localDate = mapper.toLocalDate(null);
+
+    assertThat("Unexpected local date.", localDate, nullValue());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Etc/UTC", "Europe/London"})
+  void shouldConvertInstantToLocalDate(ZoneId zoneId) {
+    Instant now = Instant.now();
+
+    mapper.zoneId = zoneId;
+    LocalDate localDate = mapper.toLocalDate(now);
+
+    assertThat("Unexpected local date.", localDate, is(LocalDate.now(zoneId)));
+  }
+}


### PR DESCRIPTION
Add an endpoint for getting Admin-facing summarries of LTFT application for the user's assigned local offices.

By default the response will include all LTFT applications for the local office ordered by the creation timestamp. But paging, sorting and status filtering are available using query parameters.

Several of the summary fields will return dummy values temporarily
- `submissionDate` will use the creation timestamp
- `reason` = `TODO`
- `daysToStart` = `40`
- `shortNotice` = `false`
- `tpd.emailStatus` = `TODO`

TIS21-6600
TIS21-6940