### PR TITLE
fix(ltft): allow nullable fields and don't null CCT Date

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.31.0"
+version = "0.31.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
@@ -86,7 +86,7 @@ public record LtftFormDto(
       UUID id,
       UUID calculationId,
       CctChangeType type,
-      double wte,
+      Double wte,
       LocalDate startDate,
       LocalDate endDate,
       LocalDate cctDate) {
@@ -102,9 +102,9 @@ public record LtftFormDto(
    */
   @Builder
   public record DeclarationsDto(
-      boolean discussedWithTpd,
-      boolean informationIsCorrect,
-      boolean notGuaranteed) {
+      Boolean discussedWithTpd,
+      Boolean informationIsCorrect,
+      Boolean notGuaranteed) {
 
   }
 
@@ -125,7 +125,7 @@ public record LtftFormDto(
       String designatedBodyCode,
       LocalDate startDate,
       LocalDate endDate,
-      double wte) {
+      Double wte) {
 
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/PersonalDetailsDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/PersonalDetailsDto.java
@@ -48,6 +48,6 @@ public record PersonalDetailsDto(
     String mobileNumber,
     String gmcNumber,
     String gdcNumber,
-    boolean skilledWorkerVisaHolder) {
+    Boolean skilledWorkerVisaHolder) {
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
@@ -41,7 +41,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto.LtftAdminPersonalDetailsDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
-import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.CctChangeDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.PersonalDetailsDto;
 import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm;
@@ -125,32 +124,20 @@ public abstract class LtftMapper {
   /**
    * Convert a {@link LtftForm} to {@link LtftFormDto} DTO.
    *
-   * @param entity  The form to convert.
-   * @param cctDate The calculated CCT date.
+   * @param entity The form to convert.
    * @return The equivalent DTO.
    */
-  @Mapping(target = "id", source = "entity.id")
-  @Mapping(target = "formRef", source = "entity.formRef")
-  @Mapping(target = "name", source = "entity.content.name")
-  @Mapping(target = "personalDetails", source = "entity")
-  @Mapping(target = "programmeMembership", source = "entity.content.programmeMembership")
-  @Mapping(target = "declarations", source = "entity.content.declarations")
-  @Mapping(target = "discussions", source = "entity.content.discussions")
-  @Mapping(target = "change", expression = "java(toDto(entity.getContent().change(), cctDate))")
-  @Mapping(target = "reasons", source = "entity.content.reasons")
-  @Mapping(target = "assignedAdmin", source = "entity.content.assignedAdmin")
-  public abstract LtftFormDto toDto(LtftForm entity, LocalDate cctDate);
-
-  /**
-   * Convert a {@link CctChange} to {@link CctChangeDto}.
-   *
-   * @param entity  The entity to convert.
-   * @param cctDate The calculated CCT date.
-   * @return The equivalent DTO.
-   */
-  @Mapping(target = ".", source = "entity")
-  @Mapping(target = "cctDate", source = "cctDate")
-  public abstract CctChangeDto toDto(CctChange entity, LocalDate cctDate);
+  @Mapping(target = "id", source = "id")
+  @Mapping(target = "formRef", source = "formRef")
+  @Mapping(target = "name", source = "content.name")
+  @Mapping(target = "personalDetails", source = ".")
+  @Mapping(target = "programmeMembership", source = "content.programmeMembership")
+  @Mapping(target = "declarations", source = "content.declarations")
+  @Mapping(target = "discussions", source = "content.discussions")
+  @Mapping(target = "change", source = "content.change")
+  @Mapping(target = "reasons", source = "content.reasons")
+  @Mapping(target = "assignedAdmin", source = "content.assignedAdmin")
+  public abstract LtftFormDto toDto(LtftForm entity);
 
   /**
    * Convert a {@link LtftFormDto} DTO to a {@link LtftForm}.

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/CctChange.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/CctChange.java
@@ -42,7 +42,7 @@ public record CctChange(
     UUID id,
     UUID calculationId,
     CctChangeType type,
-    double wte,
+    Double wte,
     LocalDate startDate,
     LocalDate endDate
 ) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/CctChange.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/CctChange.java
@@ -35,6 +35,7 @@ import org.springframework.data.mongodb.core.mapping.Field;
  * @param wte           The whole time equivalent after the change.
  * @param startDate     The start date of the change.
  * @param endDate       The end date of the change.
+ * @param cctDate       The new expected CCT/programme completion date.
  */
 @Builder
 public record CctChange(
@@ -44,7 +45,7 @@ public record CctChange(
     CctChangeType type,
     Double wte,
     LocalDate startDate,
-    LocalDate endDate
-) {
+    LocalDate endDate,
+    LocalDate cctDate) {
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/LtftContent.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/LtftContent.java
@@ -75,7 +75,7 @@ public record LtftContent(
       String mobileNumber,
       String gmcNumber,
       String gdcNumber,
-      boolean skilledWorkerVisaHolder) {
+      Boolean skilledWorkerVisaHolder) {
 
   }
 
@@ -99,7 +99,7 @@ public record LtftContent(
       String designatedBodyCode,
       LocalDate startDate,
       LocalDate endDate,
-      double wte) {
+      Double wte) {
 
   }
 
@@ -112,9 +112,9 @@ public record LtftContent(
    */
   @Builder
   public record Declarations(
-      boolean discussedWithTpd,
-      boolean informationIsCorrect,
-      boolean notGuaranteed) {
+      Boolean discussedWithTpd,
+      Boolean informationIsCorrect,
+      Boolean notGuaranteed) {
 
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -156,7 +156,7 @@ public class LtftService {
     Optional<LtftForm> form = ltftFormRepository.
         findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
             formId, Set.of(DRAFT), adminIdentity.getGroups());
-    return form.map(v -> mapper.toDto(v, null));
+    return form.map(mapper::toDto);
   }
 
   /**
@@ -173,7 +173,7 @@ public class LtftService {
         value -> log.info("Found form {} for trainee [{}]", formId, traineeId),
         () -> log.info("Did not find form {} for trainee [{}]", formId, traineeId)
     );
-    return form.map(v -> mapper.toDto(v, null));
+    return form.map(mapper::toDto);
   }
 
   /**
@@ -192,7 +192,7 @@ public class LtftService {
       return Optional.empty();
     }
     LtftForm savedForm = ltftFormRepository.save(form);
-    return Optional.of(mapper.toDto(savedForm, null));
+    return Optional.of(mapper.toDto(savedForm));
   }
 
   /**
@@ -224,7 +224,7 @@ public class LtftService {
     }
     form.setCreated(existingForm.get().getCreated()); //explicitly set otherwise form saved as 'new'
     LtftForm savedForm = ltftFormRepository.save(form);
-    return Optional.of(mapper.toDto(savedForm, null));
+    return Optional.of(mapper.toDto(savedForm));
   }
 
   /**
@@ -260,7 +260,6 @@ public class LtftService {
    *
    * @param formId The id of the LTFT form to approve.
    * @param detail The status detail for the approval.
-   *
    * @return The DTO of the approved form, or empty if form not found or could not be approved.
    */
   public Optional<LtftFormDto> submitLtftForm(UUID formId,
@@ -289,6 +288,6 @@ public class LtftService {
     log.info("Submitting form {} for trainee [{}]", formId, traineeId);
     form.setLifecycleState(LifecycleState.SUBMITTED, statusDetail, modifiedBy, form.getRevision());
     LtftForm savedForm = ltftFormRepository.save(form);
-    return Optional.of(mapper.toDto(savedForm, null));
+    return Optional.of(mapper.toDto(savedForm));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -697,6 +697,7 @@ class LtftServiceTest {
             .wte(0.5)
             .startDate(LocalDate.MIN)
             .endDate(LocalDate.EPOCH)
+            .cctDate(LocalDate.MAX)
             .build())
         .build();
     entity.setContent(content);
@@ -717,7 +718,7 @@ class LtftServiceTest {
     assertThat("Unexpected WTE.", change.wte(), is(0.5));
     assertThat("Unexpected start date.", change.startDate(), is(LocalDate.MIN));
     assertThat("Unexpected end date.", change.endDate(), is(LocalDate.EPOCH));
-    assertThat("Unexpected CCT date.", change.cctDate(), nullValue());
+    assertThat("Unexpected CCT date.", change.cctDate(), is(LocalDate.MAX));
   }
 
   @Test
@@ -1012,7 +1013,7 @@ class LtftServiceTest {
     assertThat("Unexpected form returned.", formDtoOptional.isEmpty(), is(false));
     verify(ltftRepository).findByTraineeTisIdAndId(TRAINEE_ID, ID);
     LtftFormDto returnedFormDto = formDtoOptional.get();
-    assertThat("Unexpected returned LTFT form.", returnedFormDto, is(mapper.toDto(form, null)));
+    assertThat("Unexpected returned LTFT form.", returnedFormDto, is(mapper.toDto(form)));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -395,6 +395,30 @@ class LtftServiceTest {
   }
 
   @Test
+  void shouldGetAdminLtftDetailWithDefaultValuesWhenFormFoundWithNullValues() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+    entity.setContent(LtftContent.builder().build());
+
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    assertThat("Unexpected ID.", dto.id(), is(ID));
+    assertThat("Unexpected trainee ID.", dto.traineeTisId(), nullValue());
+    assertThat("Unexpected form ref.", dto.formRef(), nullValue());
+    assertThat("Unexpected revision.", dto.revision(), is(0));
+    assertThat("Unexpected name.", dto.name(), nullValue());
+    assertThat("Unexpected created.", dto.created(), nullValue());
+    assertThat("Unexpected lastModified.", dto.lastModified(), nullValue());
+  }
+
+  @Test
   void shouldGetAdminLtftPersonalDetailsDetailWhenFormFound() {
     LtftForm entity = new LtftForm();
     entity.setId(ID);
@@ -439,6 +463,38 @@ class LtftServiceTest {
   }
 
   @Test
+  void shouldGetAdminLtftPersonalDetailsDetailWithDefaultValuesWhenFormFoundWithNullValues() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+
+    LtftContent content = LtftContent.builder()
+        .personalDetails(PersonalDetails.builder().build())
+        .build();
+    entity.setContent(content);
+
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    PersonalDetailsDto personalDetails = dto.personalDetails();
+    assertThat("Unexpected ID.", personalDetails.id(), nullValue());
+    assertThat("Unexpected title.", personalDetails.title(), nullValue());
+    assertThat("Unexpected forenames.", personalDetails.forenames(), nullValue());
+    assertThat("Unexpected surname.", personalDetails.surname(), nullValue());
+    assertThat("Unexpected email.", personalDetails.email(), nullValue());
+    assertThat("Unexpected telephone number.", personalDetails.telephoneNumber(), nullValue());
+    assertThat("Unexpected mobile number.", personalDetails.mobileNumber(), nullValue());
+    assertThat("Unexpected GMC number.", personalDetails.gmcNumber(), nullValue());
+    assertThat("Unexpected GDC number.", personalDetails.gdcNumber(), nullValue());
+    assertThat("Unexpected visa flag.", personalDetails.skilledWorkerVisaHolder(), nullValue());
+  }
+
+  @Test
   void shouldGetAdminLtftProgrammeMembershipDetailWhenFormFound() {
     LtftForm entity = new LtftForm();
     entity.setId(ID);
@@ -476,6 +532,34 @@ class LtftServiceTest {
   }
 
   @Test
+  void shouldGetAdminLtftProgrammeMembershipDetailWithDefaultValuesWhenFormFoundWithNullValues() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+
+    LtftContent content = LtftContent.builder()
+        .programmeMembership(ProgrammeMembership.builder().build())
+        .build();
+    entity.setContent(content);
+
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    ProgrammeMembershipDto programmeMembership = dto.programmeMembership();
+    assertThat("Unexpected PM ID.", programmeMembership.id(), nullValue());
+    assertThat("Unexpected PM name.", programmeMembership.name(), nullValue());
+    assertThat("Unexpected PM DBC.", programmeMembership.designatedBodyCode(), nullValue());
+    assertThat("Unexpected PM start date.", programmeMembership.startDate(), nullValue());
+    assertThat("Unexpected PM end date.", programmeMembership.endDate(), nullValue());
+    assertThat("Unexpected PM wte.", programmeMembership.wte(), nullValue());
+  }
+
+  @Test
   void shouldGetAdminLtftDeclarationsDetailWhenFormFound() {
     LtftForm entity = new LtftForm();
     entity.setId(ID);
@@ -502,6 +586,31 @@ class LtftServiceTest {
     assertThat("Unexpected declaration.", declarations.discussedWithTpd(), is(true));
     assertThat("Unexpected declaration.", declarations.notGuaranteed(), is(false));
     assertThat("Unexpected declaration.", declarations.informationIsCorrect(), is(true));
+  }
+
+  @Test
+  void shouldGetAdminLtftDeclarationsDetailWithDefaultValuesWhenFormFoundWithNullValues() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+
+    LtftContent content = LtftContent.builder()
+        .declarations(Declarations.builder().build())
+        .build();
+    entity.setContent(content);
+
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    DeclarationsDto declarations = dto.declarations();
+    assertThat("Unexpected declaration.", declarations.discussedWithTpd(), nullValue());
+    assertThat("Unexpected declaration.", declarations.notGuaranteed(), nullValue());
+    assertThat("Unexpected declaration.", declarations.informationIsCorrect(), nullValue());
   }
 
   @Test
@@ -548,6 +657,31 @@ class LtftServiceTest {
   }
 
   @Test
+  void shouldGetAdminLtftDiscussionDetailWithDefaultValuesWhenFormFoundWithNullValues() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+
+    LtftContent content = LtftContent.builder()
+        .discussions(Discussions.builder().build())
+        .build();
+    entity.setContent(content);
+
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    DiscussionsDto discussions = dto.discussions();
+    assertThat("Unexpected TPD name.", discussions.tpdName(), nullValue());
+    assertThat("Unexpected TPD email.", discussions.tpdEmail(), nullValue());
+    assertThat("Unexpected other discussion count.", discussions.other(), nullValue());
+  }
+
+  @Test
   void shouldGetAdminLtftChangeDetailWhenFormFound() {
     LtftForm entity = new LtftForm();
     entity.setId(ID);
@@ -587,6 +721,35 @@ class LtftServiceTest {
   }
 
   @Test
+  void shouldGetAdminLtftChangeDetailWithDefaultValuesWhenFormFoundWithNullValues() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+
+    LtftContent content = LtftContent.builder()
+        .change(CctChange.builder().build())
+        .build();
+    entity.setContent(content);
+
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    CctChangeDto change = dto.change();
+    assertThat("Unexpected ID.", change.id(), nullValue());
+    assertThat("Unexpected calculation ID.", change.calculationId(), nullValue());
+    assertThat("Unexpected type.", change.type(), nullValue());
+    assertThat("Unexpected WTE.", change.wte(), nullValue());
+    assertThat("Unexpected start date.", change.startDate(), nullValue());
+    assertThat("Unexpected end date.", change.endDate(), nullValue());
+    assertThat("Unexpected CCT date.", change.cctDate(), nullValue());
+  }
+
+  @Test
   void shouldGetAdminLtftReasonsDetailWhenFormFound() {
     LtftForm entity = new LtftForm();
     entity.setId(ID);
@@ -617,6 +780,30 @@ class LtftServiceTest {
   }
 
   @Test
+  void shouldGetAdminLtftReasonsDetailWithDefaultValuesWhenFormFoundWithNullValues() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+
+    LtftContent content = LtftContent.builder()
+        .reasons(Reasons.builder().build())
+        .build();
+    entity.setContent(content);
+
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    ReasonsDto reasons = dto.reasons();
+    assertThat("Unexpected reason count.", reasons.selected(), nullValue());
+    assertThat("Unexpected reason detail.", reasons.otherDetail(), nullValue());
+  }
+
+  @Test
   void shouldGetAdminLtftAssignedAdminDetailWhenFormFound() {
     LtftForm entity = new LtftForm();
     entity.setId(ID);
@@ -643,6 +830,31 @@ class LtftServiceTest {
     assertThat("Unexpected admin name.", assignedAdmin.name(), is("Ad Min"));
     assertThat("Unexpected admin email.", assignedAdmin.email(), is("ad.min@example.com"));
     assertThat("Unexpected admin role.", assignedAdmin.role(), is("ADMIN"));
+  }
+
+  @Test
+  void shouldGetAdminLtftAssignedAdminDetailWithDefaultValuesWhenFormFoundWithNullValues() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+
+    LtftContent content = LtftContent.builder()
+        .assignedAdmin(Person.builder().build())
+        .build();
+    entity.setContent(content);
+
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    PersonDto assignedAdmin = dto.assignedAdmin();
+    assertThat("Unexpected admin name.", assignedAdmin.name(), nullValue());
+    assertThat("Unexpected admin email.", assignedAdmin.email(), nullValue());
+    assertThat("Unexpected admin role.", assignedAdmin.role(), nullValue());
   }
 
   @Test
@@ -740,6 +952,28 @@ class LtftServiceTest {
     assertThat("Unexpected modified name.", modifiedBy.name(), is("Anthony Gilliam"));
     assertThat("Unexpected modified email.", modifiedBy.email(), is("anthony.gilliam@example.com"));
     assertThat("Unexpected modified role.", modifiedBy.role(), is("TRAINEE"));
+  }
+
+  @Test
+  void shouldGetAdminLtftStatusDetailWithDefaultValuesWhenFormFoundWithNullValues() {
+    LtftForm entity = new LtftForm();
+    entity.setId(ID);
+    entity.setContent(LtftContent.builder().build());
+
+    entity.setStatus(Status.builder().build());
+
+    when(ltftRepository
+        .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+            any(), any(), any())).thenReturn(Optional.of(entity));
+
+    Optional<LtftFormDto> optionalDto = service.getAdminLtftDetail(ID);
+
+    assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+    StatusDto status = dto.status();
+    assertThat("Unexpected state.", status.current(), nullValue());
+    assertThat("Unexpected history count.", status.history(), nullValue());
   }
 
   @Test


### PR DESCRIPTION
# fix(ltft): don't set null fields to default values

Several LTFT fields can have valid `null` values when working with a DRAFT form, if that section has not been filled in. Currently several fields are using primitive boolean and numerical types, which are being defaulted to `false`/`0`.

Update the LTFT entity and model to use non-primative types which can be defaulted to `null`.
Several of these fields should never be `null`, such as PM WTE which is always expected to be populated. However, defaulting to erroneous values causes more issues than missing data, as the source of the value becomes unknown/lost.

---

# fix(ltft): save given CCT Date
The current DTO includes CCT Date in the programme membership, but the
database model does not. The result is that the CCT Date is dropped and
cannot be retrieved again.

Add `cctDate` to the `CctChange` model and configure the `LtftMapper` to
copy the value across.

---

TIS21-6540