### PR TITLE
feat(ltft): add admin detail endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.30.1"
+version = "0.30.2"
 
 configurations {
   compileOnly {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.29.2"
+version = "0.30.0"
 
 configurations {
   compileOnly {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.30.0"
+version = "0.30.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
@@ -22,7 +22,9 @@
 package uk.nhs.hee.tis.trainee.forms.api;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
+import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,10 +34,12 @@ import org.springframework.data.web.PagedModel;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.service.LtftService;
 
@@ -82,5 +86,17 @@ public class AdminLtftResource {
       Pageable pageable) {
     Page<LtftAdminSummaryDto> page = service.getAdminLtftSummaries(states, pageable);
     return ResponseEntity.ok(new PagedModel<>(page));
+  }
+
+  /**
+   * Get the details of a form with a particular ID associated with the admin's local office.
+   *
+   * @param id The ID of the form.
+   * @return The found form details, empty if not found.
+   */
+  @GetMapping("/{id}")
+  ResponseEntity<LtftFormDto> getLtftAdminDetail(@PathVariable UUID id) {
+    Optional<LtftFormDto> formDetail = service.getAdminLtftDetail(id);
+    return ResponseEntity.of(formDetail);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
@@ -43,6 +43,7 @@ import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto.LtftAdminPersonalDet
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.CctChangeDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftSummaryDto;
+import uk.nhs.hee.tis.trainee.forms.dto.PersonalDetailsDto;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 import uk.nhs.hee.tis.trainee.forms.model.content.CctChange;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
@@ -89,7 +90,17 @@ public abstract class LtftMapper {
    */
   @Mapping(target = "id", source = "traineeTisId")
   @Mapping(target = ".", source = "content.personalDetails")
-  abstract LtftAdminPersonalDetailsDto buildPersonalDetails(LtftForm entity);
+  abstract LtftAdminPersonalDetailsDto buildAdminPersonalDetails(LtftForm entity);
+
+  /**
+   * Build a {@link PersonalDetailsDto} from an {@link LtftForm}.
+   *
+   * @param entity The entity to build personal details from.
+   * @return The built personal details.
+   */
+  @Mapping(target = "id", source = "traineeTisId")
+  @Mapping(target = ".", source = "content.personalDetails")
+  abstract PersonalDetailsDto buildPersonalDetails(LtftForm entity);
 
   /**
    * Convert a {@link LtftForm} entity to a {@link LtftSummaryDto} DTO.
@@ -120,7 +131,7 @@ public abstract class LtftMapper {
   @Mapping(target = "id", source = "entity.id")
   @Mapping(target = "formRef", source = "entity.formRef")
   @Mapping(target = "name", source = "entity.content.name")
-  @Mapping(target = "personalDetails", source = "entity.content.personalDetails")
+  @Mapping(target = "personalDetails", source = "entity")
   @Mapping(target = "programmeMembership", source = "entity.content.programmeMembership")
   @Mapping(target = "declarations", source = "entity.content.declarations")
   @Mapping(target = "discussions", source = "entity.content.discussions")

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
@@ -42,10 +42,12 @@ public interface LtftFormRepository extends MongoRepository<LtftForm, UUID> {
   /**
    * Count all LTFT forms with one of the given DBCs.
    *
-   * @param dbcs The designated body codes to include in the count.
+   * @param states The states to exclude from the count.
+   * @param dbcs   The designated body codes to include in the count.
    * @return The number of found LTFT forms.
    */
-  long countByContent_ProgrammeMembership_DesignatedBodyCodeIn(Set<String> dbcs);
+  long countByStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+      Set<LifecycleState> states, Set<String> dbcs);
 
   /**
    * Count all LTFT forms with one of the given current states and DBCs.

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
@@ -107,8 +107,8 @@ public interface LtftFormRepository extends MongoRepository<LtftForm, UUID> {
    * @return The found LTFT form, empty if not found.
    */
   Optional<LtftForm>
-  findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
-      UUID id, Set<LifecycleState> states, Set<String> dbcs);
+      findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+          UUID id, Set<LifecycleState> states, Set<String> dbcs);
 
   /**
    * Delete the LTFT form with the given id.

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
@@ -77,12 +77,13 @@ public interface LtftFormRepository extends MongoRepository<LtftForm, UUID> {
   /**
    * Find all LTFT forms with one of the given DBCs.
    *
+   * @param states   The states to exclude from the search.
    * @param dbcs     The designated body codes to include in the search.
    * @param pageable Page information to apply to the search.
    * @return A page of found LTFT forms.
    */
-  Page<LtftForm> findByContent_ProgrammeMembership_DesignatedBodyCodeIn(Set<String> dbcs,
-      Pageable pageable);
+  Page<LtftForm> findByStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+      Set<LifecycleState> states, Set<String> dbcs, Pageable pageable);
 
   /**
    * Find all LTFT forms with one of the given current states and DBCs.

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
@@ -96,6 +96,18 @@ public interface LtftFormRepository extends MongoRepository<LtftForm, UUID> {
       Set<LifecycleState> states, Set<String> dbcs, Pageable pageable);
 
   /**
+   * Find the LTFT form with the given ID and one of the given DBCs.
+   *
+   * @param id     The ID of the form to find.
+   * @param states The states to exclude from the search.
+   * @param dbcs   The designated body codes to include in the search.
+   * @return The found LTFT form, empty if not found.
+   */
+  Optional<LtftForm>
+  findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+      UUID id, Set<LifecycleState> states, Set<String> dbcs);
+
+  /**
    * Delete the LTFT form with the given id.
    *
    * @param id must not be {@literal null}.

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -122,12 +123,14 @@ public class LtftService {
 
     if (states == null || states.isEmpty()) {
       log.debug("No status filter provided, searching all LTFTs.");
-      forms = ltftFormRepository.findByContent_ProgrammeMembership_DesignatedBodyCodeIn(groups,
-          pageable);
-    } else {
       forms = ltftFormRepository
-          .findByStatus_Current_StateInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(states,
-              groups, pageable);
+          .findByStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+              Set.of(DRAFT), groups, pageable);
+    } else {
+      states = states.stream().filter(s -> s != DRAFT).collect(Collectors.toSet());
+      forms = ltftFormRepository
+          .findByStatus_Current_StateInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+              states, groups, pageable);
     }
 
     log.info("Found {} total LTFTs, returning page {} of {}", forms.getTotalElements(),

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -230,7 +230,7 @@ public class LtftService {
    *
    * @param formId The id of the LTFT form to delete.
    * @return Optional empty if the form was not found, true if the form was deleted, or false if it
-   * was not in a permitted state to delete.
+   *     was not in a permitted state to delete.
    */
   public Optional<Boolean> deleteLtftForm(UUID formId) {
     String traineeId = traineeIdentity.getTraineeId();

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -99,9 +99,12 @@ public class LtftService {
 
     if (states == null || states.isEmpty()) {
       log.debug("No status filter provided, counting all LTFTs.");
-      return ltftFormRepository.countByContent_ProgrammeMembership_DesignatedBodyCodeIn(groups);
+      return ltftFormRepository
+          .countByStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+              Set.of(DRAFT), groups);
     }
 
+    states = states.stream().filter(s -> s != DRAFT).collect(Collectors.toSet());
     return ltftFormRepository
         .countByStatus_Current_StateInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(states,
             groups);

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
@@ -25,16 +25,20 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.TEXT_PLAIN;
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMITTED;
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.UNSUBMITTED;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +51,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
 import org.springframework.http.ResponseEntity;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.service.LtftService;
 
@@ -135,5 +140,28 @@ class AdminLtftResourceTest {
     assertThat("Unexpected response size.", content, hasSize(2));
     assertThat("Unexpected response ID.", content.get(0).id(), is(id1));
     assertThat("Unexpected response ID.", content.get(1).id(), is(id2));
+  }
+
+  @Test
+  void shouldNotGetDetailWhenFormNotFound() {
+    UUID id = UUID.randomUUID();
+    when(service.getAdminLtftDetail(id)).thenReturn(Optional.empty());
+
+    ResponseEntity<LtftFormDto> response = controller.getLtftAdminDetail(id);
+
+    assertThat("Unexpected response code.", response.getStatusCode(), is(NOT_FOUND));
+    assertThat("Unexpected response body.", response.getBody(), nullValue());
+  }
+
+  @Test
+  void shouldGetDetailWhenFormFound() {
+    UUID id = UUID.randomUUID();
+    LtftFormDto dto = LtftFormDto.builder().id(id).build();
+    when(service.getAdminLtftDetail(id)).thenReturn(Optional.of(dto));
+
+    ResponseEntity<LtftFormDto> response = controller.getLtftAdminDetail(id);
+
+    assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
+    assertThat("Unexpected response body.", response.getBody(), sameInstance(dto));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -308,9 +308,9 @@ class LtftServiceTest {
     service.getAdminLtftSummaries(states, pageRequest);
 
     ArgumentCaptor<Set<LifecycleState>> statesCaptor = ArgumentCaptor.captor();
-    verify(
-        ltftRepository).findByStatus_Current_StateInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
-        statesCaptor.capture(), any(), any());
+    verify(ltftRepository)
+        .findByStatus_Current_StateInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            statesCaptor.capture(), any(), any());
 
     Set<LifecycleState> filteredStates = statesCaptor.getValue();
     assertThat("Unexpected state count.", filteredStates, hasSize(1));
@@ -409,8 +409,8 @@ class LtftServiceTest {
         .build();
     entity.setContent(content);
 
-    when(
-        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
             any(), any(), any())).thenReturn(Optional.of(entity));
 
     Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
@@ -451,8 +451,8 @@ class LtftServiceTest {
         .build();
     entity.setContent(content);
 
-    when(
-        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
             any(), any(), any())).thenReturn(Optional.of(entity));
 
     Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
@@ -483,8 +483,8 @@ class LtftServiceTest {
         .build();
     entity.setContent(content);
 
-    when(
-        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
             any(), any(), any())).thenReturn(Optional.of(entity));
 
     Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
@@ -516,8 +516,8 @@ class LtftServiceTest {
         .build();
     entity.setContent(content);
 
-    when(
-        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
             any(), any(), any())).thenReturn(Optional.of(entity));
 
     Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
@@ -561,8 +561,8 @@ class LtftServiceTest {
         .build();
     entity.setContent(content);
 
-    when(
-        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
             any(), any(), any())).thenReturn(Optional.of(entity));
 
     Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
@@ -593,8 +593,8 @@ class LtftServiceTest {
         .build();
     entity.setContent(content);
 
-    when(
-        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
             any(), any(), any())).thenReturn(Optional.of(entity));
 
     Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
@@ -624,8 +624,8 @@ class LtftServiceTest {
         .build();
     entity.setContent(content);
 
-    when(
-        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
             any(), any(), any())).thenReturn(Optional.of(entity));
 
     Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
@@ -683,8 +683,8 @@ class LtftServiceTest {
         ))
         .build());
 
