### PR TITLE
feat(ltft): add admin LTFT status update endpoints

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
@@ -22,7 +22,9 @@
 package uk.nhs.hee.tis.trainee.forms.api;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
+import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,11 +33,17 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedModel;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.LtftStatusInfoDto.LftfStatusInfoDetailDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.service.LtftService;
 
@@ -82,5 +90,51 @@ public class AdminLtftResource {
       Pageable pageable) {
     Page<LtftAdminSummaryDto> page = service.getAdminLtftSummaries(states, pageable);
     return ResponseEntity.ok(new PagedModel<>(page));
+  }
+
+  /**
+   * Approve the form with the given ID, must be associated with the user's local office.
+   *
+   * @param id The ID of the form to approve.
+   * @return The approved form.
+   * @throws MethodArgumentNotValidException When the state transition was not valid.
+   */
+  @PutMapping("/{id}/approve")
+  ResponseEntity<LtftFormDto> approveLtft(@PathVariable UUID id)
+      throws MethodArgumentNotValidException {
+    Optional<LtftFormDto> form = service.updateLtftStatusAsAdmin(id, LifecycleState.APPROVED, null);
+    return ResponseEntity.of(form);
+  }
+
+  /**
+   * Unsubmit the form with the given ID, must be associated with the user's local office.
+   *
+   * @param id     The ID of the form to unsubmit.
+   * @param detail The reason for unsubmitting.
+   * @return The approved form.
+   * @throws MethodArgumentNotValidException When the state transition was not valid.
+   */
+  @PutMapping("/{id}/unsubmit")
+  ResponseEntity<LtftFormDto> unsubmitLtft(@PathVariable UUID id,
+      @RequestBody LftfStatusInfoDetailDto detail) throws MethodArgumentNotValidException {
+    Optional<LtftFormDto> form = service.updateLtftStatusAsAdmin(id, LifecycleState.UNSUBMITTED,
+        detail);
+    return ResponseEntity.of(form);
+  }
+
+  /**
+   * Withdraw the form with the given ID, must be associated with the user's local office.
+   *
+   * @param id     The ID of the form to withdraw.
+   * @param detail The reason for withdrawal.
+   * @return The approved form.
+   * @throws MethodArgumentNotValidException When the state transition was not valid.
+   */
+  @PutMapping("/{id}/withdraw")
+  ResponseEntity<LtftFormDto> withdrawLtft(@PathVariable UUID id,
+      @RequestBody LftfStatusInfoDetailDto detail) throws MethodArgumentNotValidException {
+    Optional<LtftFormDto> form = service.updateLtftStatusAsAdmin(id, LifecycleState.WITHDRAWN,
+        detail);
+    return ResponseEntity.of(form);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/RestResponseEntityExceptionHandler.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.api;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+/**
+ * Exception handler for REST requests.
+ */
+@RestControllerAdvice
+public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
+
+  private static final String TITLE_VALIDATION_FAILURE = "Validation failure";
+
+  @Override
+  protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+      HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+    BindingResult result = ex.getBindingResult();
+    List<BodyValidationError> errors = result.getFieldErrors().stream()
+        .map(fe -> {
+          String pointer = "#/" + fe.getField().replace('.', JsonPointer.SEPARATOR);
+          return new BodyValidationError(pointer, fe.getDefaultMessage());
+        })
+        .sorted(
+            Comparator.comparing(BodyValidationError::pointer)
+                .thenComparing(BodyValidationError::detail)
+        )
+        .toList();
+
+    ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+    problemDetail.setTitle(TITLE_VALIDATION_FAILURE);
+    problemDetail.setProperty("errors", errors);
+    return handleExceptionInternal(ex, problemDetail, headers, status, request);
+  }
+
+  @Override
+  protected ResponseEntity<Object> handleHandlerMethodValidationException(
+      HandlerMethodValidationException ex, HttpHeaders headers, HttpStatusCode status,
+      WebRequest request) {
+
+    List<ParameterValidationError> errors = ex.getAllValidationResults().stream()
+        .flatMap(result -> {
+          String parameterName = result.getMethodParameter().getParameterName();
+
+          return result.getResolvableErrors().stream()
+              .map(err -> new ParameterValidationError(parameterName, err.getDefaultMessage()));
+        })
+        .sorted(
+            Comparator.comparing(ParameterValidationError::parameter)
+                .thenComparing(ParameterValidationError::detail)
+        )
+        .toList();
+
+    ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+    problemDetail.setTitle(ex.getReason());
+    problemDetail.setProperty("errors", errors);
+    return handleExceptionInternal(ex, problemDetail, headers, status, request);
+  }
+
+  /**
+   * A detailed parameter validation error.
+   *
+   * @param parameter The name of the parameter.
+   * @param detail    The validation failure detail.
+   */
+  record ParameterValidationError(String parameter, String detail) {
+
+  }
+
+  /**
+   * A detailed request body validation error.
+   *
+   * @param pointer The JSON pointer for the body's field.
+   * @param detail  The validation failure detail.
+   */
+  record BodyValidationError(String pointer, String detail) {
+
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
@@ -29,12 +29,14 @@ import java.util.UUID;
 import lombok.Data;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.dto.validation.Create;
+import uk.nhs.hee.tis.trainee.forms.model.Person;
 
 /**
  * A DTO for transferring LTFT forms.
  */
 @Data
 public class LtftFormDto {
+
   @Null(groups = Create.class)
   private UUID id;
 
@@ -55,6 +57,7 @@ public class LtftFormDto {
    */
   @Data
   public static class LtftProgrammeMembershipDto {
+
     private UUID id;
     private String name;
     private LocalDate startDate;
@@ -67,6 +70,7 @@ public class LtftFormDto {
    */
   @Data
   public static class LtftStatusDto {
+
     private LifecycleState current;
     private List<LtftStatusInfoDto> history;
   }
@@ -76,10 +80,22 @@ public class LtftFormDto {
    */
   @Data
   public static class LtftStatusInfoDto {
+
     private LifecycleState state;
-    private String detail;
+    private LftfStatusInfoDetailDto detail;
+    private Person modifiedBy;
     private Instant timestamp;
     private Integer revision;
+
+    /**
+     * A DTO for state change details.
+     */
+    @Data
+    public static class LftfStatusInfoDetailDto {
+
+      private String reason;
+      private String message;
+    }
   }
 
   /**
@@ -87,6 +103,7 @@ public class LtftFormDto {
    */
   @Data
   public static class LtftDiscussionDto {
+
     private String tpdName;
     private String tpdEmail;
     private List<LtftPersonRole> other;
@@ -97,6 +114,7 @@ public class LtftFormDto {
    */
   @Data
   public static class LtftPersonRole {
+
     private String name;
     private String email;
     private String role;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/enumeration/LifecycleState.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/enumeration/LifecycleState.java
@@ -45,13 +45,13 @@ public enum LifecycleState {
     DELETED.allowedTransitions = Set.of();
     DELETED.allowedFormTypes = Set.of(AbstractFormR.class);
 
-    DRAFT.allowedTransitions = Set.of(SUBMITTED, DELETED);
+    DRAFT.allowedTransitions = Set.of(DELETED, SUBMITTED);
     DRAFT.allowedFormTypes = Set.of(AbstractForm.class);
 
     REJECTED.allowedTransitions = Set.of();
     REJECTED.allowedFormTypes = Set.of(LtftForm.class);
 
-    SUBMITTED.allowedTransitions = Set.of(APPROVED, REJECTED, UNSUBMITTED, WITHDRAWN);
+    SUBMITTED.allowedTransitions = Set.of(APPROVED, DELETED, REJECTED, UNSUBMITTED, WITHDRAWN);
     SUBMITTED.allowedFormTypes = Set.of(AbstractForm.class);
 
     UNSUBMITTED.allowedTransitions = Set.of(SUBMITTED, WITHDRAWN);
@@ -70,6 +70,9 @@ public enum LifecycleState {
    */
   public static boolean canTransitionTo(AbstractForm form, LifecycleState newLifecycleState) {
     LifecycleState currentState = form.getLifecycleState();
-    return currentState != null && currentState.allowedTransitions.contains(newLifecycleState);
+
+    return currentState != null && currentState.allowedTransitions.contains(newLifecycleState)
+        && newLifecycleState.allowedFormTypes.stream()
+        .anyMatch(type -> type.isAssignableFrom(form.getClass()));
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractAuditedForm.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractAuditedForm.java
@@ -29,6 +29,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import lombok.With;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.domain.Persistable;
@@ -106,6 +107,7 @@ public abstract class AbstractAuditedForm<T extends FormContent> extends Abstrac
   @Builder
   public record Status(
 
+      @With
       StatusInfo current,
       List<StatusInfo> history) {
 
@@ -123,12 +125,16 @@ public abstract class AbstractAuditedForm<T extends FormContent> extends Abstrac
 
         @Indexed
         LifecycleState state,
-        String detail,
+        StatusDetail detail,
         Person modifiedBy,
         Instant timestamp,
         Integer revision
     ) {
 
+      @Builder
+      public record StatusDetail(String reason, String message) {
+
+      }
     }
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
@@ -75,6 +75,16 @@ public interface LtftFormRepository extends MongoRepository<LtftForm, UUID> {
   Optional<LtftForm> findByTraineeTisIdAndId(String traineeId, UUID id);
 
   /**
+   * Find the LTFT form with the given ID associated with one of the given DBCs.
+   *
+   * @param id   The ID of the form.
+   * @param dbcs The designated body codes to include in the search.
+   * @return The LTFT form, or optional empty if ID not found or did not match DBCs.
+   */
+  Optional<LtftForm> findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(UUID id,
+      Set<String> dbcs);
+
+  /**
    * Find all LTFT forms with one of the given DBCs.
    *
    * @param dbcs     The designated body codes to include in the search.

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/RestResponseEntityExceptionHandlerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/RestResponseEntityExceptionHandlerTest.java
@@ -1,0 +1,221 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.api;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.validation.constraints.NotNull;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.method.MethodValidationResult;
+import org.springframework.validation.method.ParameterValidationResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import uk.nhs.hee.tis.trainee.forms.api.RestResponseEntityExceptionHandler.BodyValidationError;
+import uk.nhs.hee.tis.trainee.forms.api.RestResponseEntityExceptionHandler.ParameterValidationError;
+
+class RestResponseEntityExceptionHandlerTest {
+
+  private static final HttpStatusCode STATUS_CODE = HttpStatusCode.valueOf(
+      new Random().nextInt(400, 500));
+
+  private RestResponseEntityExceptionHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new RestResponseEntityExceptionHandler();
+  }
+
+  @Test
+  void shouldHandleMethodArgumentNotValid() {
+    BeanPropertyBindingResult result = new BeanPropertyBindingResult(null, "dto");
+    result.addError(new FieldError("dto", "field2", "detail3"));
+    result.addError(new FieldError("dto", "field1", "detail2"));
+    result.addError(new FieldError("dto", "field1", "detail1"));
+    result.addError(new FieldError("dto", "field1.subField", "detail4"));
+    MethodArgumentNotValidException exception = new MethodArgumentNotValidException(
+        mock(MethodParameter.class), result);
+
+    HttpHeaders headers = HttpHeaders.EMPTY;
+    WebRequest request = new ServletWebRequest(new MockHttpServletRequest());
+
+    ResponseEntity<Object> response = handler.handleMethodArgumentNotValid(exception, headers,
+        STATUS_CODE, request);
+
+    assertThat("Unexpected response.", response, notNullValue());
+    assertThat("Unexpected headers.", response.getHeaders(), is(headers));
+    assertThat("Unexpected response code.", response.getStatusCode(), is(STATUS_CODE));
+    assertThat("Unexpected response type.", response.getBody(), instanceOf(ProblemDetail.class));
+
+    ProblemDetail problem = (ProblemDetail) response.getBody();
+    assertThat("Unexpected problem.", problem, notNullValue());
+    assertThat("Unexpected problem title.", problem.getTitle(), is("Validation failure"));
+    assertThat("Unexpected problem status.", problem.getStatus(), is(STATUS_CODE.value()));
+    assertThat("Unexpected problem status.", problem.getInstance(), nullValue());
+    assertThat("Unexpected problem status.", problem.getType(), is(URI.create("about:blank")));
+    assertThat("Unexpected problem status.", problem.getDetail(), nullValue());
+
+    Map<String, Object> problemProperties = problem.getProperties();
+    assertThat("Unexpected problem properties.", problemProperties, notNullValue());
+    assertThat("Unexpected property count.", problemProperties.size(), is(1));
+
+    Object errors = problemProperties.get("errors");
+    assertThat("Unexpected errors type.", errors, instanceOf(List.class));
+
+    List<BodyValidationError> errorsList = (List<BodyValidationError>) errors;
+    assertThat("Unexpected errors count.", errorsList.size(), is(4));
+
+    BodyValidationError error = errorsList.get(0);
+    assertThat("Unexpected error pointer.", error.pointer(), is("#/field1"));
+    assertThat("Unexpected error detail.", error.detail(), is("detail1"));
+
+    error = errorsList.get(1);
+    assertThat("Unexpected error pointer.", error.pointer(), is("#/field1"));
+    assertThat("Unexpected error detail.", error.detail(), is("detail2"));
+
+    error = errorsList.get(2);
+    assertThat("Unexpected error pointer.", error.pointer(), is("#/field1/subField"));
+    assertThat("Unexpected error detail.", error.detail(), is("detail4"));
+
+    error = errorsList.get(3);
+    assertThat("Unexpected error pointer.", error.pointer(), is("#/field2"));
+    assertThat("Unexpected error detail.", error.detail(), is("detail3"));
+  }
+
+  @Test
+  void shouldHandleMethodValidationException() {
+    // Use a linked hash map to allow verification of sorting.
+    Map<String, List<String>> parametersToMessages = new LinkedHashMap<>();
+    parametersToMessages.put("parameter2", List.of("detail3"));
+    parametersToMessages.put("parameter1", List.of("detail2", "detail1"));
+    MethodValidationResultStub validationResult = new MethodValidationResultStub(
+        parametersToMessages);
+    HandlerMethodValidationException exception = new HandlerMethodValidationException(
+        validationResult);
+
+    HttpHeaders headers = HttpHeaders.EMPTY;
+    WebRequest request = new ServletWebRequest(new MockHttpServletRequest());
+
+    ResponseEntity<Object> response = handler.handleHandlerMethodValidationException(exception,
+        headers, STATUS_CODE, request);
+
+    assertThat("Unexpected response.", response, notNullValue());
+    assertThat("Unexpected headers.", response.getHeaders(), is(headers));
+    assertThat("Unexpected response code.", response.getStatusCode(), is(STATUS_CODE));
+    assertThat("Unexpected response type.", response.getBody(), instanceOf(ProblemDetail.class));
+
+    ProblemDetail problem = (ProblemDetail) response.getBody();
+    assertThat("Unexpected problem.", problem, notNullValue());
+    assertThat("Unexpected problem title.", problem.getTitle(), is("Validation failure"));
+    assertThat("Unexpected problem status.", problem.getStatus(), is(STATUS_CODE.value()));
+    assertThat("Unexpected problem status.", problem.getInstance(), nullValue());
+    assertThat("Unexpected problem status.", problem.getType(), is(URI.create("about:blank")));
+    assertThat("Unexpected problem status.", problem.getDetail(), nullValue());
+
+    Map<String, Object> problemProperties = problem.getProperties();
+    assertThat("Unexpected problem properties.", problemProperties, notNullValue());
+    assertThat("Unexpected property count.", problemProperties.size(), is(1));
+
+    Object errors = problemProperties.get("errors");
+    assertThat("Unexpected errors type.", errors, instanceOf(List.class));
+
+    List<ParameterValidationError> errorsList = (List<ParameterValidationError>) errors;
+    assertThat("Unexpected errors count.", errorsList.size(), is(3));
+
+    ParameterValidationError error = errorsList.get(0);
+    assertThat("Unexpected error parameter.", error.parameter(), is("parameter1"));
+    assertThat("Unexpected error detail.", error.detail(), is("detail1"));
+
+    error = errorsList.get(1);
+    assertThat("Unexpected error parameter.", error.parameter(), is("parameter1"));
+    assertThat("Unexpected error detail.", error.detail(), is("detail2"));
+
+    error = errorsList.get(2);
+    assertThat("Unexpected error parameter.", error.parameter(), is("parameter2"));
+    assertThat("Unexpected error detail.", error.detail(), is("detail3"));
+  }
+
+  /**
+   * A test stub for {@link MethodValidationResult}.
+   *
+   * @param parametersToMessages A map where the key is parameter names and the value is a list of
+   *                             error messages.
+   */
+  private record MethodValidationResultStub(
+      Map<String, List<String>> parametersToMessages) implements MethodValidationResult {
+
+    @Override
+    public @NotNull Object getTarget() {
+      return "testTarget";
+    }
+
+    @Override
+    public Method getMethod() {
+      return null;
+    }
+
+    @Override
+    public boolean isForReturnValue() {
+      return false;
+    }
+
+    @Override
+    public @NotNull List<ParameterValidationResult> getAllValidationResults() {
+      return parametersToMessages.entrySet().stream()
+          .map(entry -> {
+            String parameterName = entry.getKey();
+            MethodParameter parameter = mock(MethodParameter.class);
+            when(parameter.getParameterName()).thenReturn(parameterName);
+
+            List<DefaultMessageSourceResolvable> messages = entry.getValue().stream()
+                .map(msg -> new DefaultMessageSourceResolvable(null, null, msg))
+                .toList();
+
+            return new ParameterValidationResult(parameter, null, messages, null, null, null);
+          })
+          .toList();
+    }
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/model/LtftFormTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/model/LtftFormTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status;
 import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status.StatusInfo;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status.StatusInfo.StatusDetail;
 
 class LtftFormTest {
 
@@ -55,7 +56,7 @@ class LtftFormTest {
         .build();
     List<StatusInfo> history = List.of(StatusInfo.builder()
         .state(LifecycleState.SUBMITTED)
-        .detail("test")
+        .detail(StatusDetail.builder().reason("testReason").message("testMessage").build())
         .timestamp(Instant.now())
         .build()
     );


### PR DESCRIPTION
Add admin-facing endpoints for approval, unsubmit and withdraw state transitions.
The transition path will be validation and an error return if the transition is not allowed (e.g. DRAFT -> APPROVED).

TIS21-6540