### PR TITLE
feat(ltft): add missing fields to LTFT detail DTO

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.29.1"
+version = "0.29.2"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
@@ -218,9 +218,10 @@ class LtftResourceIntegrationTest {
 
   @Test
   void shouldBeBadRequestWhenCreatingLtftFormWithId() throws Exception {
-    LtftFormDto formToSave = new LtftFormDto();
-    formToSave.setId(ID);
-    formToSave.setTraineeTisId(TRAINEE_ID);
+    LtftFormDto formToSave = LtftFormDto.builder()
+        .id(ID)
+        .traineeTisId(TRAINEE_ID)
+        .build();
     String formToSaveJson = mapper.writeValueAsString(formToSave);
     String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
     mockMvc.perform(post("/api/ltft")
@@ -236,9 +237,10 @@ class LtftResourceIntegrationTest {
 
   @Test
   void shouldCreateLtftFormForTrainee() throws Exception {
-    LtftFormDto formToSave = new LtftFormDto();
-    formToSave.setTraineeTisId(TRAINEE_ID);
-    formToSave.setName("test");
+    LtftFormDto formToSave = LtftFormDto.builder()
+        .traineeTisId(TRAINEE_ID)
+        .name("test")
+        .build();
     String formToSaveJson = mapper.writeValueAsString(formToSave);
     String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
     mockMvc.perform(post("/api/ltft")
@@ -263,9 +265,10 @@ class LtftResourceIntegrationTest {
 
   @Test
   void shouldBeBadRequestWhenUpdatingLtftFormForDifferentTrainee() throws Exception {
-    LtftFormDto formToUpdate = new LtftFormDto();
-    formToUpdate.setTraineeTisId("another trainee");
-    formToUpdate.setId(ID);
+    LtftFormDto formToUpdate = LtftFormDto.builder()
+        .id(ID)
+        .traineeTisId("another trainee")
+        .build();
     String formToUpdateJson = mapper.writeValueAsString(formToUpdate);
     String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
     mockMvc.perform(put("/api/ltft/" + ID)
@@ -278,8 +281,9 @@ class LtftResourceIntegrationTest {
 
   @Test
   void shouldBeBadRequestWhenUpdatingLtftFormWithoutId() throws Exception {
-    LtftFormDto formToUpdate = new LtftFormDto();
-    formToUpdate.setTraineeTisId(TRAINEE_ID);
+    LtftFormDto formToUpdate = LtftFormDto.builder()
+        .traineeTisId(TRAINEE_ID)
+        .build();
     String formToUpdateJson = mapper.writeValueAsString(formToUpdate);
     String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
     mockMvc.perform(put("/api/ltft/someId")
@@ -292,9 +296,10 @@ class LtftResourceIntegrationTest {
 
   @Test
   void shouldBeBadRequestWhenUpdatingLtftFormWithInconsistentIds() throws Exception {
-    LtftFormDto formToUpdate = new LtftFormDto();
-    formToUpdate.setTraineeTisId(TRAINEE_ID);
-    formToUpdate.setId(ID);
+    LtftFormDto formToUpdate = LtftFormDto.builder()
+        .id(ID)
+        .traineeTisId(TRAINEE_ID)
+        .build();
     String formToUpdateJson = mapper.writeValueAsString(formToUpdate);
     String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
     mockMvc.perform(put("/api/ltft/" + UUID.randomUUID())
@@ -307,9 +312,10 @@ class LtftResourceIntegrationTest {
 
   @Test
   void shouldBeBadRequestWhenUpdatingLtftFormNotAlreadyExistingForTrainee() throws Exception {
-    LtftFormDto formToUpdate = new LtftFormDto();
-    formToUpdate.setTraineeTisId(TRAINEE_ID);
-    formToUpdate.setId(ID);
+    LtftFormDto formToUpdate = LtftFormDto.builder()
+        .id(ID)
+        .traineeTisId(TRAINEE_ID)
+        .build();
     String formToUpdateJson = mapper.writeValueAsString(formToUpdate);
     String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
     mockMvc.perform(put("/api/ltft/" + ID)
@@ -327,10 +333,11 @@ class LtftResourceIntegrationTest {
     LtftForm formSaved = template.save(form);
 
     UUID savedId = formSaved.getId();
-    LtftFormDto formToUpdate = new LtftFormDto();
-    formToUpdate.setTraineeTisId(TRAINEE_ID);
-    formToUpdate.setId(savedId);
-    formToUpdate.setName("updated");
+    LtftFormDto formToUpdate = LtftFormDto.builder()
+        .id(savedId)
+        .traineeTisId(TRAINEE_ID)
+        .name("updated")
+        .build();
 
     String formToUpdateJson = mapper.writeValueAsString(formToUpdate);
     String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
@@ -402,6 +409,7 @@ class LtftResourceIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$").doesNotExist());
 
-    assertThat("Unexpected saved record count.", template.count(new Query(), LtftForm.class), is(0L));
+    assertThat("Unexpected saved record count.", template.count(new Query(), LtftForm.class),
+        is(0L));
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
@@ -26,79 +26,168 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
-import lombok.Data;
+import lombok.Builder;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.dto.validation.Create;
+import uk.nhs.hee.tis.trainee.forms.model.content.CctChangeType;
 
 /**
  * A DTO for transferring LTFT forms.
+ *
+ * @param id                  The ID of the LTFT form.
+ * @param traineeTisId        The trainee's TID ID.
+ * @param formRef             The human-readable reference for the form.
+ * @param revision            The revision number of the form.
+ * @param name                The trainee provided name for the application.
+ * @param personalDetails     The trainee's personal details.
+ * @param programmeMembership The programme membership linked with the LTFT application.
+ * @param declarations        The LTFT declarations.
+ * @param discussions         Discussions which took place as part of the LTFT process.
+ * @param change              The calculated LTFT change.
+ * @param reasons             The reasons for applying for LTFT.
+ * @param assignedAdmin       The administration assigned to the LTFT application.
+ * @param status              The status of the LTFT application, both current and audit history.
+ * @param created             When the LTFT application was first created.
+ * @param lastModified        When the LTFT application was last modified.
  */
-@Data
-public class LtftFormDto {
-  @Null(groups = Create.class)
-  private UUID id;
+@Builder
+public record LtftFormDto(
+    @Null(groups = Create.class)
+    UUID id,
+    String traineeTisId,
+    String formRef,
+    int revision,
+    String name,
+    PersonalDetailsDto personalDetails,
+    ProgrammeMembershipDto programmeMembership,
+    DeclarationsDto declarations,
+    DiscussionsDto discussions,
+    CctChangeDto change,
+    ReasonsDto reasons,
+    PersonDto assignedAdmin,
+    StatusDto status,
 
-  private String traineeTisId;
-
-  private String name;
-
-  private LtftProgrammeMembershipDto programmeMembership;
-
-  private LtftStatusDto status;
-  private LtftDiscussionDto discussions;
-
-  private Instant created;
-  private Instant lastModified;
+    Instant created,
+    Instant lastModified) {
 
   /**
-   * A DTO for LTFT programme membership details.
+   * The calculated LTFT change.
+   *
+   * @param id            The ID of the CCT change used to start the application.
+   * @param calculationId The ID of the CCT calculation used to start the application.
+   * @param type          The type of change.
+   * @param wte           The whole time equivalent after the change.
+   * @param startDate     The start date of the change.
+   * @param endDate       The end date of the change.
+   * @param cctDate       The expected CCT date after this change is applied.
    */
-  @Data
-  public static class LtftProgrammeMembershipDto {
-    private UUID id;
-    private String name;
-    private LocalDate startDate;
-    private LocalDate endDate;
-    private double wte;
+  @Builder
+  public record CctChangeDto(
+      UUID id,
+      UUID calculationId,
+      CctChangeType type,
+      double wte,
+      LocalDate startDate,
+      LocalDate endDate,
+      LocalDate cctDate) {
+
   }
 
   /**
-   * A DTO for LTFT form lifecycle state.
+   * A set of declarations that the trainee must provide.
+   *
+   * @param discussedWithTpd     That the trainee has discussed with their TPD.
+   * @param informationIsCorrect That the trainee has given correct information.
+   * @param notGuaranteed        That LTFT approval is not guaranteed
    */
-  @Data
-  public static class LtftStatusDto {
-    private LifecycleState current;
-    private List<LtftStatusInfoDto> history;
+  @Builder
+  public record DeclarationsDto(
+      boolean discussedWithTpd,
+      boolean informationIsCorrect,
+      boolean notGuaranteed) {
+
   }
 
   /**
-   * A DTO for LTFT form lifecycle state details.
+   * Programme membership data for a calculation.
+   *
+   * @param id                 The ID of the programme membership.
+   * @param name               The name of the programme.
+   * @param designatedBodyCode The designated body code for the programme.
+   * @param startDate          The start date of the programme.
+   * @param endDate            The end date of the programme.
+   * @param wte                The whole time equivalent of the programme membership.
    */
-  @Data
-  public static class LtftStatusInfoDto {
-    private LifecycleState state;
-    private String detail;
-    private Instant timestamp;
-    private Integer revision;
+  @Builder
+  public record ProgrammeMembershipDto(
+      UUID id,
+      String name,
+      String designatedBodyCode,
+      LocalDate startDate,
+      LocalDate endDate,
+      double wte) {
+
   }
 
   /**
-   * A DTO for LTFT discussions.
+   * Reasons for applying for LTFT.
+   *
+   * @param selected    A list of selected reasons.
+   * @param otherDetail Additional details if required.
    */
-  @Data
-  public static class LtftDiscussionDto {
-    private String tpdName;
-    private String tpdEmail;
-    private List<LtftPersonRole> other;
+  @Builder
+  public record ReasonsDto(
+      List<String> selected,
+      String otherDetail) {
+
   }
 
   /**
-   * A DTO for LTFT form discussion non-TPD people.
+   * The form status.
+   *
+   * @param current The information for the current form status.
+   * @param history A list of form status history.
    */
-  @Data
-  public static class LtftPersonRole {
-    private String name;
-    private String email;
-    private String role;
+  @Builder
+  public record StatusDto(
+
+      StatusInfoDto current,
+      List<StatusInfoDto> history) {
+
+    /**
+     * Form status information.
+     *
+     * @param state      The lifecycle state of the form.
+     * @param detail     Any status detail.
+     * @param modifiedBy The Person who made this status change.
+     * @param timestamp  The timestamp of the status change.
+     * @param revision   The revision number associated with this status change.
+     */
+    @Builder
+    public record StatusInfoDto(
+
+        LifecycleState state,
+        String detail,
+        PersonDto modifiedBy,
+        Instant timestamp,
+        Integer revision
+    ) {
+
+    }
+  }
+
+  /**
+   * Discussions that the trainee has had about their LTFT needs.
+   *
+   * @param tpdName  The name of their TPD.
+   * @param tpdEmail The contact email for their TPD.
+   * @param other    Other people they have discussed with e.g. Education Supervisor.
+   */
+  @Builder
+  public record DiscussionsDto(
+      String tpdName,
+      String tpdEmail,
+      List<PersonDto> other) {
+
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/PersonalDetailsDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/PersonalDetailsDto.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.dto;
+
+import lombok.Builder;
+
+/**
+ * A trainee's personal details.
+ *
+ * @param id                      The trainee's TIS ID.
+ * @param title                   The trainee's title.
+ * @param forenames               The trainee's forenames or given name.
+ * @param surname                 The trainee's surname or family name.
+ * @param email                   The trainee's email address.
+ * @param telephoneNumber         The trainee's contact telephone number.
+ * @param mobileNumber            The trainee's contact mobile number.
+ * @param gmcNumber               The trainee's GMC registration number.
+ * @param gdcNumber               The trainee's GDC registration number.
+ * @param skilledWorkerVisaHolder Whether the trainee holds a skilled worker visa.
+ */
+@Builder
+public record PersonalDetailsDto(
+    String id,
+    String title,
+    String forenames,
+    String surname,
+    String email,
+    String telephoneNumber,
+    String mobileNumber,
+    String gmcNumber,
+    String gdcNumber,
+    boolean skilledWorkerVisaHolder) {
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
@@ -41,6 +41,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto.LtftAdminPersonalDetailsDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.CctChangeDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 import uk.nhs.hee.tis.trainee.forms.model.content.CctChange;
@@ -112,14 +113,32 @@ public abstract class LtftMapper {
   /**
    * Convert a {@link LtftForm} to {@link LtftFormDto} DTO.
    *
-   * @param entity The form to convert.
+   * @param entity  The form to convert.
+   * @param cctDate The calculated CCT date.
    * @return The equivalent DTO.
    */
-  @Mapping(target = "name", source = "content.name")
-  @Mapping(target = "discussions", source = "content.discussions")
-  @Mapping(target = "programmeMembership", source = "content.programmeMembership")
-  @Mapping(target = "status.current", source = "status.current.state")
-  public abstract LtftFormDto toDto(LtftForm entity);
+  @Mapping(target = "id", source = "entity.id")
+  @Mapping(target = "formRef", source = "entity.formRef")
+  @Mapping(target = "name", source = "entity.content.name")
+  @Mapping(target = "personalDetails", source = "entity.content.personalDetails")
+  @Mapping(target = "programmeMembership", source = "entity.content.programmeMembership")
+  @Mapping(target = "declarations", source = "entity.content.declarations")
+  @Mapping(target = "discussions", source = "entity.content.discussions")
+  @Mapping(target = "change", expression = "java(toDto(entity.getContent().change(), cctDate))")
+  @Mapping(target = "reasons", source = "entity.content.reasons")
+  @Mapping(target = "assignedAdmin", source = "entity.content.assignedAdmin")
+  public abstract LtftFormDto toDto(LtftForm entity, LocalDate cctDate);
+
+  /**
+   * Convert a {@link CctChange} to {@link CctChangeDto}.
+   *
+   * @param entity  The entity to convert.
+   * @param cctDate The calculated CCT date.
+   * @return The equivalent DTO.
+   */
+  @Mapping(target = ".", source = "entity")
+  @Mapping(target = "cctDate", source = "cctDate")
+  public abstract CctChangeDto toDto(CctChange entity, LocalDate cctDate);
 
   /**
    * Convert a {@link LtftFormDto} DTO to a {@link LtftForm}.
@@ -128,6 +147,7 @@ public abstract class LtftMapper {
    * @return The equivalent LTFT Form.
    */
   @InheritInverseConfiguration
+  @Mapping(target = "content", source = "dto")
   public abstract LtftForm toEntity(LtftFormDto dto);
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -145,7 +145,7 @@ public class LtftService {
         value -> log.info("Found form {} for trainee [{}]", formId, traineeId),
         () -> log.info("Did not find form {} for trainee [{}]", formId, traineeId)
     );
-    return form.map(mapper::toDto);
+    return form.map(v -> mapper.toDto(v, null));
   }
 
   /**
@@ -164,7 +164,7 @@ public class LtftService {
       return Optional.empty();
     }
     LtftForm savedForm = ltftFormRepository.save(form);
-    return Optional.of(mapper.toDto(savedForm));
+    return Optional.of(mapper.toDto(savedForm, null));
   }
 
   /**
@@ -196,7 +196,7 @@ public class LtftService {
     }
     form.setCreated(existingForm.get().getCreated()); //explicitly set otherwise form saved as 'new'
     LtftForm savedForm = ltftFormRepository.save(form);
-    return Optional.of(mapper.toDto(savedForm));
+    return Optional.of(mapper.toDto(savedForm, null));
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceTest.java
@@ -98,7 +98,7 @@ class LtftResourceTest {
   void shouldReturnBadRequestWhenServiceWontSaveLtftForm() {
     when(service.saveLtftForm(any())).thenReturn(Optional.empty());
 
-    ResponseEntity<LtftFormDto> response = controller.createLtft(new LtftFormDto());
+    ResponseEntity<LtftFormDto> response = controller.createLtft(LtftFormDto.builder().build());
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(BAD_REQUEST));
   }
@@ -107,7 +107,7 @@ class LtftResourceTest {
   void shouldReturnBadRequestWhenServiceWontUpdateLtftForm() {
     when(service.updateLtftForm(any(), any())).thenReturn(Optional.empty());
 
-    ResponseEntity<LtftFormDto> response = controller.updateLtft(ID, new LtftFormDto());
+    ResponseEntity<LtftFormDto> response = controller.updateLtft(ID, LtftFormDto.builder().build());
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(BAD_REQUEST));
   }
@@ -123,13 +123,15 @@ class LtftResourceTest {
 
   @Test
   void shouldReturnSavedLtftFormWhenSaved() {
-    LtftFormDto savedForm = new LtftFormDto();
-    savedForm.setId(ID);
-    savedForm.setTraineeTisId("some trainee");
+    LtftFormDto savedForm = LtftFormDto.builder()
+        .id(ID)
+        .traineeTisId("some trainee")
+        .build();
     when(service.saveLtftForm(any())).thenReturn(Optional.of(savedForm));
 
-    LtftFormDto newForm = new LtftFormDto();
-    newForm.setTraineeTisId("some trainee");
+    LtftFormDto newForm = LtftFormDto.builder()
+        .traineeTisId("some trainee")
+        .build();
     ResponseEntity<LtftFormDto> response = controller.createLtft(newForm);
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
@@ -140,14 +142,16 @@ class LtftResourceTest {
 
   @Test
   void shouldReturnSavedLtftFormWhenUpdated() {
-    LtftFormDto savedForm = new LtftFormDto();
-    savedForm.setId(ID);
-    savedForm.setTraineeTisId("some trainee");
+    LtftFormDto savedForm = LtftFormDto.builder()
+        .id(ID)
+        .traineeTisId("some trainee")
+        .build();
     when(service.updateLtftForm(any(), any())).thenReturn(Optional.of(savedForm));
 
-    LtftFormDto existingForm = new LtftFormDto();
-    existingForm.setId(ID);
-    existingForm.setTraineeTisId("some trainee");
+    LtftFormDto existingForm = LtftFormDto.builder()
+        .id(ID)
+        .traineeTisId("some trainee")
+        .build();
     ResponseEntity<LtftFormDto> response = controller.updateLtft(ID, existingForm);
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
@@ -158,9 +162,10 @@ class LtftResourceTest {
 
   @Test
   void shouldReturnLtftFormWhenFound() {
-    LtftFormDto existingForm = new LtftFormDto();
-    existingForm.setId(ID);
-    existingForm.setTraineeTisId("some trainee");
+    LtftFormDto existingForm = LtftFormDto.builder()
+        .id(ID)
+        .traineeTisId("some trainee")
+        .build();
     when(service.getLtftForm(ID)).thenReturn(Optional.of(existingForm));
 
     ResponseEntity<LtftFormDto> response = controller.getLtft(ID);

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -290,13 +290,14 @@ class LtftServiceTest {
     assertThat("Unexpected form returned.", formDtoOptional.isEmpty(), is(false));
     verify(ltftRepository).findByTraineeTisIdAndId(TRAINEE_ID, ID);
     LtftFormDto returnedFormDto = formDtoOptional.get();
-    assertThat("Unexpected returned LTFT form.", returnedFormDto, is(mapper.toDto(form)));
+    assertThat("Unexpected returned LTFT form.", returnedFormDto, is(mapper.toDto(form, null)));
   }
 
   @Test
   void shouldNotSaveIfNewLtftFormNotForTrainee() {
-    LtftFormDto dtoToSave = new LtftFormDto();
-    dtoToSave.setTraineeTisId("another trainee");
+    LtftFormDto dtoToSave = LtftFormDto.builder()
+        .traineeTisId("another trainee")
+        .build();
 
     Optional<LtftFormDto> formDtoOptional = service.saveLtftForm(dtoToSave);
 
@@ -306,8 +307,9 @@ class LtftServiceTest {
 
   @Test
   void shouldSaveIfNewLtftFormForTrainee() {
-    LtftFormDto dtoToSave = new LtftFormDto();
-    dtoToSave.setTraineeTisId(TRAINEE_ID);
+    LtftFormDto dtoToSave = LtftFormDto.builder()
+        .traineeTisId(TRAINEE_ID)
+        .build();
 
     LtftForm existingForm = new LtftForm();
     existingForm.setId(ID);
@@ -323,8 +325,9 @@ class LtftServiceTest {
 
   @Test
   void shouldNotUpdateFormIfWithoutId() {
-    LtftFormDto dtoToSave = new LtftFormDto();
-    dtoToSave.setTraineeTisId(TRAINEE_ID);
+    LtftFormDto dtoToSave = LtftFormDto.builder()
+        .traineeTisId(TRAINEE_ID)
+        .build();
 
     Optional<LtftFormDto> formDtoOptional = service.updateLtftForm(ID, dtoToSave);
 
@@ -334,9 +337,10 @@ class LtftServiceTest {
 
   @Test
   void shouldNotUpdateFormIfIdDoesNotMatchPathParameter() {
-    LtftFormDto dtoToSave = new LtftFormDto();
-    dtoToSave.setTraineeTisId(TRAINEE_ID);
-    dtoToSave.setId(ID);
+    LtftFormDto dtoToSave = LtftFormDto.builder()
+        .id(ID)
+        .traineeTisId(TRAINEE_ID)
+        .build();
 
     Optional<LtftFormDto> formDtoOptional
         = service.updateLtftForm(UUID.randomUUID(), dtoToSave);
@@ -347,9 +351,10 @@ class LtftServiceTest {
 
   @Test
   void shouldNotUpdateFormIfTraineeDoesNotMatchLoggedInUser() {
-    LtftFormDto dtoToSave = new LtftFormDto();
-    dtoToSave.setTraineeTisId("another trainee");
-    dtoToSave.setId(ID);
+    LtftFormDto dtoToSave = LtftFormDto.builder()
+        .id(ID)
+        .traineeTisId("another trainee")
+        .build();
 
     Optional<LtftFormDto> formDtoOptional = service.updateLtftForm(ID, dtoToSave);
 
@@ -359,9 +364,10 @@ class LtftServiceTest {
 
   @Test
   void shouldNotUpdateFormIfExistingFormNotFound() {
-    LtftFormDto dtoToSave = new LtftFormDto();
-    dtoToSave.setTraineeTisId(TRAINEE_ID);
-    dtoToSave.setId(ID);
+    LtftFormDto dtoToSave = LtftFormDto.builder()
+        .id(ID)
+        .traineeTisId(TRAINEE_ID)
+        .build();
 
     when(ltftRepository.findByTraineeTisIdAndId(TRAINEE_ID, ID))
         .thenReturn(Optional.empty());
@@ -375,9 +381,10 @@ class LtftServiceTest {
 
   @Test
   void shouldSaveIfUpdatingLtftFormForTrainee() {
-    LtftFormDto dtoToSave = new LtftFormDto();
-    dtoToSave.setTraineeTisId(TRAINEE_ID);
-    dtoToSave.setId(ID);
+    LtftFormDto dtoToSave = LtftFormDto.builder()
+        .id(ID)
+        .traineeTisId(TRAINEE_ID)
+        .build();
 
     LtftForm existingForm = new LtftForm();
     existingForm.setId(ID);


### PR DESCRIPTION
Refactor `LtftFormDto` and add the missing fields. The detail DTO has been based on the database model, with some additional fields taken from the API docs.

The current docs and the DTO are not an exact match, the DTO may need further tweaks in some places but the API docs are also known to be out of date.
Health-Education-England/tis-trainee-api#28 exists with some of the changes, already. Other changes like the `formRef` field still need to be added once PR-28 has been approved/merged.

The CCT date is calculated dynamically when converting from the database entity, the value will always be null until the calculation is implemented.

TIS21-6540