### PR TITLE
fix: LTFT draft hard-delete logic

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.29.0"
+version = "0.29.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/enumeration/LifecycleState.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/enumeration/LifecycleState.java
@@ -45,7 +45,7 @@ public enum LifecycleState {
     DELETED.allowedTransitions = Set.of();
     DELETED.allowedFormTypes = Set.of(AbstractFormR.class);
 
-    DRAFT.allowedTransitions = Set.of(SUBMITTED, DELETED);
+    DRAFT.allowedTransitions = Set.of(SUBMITTED);
     DRAFT.allowedFormTypes = Set.of(AbstractForm.class);
 
     REJECTED.allowedTransitions = Set.of();

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -21,7 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.forms.service;
 
-import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.canTransitionTo;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.DRAFT;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.List;
@@ -216,7 +216,7 @@ public class LtftService {
     }
 
     LtftForm form = formOptional.get();
-    if (!canTransitionTo(form, LifecycleState.DELETED)) {
+    if (!form.getLifecycleState().equals(DRAFT)) {
       log.info("Form {} was not in a permitted state to delete [{}]", formId,
           form.getLifecycleState());
       return Optional.of(false);


### PR DESCRIPTION
Should not reference the DELETED lifecycle state, since that is reserved for soft-deletes.

NO-TICKET