-    when(
-        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
             any(), any(), any())).thenReturn(Optional.of(entity));
 
     Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -22,7 +22,9 @@
 package uk.nhs.hee.tis.trainee.forms.service;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -34,6 +36,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -48,7 +51,16 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.CctChangeDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.DeclarationsDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.DiscussionsDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.ProgrammeMembershipDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.ReasonsDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto.StatusInfoDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftSummaryDto;
+import uk.nhs.hee.tis.trainee.forms.dto.PersonDto;
+import uk.nhs.hee.tis.trainee.forms.dto.PersonalDetailsDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.dto.identity.AdminIdentity;
 import uk.nhs.hee.tis.trainee.forms.dto.identity.TraineeIdentity;
@@ -56,11 +68,18 @@ import uk.nhs.hee.tis.trainee.forms.mapper.LtftMapper;
 import uk.nhs.hee.tis.trainee.forms.mapper.LtftMapperImpl;
 import uk.nhs.hee.tis.trainee.forms.mapper.TemporalMapperImpl;
 import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status.StatusInfo;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 import uk.nhs.hee.tis.trainee.forms.model.Person;
+import uk.nhs.hee.tis.trainee.forms.model.content.CctChange;
+import uk.nhs.hee.tis.trainee.forms.model.content.CctChangeType;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
+import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent.Declarations;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent.Discussions;
+import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent.PersonalDetails;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent.ProgrammeMembership;
+import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent.Reasons;
 import uk.nhs.hee.tis.trainee.forms.repository.LtftFormRepository;
 
 class LtftServiceTest {
@@ -196,7 +215,7 @@ class LtftServiceTest {
 
   @ParameterizedTest
   @NullAndEmptySource
-  void shouldGetAllLocalOfficeLtftWhenFiltersEmpty(Set<LifecycleState> states) {
+  void shouldGetAllAdminLtftsWhenFiltersEmpty(Set<LifecycleState> states) {
     PageRequest pageRequest = PageRequest.of(1, 1);
 
     LtftForm entity1 = new LtftForm();
@@ -225,7 +244,7 @@ class LtftServiceTest {
   }
 
   @Test
-  void shouldGetFilteredLocalOfficeLtftWhenFiltersNotEmpty() {
+  void shouldGetFilteredAdminLtftsWhenFiltersNotEmpty() {
     Set<LifecycleState> states = Set.of(LifecycleState.SUBMITTED);
     PageRequest pageRequest = PageRequest.of(1, 1);
 
@@ -252,6 +271,419 @@ class LtftServiceTest {
 
     verify(ltftRepository, never()).findByContent_ProgrammeMembership_DesignatedBodyCodeIn(any(),
         any());
+  }
+
+  @Test
+  void shouldGetAdminLtftDetailWithFormId() {
+    service.getAdminLtftDetail(ID);
+
+    verify(ltftRepository)
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            eq(ID), any(), any());
+  }
+
+  @Test
+  void shouldGetAdminLtftDetailWithDraftExcluded() {
+    service.getAdminLtftDetail(ID);
+
+    verify(ltftRepository)
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), eq(Set.of(LifecycleState.DRAFT)), any());
+  }
+
+  @Test
+  void shouldGetAdminLtftDetailWithAdminDbcs() {
+    service.getAdminLtftDetail(ID);
+
+    verify(ltftRepository)
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), eq(Set.of(ADMIN_GROUP)));
+  }
+
+  @Test
+  void shouldGetEmptyAdminLtftDetailWhenFormNotFound() {
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.empty());
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(false));
+  }
+
+  @Test
+  void shouldGetAdminLtftDetailWhenFormFound() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+    entity.setTraineeTisId(TRAINEE_ID);
+    entity.setFormRef("LTFT_test_ref");
+    entity.setRevision(1);
+    entity.setCreated(Instant.MIN);
+    entity.setLastModified(Instant.MAX);
+
+    LtftContent content = LtftContent.builder()
+        .name("Test LTFT")
+        .build();
+    entity.setContent(content);
+
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    assertThat("Unexpected ID.", dto.id(), is(ID));
+    assertThat("Unexpected trainee ID.", dto.traineeTisId(), is(TRAINEE_ID));
+    assertThat("Unexpected form ref.", dto.formRef(), is("LTFT_test_ref"));
+    assertThat("Unexpected revision.", dto.revision(), is(1));
+    assertThat("Unexpected name.", dto.name(), is("Test LTFT"));
+    assertThat("Unexpected created.", dto.created(), is(Instant.MIN));
+    assertThat("Unexpected lastModified.", dto.lastModified(), is(Instant.MAX));
+  }
+
+  @Test
+  void shouldGetAdminLtftPersonalDetailsDetailWhenFormFound() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+    entity.setTraineeTisId(TRAINEE_ID);
+
+    LtftContent content = LtftContent.builder()
+        .personalDetails(PersonalDetails.builder()
+            .title("Dr")
+            .forenames("Anthony")
+            .surname("Gilliam")
+            .email("anthony.gilliam@example.com")
+            .telephoneNumber("07700900000")
+            .mobileNumber("07700900001")
+            .gmcNumber("1234567")
+            .gdcNumber("D123456")
+            .skilledWorkerVisaHolder(true)
+            .build())
+        .build();
+    entity.setContent(content);
+
+    when(
+        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    PersonalDetailsDto personalDetails = dto.personalDetails();
+    assertThat("Unexpected ID.", personalDetails.id(), is(TRAINEE_ID));
+    assertThat("Unexpected title.", personalDetails.title(), is("Dr"));
+    assertThat("Unexpected forenames.", personalDetails.forenames(), is("Anthony"));
+    assertThat("Unexpected surname.", personalDetails.surname(), is("Gilliam"));
+    assertThat("Unexpected email.", personalDetails.email(), is("anthony.gilliam@example.com"));
+    assertThat("Unexpected telephone number.", personalDetails.telephoneNumber(),
+        is("07700900000"));
+    assertThat("Unexpected mobile number.", personalDetails.mobileNumber(), is("07700900001"));
+    assertThat("Unexpected GMC number.", personalDetails.gmcNumber(), is("1234567"));
+    assertThat("Unexpected GDC number.", personalDetails.gdcNumber(), is("D123456"));
+    assertThat("Unexpected visa flag.", personalDetails.skilledWorkerVisaHolder(), is(true));
+  }
+
+  @Test
+  void shouldGetAdminLtftProgrammeMembershipDetailWhenFormFound() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+
+    UUID pmId = UUID.randomUUID();
+
+    LtftContent content = LtftContent.builder()
+        .programmeMembership(ProgrammeMembership.builder()
+            .id(pmId)
+            .name("Test PM")
+            .designatedBodyCode("1-1DBC")
+            .startDate(LocalDate.MIN)
+            .endDate(LocalDate.MAX)
+            .wte(0.75)
+            .build())
+        .build();
+    entity.setContent(content);
+
+    when(
+        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    ProgrammeMembershipDto programmeMembership = dto.programmeMembership();
+    assertThat("Unexpected PM ID.", programmeMembership.id(), is(pmId));
+    assertThat("Unexpected PM name.", programmeMembership.name(), is("Test PM"));
+    assertThat("Unexpected PM DBC.", programmeMembership.designatedBodyCode(), is("1-1DBC"));
+    assertThat("Unexpected PM start date.", programmeMembership.startDate(), is(LocalDate.MIN));
+    assertThat("Unexpected PM end date.", programmeMembership.endDate(), is(LocalDate.MAX));
+    assertThat("Unexpected PM wte.", programmeMembership.wte(), is(0.75));
+  }
+
+  @Test
+  void shouldGetAdminLtftDeclarationsDetailWhenFormFound() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+
+    LtftContent content = LtftContent.builder()
+        .declarations(Declarations.builder()
+            .discussedWithTpd(true)
+            .notGuaranteed(false)
+            .informationIsCorrect(true)
+            .build())
+        .build();
+    entity.setContent(content);
+
+    when(
+        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    DeclarationsDto declarations = dto.declarations();
+    assertThat("Unexpected declaration.", declarations.discussedWithTpd(), is(true));
+    assertThat("Unexpected declaration.", declarations.notGuaranteed(), is(false));
+    assertThat("Unexpected declaration.", declarations.informationIsCorrect(), is(true));
+  }
+
+  @Test
+  void shouldGetAdminLtftDiscussionDetailWhenFormFound() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+
+    LtftContent content = LtftContent.builder()
+        .discussions(Discussions.builder()
+            .tpdName("Tee Pee-Dee")
+            .tpdEmail("t.pd@example.com")
+            .other(List.of(
+                Person.builder().name("Other 1").email("other.1@example.com").role("Role 1")
+                    .build(),
+                Person.builder().name("Other 2").email("other.2@example.com").role("Role 2").build()
+            ))
+            .build())
+        .build();
+    entity.setContent(content);
+
+    when(
+        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    DiscussionsDto discussions = dto.discussions();
+    assertThat("Unexpected TPD name.", discussions.tpdName(), is("Tee Pee-Dee"));
+    assertThat("Unexpected TPD email.", discussions.tpdEmail(), is("t.pd@example.com"));
+    assertThat("Unexpected other discussion count.", discussions.other(), hasSize(2));
+
+    PersonDto discussion1 = discussions.other().get(0);
+    assertThat("Unexpected discussion name.", discussion1.name(), is("Other 1"));
+    assertThat("Unexpected discussion email.", discussion1.email(), is("other.1@example.com"));
+    assertThat("Unexpected discussion role.", discussion1.role(), is("Role 1"));
+
+    PersonDto discussion2 = discussions.other().get(1);
+    assertThat("Unexpected discussion name.", discussion2.name(), is("Other 2"));
+    assertThat("Unexpected discussion email.", discussion2.email(), is("other.2@example.com"));
+    assertThat("Unexpected discussion role.", discussion2.role(), is("Role 2"));
+  }
+
+  @Test
+  void shouldGetAdminLtftChangeDetailWhenFormFound() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+
+    UUID changeId = UUID.randomUUID();
+    UUID calculationId = UUID.randomUUID();
+
+    LtftContent content = LtftContent.builder()
+        .change(CctChange.builder()
+            .id(changeId)
+            .calculationId(calculationId)
+            .type(CctChangeType.LTFT)
+            .wte(0.5)
+            .startDate(LocalDate.MIN)
+            .endDate(LocalDate.EPOCH)
+            .build())
+        .build();
+    entity.setContent(content);
+
+    when(
+        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    CctChangeDto change = dto.change();
+    assertThat("Unexpected ID.", change.id(), is(changeId));
+    assertThat("Unexpected calculation ID.", change.calculationId(), is(calculationId));
+    assertThat("Unexpected type.", change.type(), is(CctChangeType.LTFT));
+    assertThat("Unexpected WTE.", change.wte(), is(0.5));
+    assertThat("Unexpected start date.", change.startDate(), is(LocalDate.MIN));
+    assertThat("Unexpected end date.", change.endDate(), is(LocalDate.EPOCH));
+    assertThat("Unexpected CCT date.", change.cctDate(), nullValue());
+  }
+
+  @Test
+  void shouldGetAdminLtftReasonsDetailWhenFormFound() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+
+    LtftContent content = LtftContent.builder()
+        .reasons(Reasons.builder()
+            .selected(List.of("Test Reason 2", "Test Reason 1", "Test Reason 3"))
+            .otherDetail("Other Detail")
+            .build())
+        .build();
+    entity.setContent(content);
+
+    when(
+        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    ReasonsDto reasons = dto.reasons();
+    assertThat("Unexpected reason count.", reasons.selected(), hasSize(3));
+    assertThat("Unexpected reason.", reasons.selected().get(0), is("Test Reason 2"));
+    assertThat("Unexpected reason.", reasons.selected().get(1), is("Test Reason 1"));
+    assertThat("Unexpected reason.", reasons.selected().get(2), is("Test Reason 3"));
+    assertThat("Unexpected reason detail.", reasons.otherDetail(), is("Other Detail"));
+  }
+
+  @Test
+  void shouldGetAdminLtftAssignedAdminDetailWhenFormFound() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+
+    LtftContent content = LtftContent.builder()
+        .assignedAdmin(Person.builder()
+            .name("Ad Min")
+            .email("ad.min@example.com")
+            .role("ADMIN")
+            .build())
+        .build();
+    entity.setContent(content);
+
+    when(
+        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    PersonDto assignedAdmin = dto.assignedAdmin();
+    assertThat("Unexpected admin name.", assignedAdmin.name(), is("Ad Min"));
+    assertThat("Unexpected admin email.", assignedAdmin.email(), is("ad.min@example.com"));
+    assertThat("Unexpected admin role.", assignedAdmin.role(), is("ADMIN"));
+  }
+
+  @Test
+  void shouldGetAdminLtftStatusDetailWhenFormFound() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+    entity.setContent(LtftContent.builder().build());
+
+    entity.setStatus(Status.builder()
+        .current(StatusInfo.builder()
+            .state(LifecycleState.SUBMITTED)
+            .detail("Submitted Detail")
+            .timestamp(Instant.EPOCH)
+            .revision(1)
+            .modifiedBy(Person.builder()
+                .name("Anthony Gilliam")
+                .email("anthony.gilliam@example.com")
+                .role("TRAINEE")
+                .build())
+            .build())
+        .history(List.of(
+            StatusInfo.builder()
+                .state(LifecycleState.DRAFT)
+                .detail("Draft Detail")
+                .timestamp(Instant.MIN)
+                .revision(0)
+                .modifiedBy(Person.builder()
+                    .name("Anthony Gilliam")
+                    .email("anthony.gilliam@example.com")
+                    .role("TRAINEE")
+                    .build())
+                .build(),
+            StatusInfo.builder()
+                .state(LifecycleState.SUBMITTED)
+                .detail("Submitted Detail")
+                .timestamp(Instant.EPOCH)
+                .revision(1)
+                .modifiedBy(Person.builder()
+                    .name("Anthony Gilliam")
+                    .email("anthony.gilliam@example.com")
+                    .role("TRAINEE")
+                    .build())
+                .build()
+        ))
+        .build());
+
+    when(
+        ltftRepository.findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    StatusDto status = dto.status();
+    StatusInfoDto currentStatus = status.current();
+    assertThat("Unexpected state.", currentStatus.state(), is(LifecycleState.SUBMITTED));
+    assertThat("Unexpected detail.", currentStatus.detail(), is("Submitted Detail"));
+    assertThat("Unexpected timestamp.", currentStatus.timestamp(), is(Instant.EPOCH));
+    assertThat("Unexpected revision.", currentStatus.revision(), is(1));
+
+    PersonDto modifiedBy = currentStatus.modifiedBy();
+    assertThat("Unexpected modified name.", modifiedBy.name(), is("Anthony Gilliam"));
+    assertThat("Unexpected modified email.", modifiedBy.email(), is("anthony.gilliam@example.com"));
+    assertThat("Unexpected modified role.", modifiedBy.role(), is("TRAINEE"));
+
+    List<StatusInfoDto> statusHistory = status.history();
+    assertThat("Unexpected history count.", statusHistory, hasSize(2));
+
+    StatusInfoDto history1 = statusHistory.get(0);
+    assertThat("Unexpected state.", history1.state(), is(LifecycleState.DRAFT));
+    assertThat("Unexpected detail.", history1.detail(), is("Draft Detail"));
+    assertThat("Unexpected timestamp.", history1.timestamp(), is(Instant.MIN));
+    assertThat("Unexpected revision.", history1.revision(), is(0));
+
+    modifiedBy = history1.modifiedBy();
+    assertThat("Unexpected modified name.", modifiedBy.name(), is("Anthony Gilliam"));
+    assertThat("Unexpected modified email.", modifiedBy.email(), is("anthony.gilliam@example.com"));
+    assertThat("Unexpected modified role.", modifiedBy.role(), is("TRAINEE"));
+
+    StatusInfoDto history2 = statusHistory.get(1);
+    assertThat("Unexpected state.", history2.state(), is(LifecycleState.SUBMITTED));
+    assertThat("Unexpected detail.", history2.detail(), is("Submitted Detail"));
+    assertThat("Unexpected timestamp.", history2.timestamp(), is(Instant.EPOCH));
+    assertThat("Unexpected revision.", history2.revision(), is(1));
+
+    modifiedBy = history2.modifiedBy();
+    assertThat("Unexpected modified name.", modifiedBy.name(), is("Anthony Gilliam"));
+    assertThat("Unexpected modified email.", modifiedBy.email(), is("anthony.gilliam@example.com"));
+    assertThat("Unexpected modified role.", modifiedBy.role(), is("TRAINEE"));
   }
 
   @Test


### PR DESCRIPTION
# feat(ltft): add admin detail endpoint
Add an endpoint for admins to get LTFT application details for a given
ID.
The LTFT must be associated with one of the admin's assigned DBCs, only
non-DRAFT forms are accessible to admins.

TIS21-6602
TIS21-7011

---

# fix(ltft): exclude DRAFT LTFTs from admin summary
The admin summary list should not include any DRAFT forms, update
LtftService to exclude DRAFTs when no filters are provided and to
remove DRAFT from the requested states if included in the request.

TIS21-6600
TIS21-7019

---

# fix(ltft): exclude DRAFT LTFT from admin count
Admins do not have visibility of DRAFT LTFT forms, remove them from the
count so there is no possibility of getting a conflicting result.

TIS21-6599
TIS21-6938