### PR TITLE
feat(ltft): admin approval endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.32.0"
+version = "0.33.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
@@ -459,7 +459,7 @@ class LtftResourceIntegrationTest {
         .andExpect(jsonPath("$.status.current.detail.message").value("message"))
         .andExpect(jsonPath("$.status.current.modifiedBy.name").value("given family"))
         .andExpect(jsonPath("$.status.current.modifiedBy.email").value("email"))
-        .andExpect(jsonPath("$.status.current.modifiedBy.role").value(TraineeIdentity.ROLE));
+        .andExpect(jsonPath("$.status.current.modifiedBy.role").value("TRAINEE"));
   }
 
   @ParameterizedTest
@@ -536,7 +536,7 @@ class LtftResourceIntegrationTest {
         .andExpect(jsonPath("$.status.current.detail.message").value("message"))
         .andExpect(jsonPath("$.status.current.modifiedBy.name").value("given family"))
         .andExpect(jsonPath("$.status.current.modifiedBy.email").value("email"))
-        .andExpect(jsonPath("$.status.current.modifiedBy.role").value(TraineeIdentity.ROLE));
+        .andExpect(jsonPath("$.status.current.modifiedBy.role").value("TRAINEE"));
   }
 
   @ParameterizedTest
@@ -589,6 +589,6 @@ class LtftResourceIntegrationTest {
         .andExpect(jsonPath("$.status.current.detail.message").value("message"))
         .andExpect(jsonPath("$.status.current.modifiedBy.name").value("given family"))
         .andExpect(jsonPath("$.status.current.modifiedBy.email").value("email"))
-        .andExpect(jsonPath("$.status.current.modifiedBy.role").value(TraineeIdentity.ROLE));
+        .andExpect(jsonPath("$.status.current.modifiedBy.role").value("TRAINEE"));
   }
 }

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
@@ -55,6 +55,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -65,7 +66,6 @@ import uk.nhs.hee.tis.trainee.forms.DockerImageNames;
 import uk.nhs.hee.tis.trainee.forms.TestJwtUtil;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
-import uk.nhs.hee.tis.trainee.forms.dto.identity.TraineeIdentity;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 import uk.nhs.hee.tis.trainee.forms.model.Person;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
@@ -249,10 +249,16 @@ class LtftResourceIntegrationTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(formToSaveJson))
         .andExpect(status().isBadRequest())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.fieldErrors", hasSize(1)))
-        .andExpect(jsonPath("$.fieldErrors[0].field").value("id"))
-        .andExpect(jsonPath("$.fieldErrors[0].message").value("must be null"));
+        .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+        .andExpect(jsonPath("$.type", is("about:blank")))
+        .andExpect(jsonPath("$.title", is("Validation failure")))
+        .andExpect(jsonPath("$.status", is(HttpStatus.BAD_REQUEST.value())))
+        .andExpect(jsonPath("$.instance", is("/api/ltft")))
+        .andExpect(jsonPath("$.properties.errors").isArray())
+        .andExpect(jsonPath("$.properties.errors", hasSize(1)))
+        .andExpect(jsonPath("$.properties.errors[0].pointer", is("#/id")))
+        .andExpect(
+            jsonPath("$.properties.errors[0].detail", is("must be null")));
   }
 
   @Test
@@ -295,7 +301,12 @@ class LtftResourceIntegrationTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(formToUpdateJson))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$").doesNotExist());
+        .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+        .andExpect(jsonPath("$.type", is("about:blank")))
+        .andExpect(jsonPath("$.title", is("Bad Request")))
+        .andExpect(jsonPath("$.status", is(HttpStatus.BAD_REQUEST.value())))
+        .andExpect(jsonPath("$.detail", is("Failed to convert 'formId' with value: 'someId'")))
+        .andExpect(jsonPath("$.instance", is("/api/ltft/someId")));
   }
 
   @Test

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.forms.api;
 
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.APPROVED;
+
 import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.Optional;
 import java.util.Set;
@@ -33,8 +35,10 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedModel;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -98,5 +102,19 @@ public class AdminLtftResource {
   ResponseEntity<LtftFormDto> getLtftAdminDetail(@PathVariable UUID id) {
     Optional<LtftFormDto> formDetail = service.getAdminLtftDetail(id);
     return ResponseEntity.of(formDetail);
+  }
+
+  /**
+   * Approve the form with the given ID, must be associated with the user's local office.
+   *
+   * @param id The ID of the form to approve.
+   * @return The approved form.
+   * @throws MethodArgumentNotValidException When the state transition was not valid.
+   */
+  @PutMapping("/{id}/approve")
+  ResponseEntity<LtftFormDto> approveLtft(@PathVariable UUID id)
+      throws MethodArgumentNotValidException {
+    Optional<LtftFormDto> form = service.updateStatusAsAdmin(id, APPROVED, null);
+    return ResponseEntity.of(form);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/RestResponseEntityExceptionHandler.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.api;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+/**
+ * Exception handler for REST requests.
+ */
+@RestControllerAdvice
+public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
+
+  private static final String TITLE_VALIDATION_FAILURE = "Validation failure";
+
+  @Override
+  protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+      HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+    BindingResult result = ex.getBindingResult();
+    List<BodyValidationError> errors = result.getFieldErrors().stream()
+        .map(fe -> {
+          String pointer = "#/" + fe.getField().replace('.', JsonPointer.SEPARATOR);
+          return new BodyValidationError(pointer, fe.getDefaultMessage());
+        })
+        .sorted(
+            Comparator.comparing(BodyValidationError::pointer)
+                .thenComparing(BodyValidationError::detail)
+        )
+        .toList();
+
+    ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+    problemDetail.setTitle(TITLE_VALIDATION_FAILURE);
+    problemDetail.setProperty("errors", errors);
+    return handleExceptionInternal(ex, problemDetail, headers, status, request);
+  }
+
+  @Override
+  protected ResponseEntity<Object> handleHandlerMethodValidationException(
+      HandlerMethodValidationException ex, HttpHeaders headers, HttpStatusCode status,
+      WebRequest request) {
+
+    List<ParameterValidationError> errors = ex.getAllValidationResults().stream()
+        .flatMap(result -> {
+          String parameterName = result.getMethodParameter().getParameterName();
+
+          return result.getResolvableErrors().stream()
+              .map(err -> new ParameterValidationError(parameterName, err.getDefaultMessage()));
+        })
+        .sorted(
+            Comparator.comparing(ParameterValidationError::parameter)
+                .thenComparing(ParameterValidationError::detail)
+        )
+        .toList();
+
+    ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+    problemDetail.setTitle(ex.getReason());
+    problemDetail.setProperty("errors", errors);
+    return handleExceptionInternal(ex, problemDetail, headers, status, request);
+  }
+
+  /**
+   * A detailed parameter validation error.
+   *
+   * @param parameter The name of the parameter.
+   * @param detail    The validation failure detail.
+   */
+  record ParameterValidationError(String parameter, String detail) {
+
+  }
+
+  /**
+   * A detailed request body validation error.
+   *
+   * @param pointer The JSON pointer for the body's field.
+   * @param detail  The validation failure detail.
+   */
+  record BodyValidationError(String pointer, String detail) {
+
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/identity/TraineeIdentity.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/identity/TraineeIdentity.java
@@ -22,18 +22,21 @@
 package uk.nhs.hee.tis.trainee.forms.dto.identity;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 /**
  * Trainee identity data for an authenticated user.
  */
 @Data
-public class TraineeIdentity {
+@EqualsAndHashCode(callSuper = true)
+public class TraineeIdentity extends UserIdentity {
 
-  //TODO: consider generic UserIdentity abstract class shared with AdminIdentity.
-
-  public static final String ROLE = "TRAINEE";
+  private static final String ROLE = "TRAINEE";
 
   private String traineeId;
-  private String email;
-  private String name;
+
+  @Override
+  public String getRole() {
+    return ROLE;
+  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/identity/UserIdentity.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/identity/UserIdentity.java
@@ -21,32 +21,21 @@
 
 package uk.nhs.hee.tis.trainee.forms.dto.identity;
 
-import java.util.Set;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 /**
- * Identity data for an authenticated TIS Admin user.
+ * An abstract representation of a user's identity.
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
-public class AdminIdentity extends UserIdentity {
+public abstract class UserIdentity {
 
-  private static final String ROLE = "ADMIN";
-
-  private Set<String> groups;
+  private String email;
+  private String name;
 
   /**
-   * Whether the admin identity is considered complete based on the populated fields.
+   * Get the role of the user.
    *
-   * @return Whether the admin identity is considered complete.
+   * @return The role of the user.
    */
-  public boolean isComplete() {
-    return getEmail() != null && getName() != null && groups != null && !groups.isEmpty();
-  }
-
-  @Override
-  public String getRole() {
-    return ROLE;
-  }
+  public abstract String getRole();
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
@@ -111,6 +111,16 @@ public interface LtftFormRepository extends MongoRepository<LtftForm, UUID> {
           UUID id, Set<LifecycleState> states, Set<String> dbcs);
 
   /**
+   * Find the LTFT form with the given ID associated with one of the given DBCs.
+   *
+   * @param id   The ID of the form.
+   * @param dbcs The designated body codes to include in the search.
+   * @return The LTFT form, or optional empty if ID not found or did not match DBCs.
+   */
+  Optional<LtftForm> findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(UUID id,
+      Set<String> dbcs);
+
+  /**
    * Delete the LTFT form with the given id.
    *
    * @param id must not be {@literal null}.

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -34,6 +35,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.TEXT_PLAIN;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.APPROVED;
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMITTED;
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.UNSUBMITTED;
 
@@ -50,6 +52,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
@@ -160,6 +163,38 @@ class AdminLtftResourceTest {
     when(service.getAdminLtftDetail(id)).thenReturn(Optional.of(dto));
 
     ResponseEntity<LtftFormDto> response = controller.getLtftAdminDetail(id);
+
+    assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
+    assertThat("Unexpected response body.", response.getBody(), sameInstance(dto));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenApprovalNotValid() throws MethodArgumentNotValidException {
+    UUID id = UUID.randomUUID();
+    when(service.updateStatusAsAdmin(id, APPROVED, null)).thenThrow(
+        MethodArgumentNotValidException.class);
+
+    assertThrows(MethodArgumentNotValidException.class, () -> controller.approveLtft(id));
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenApprovalFormNotFound() throws MethodArgumentNotValidException {
+    UUID id = UUID.randomUUID();
+    when(service.updateStatusAsAdmin(id, APPROVED, null)).thenReturn(Optional.empty());
+
+    ResponseEntity<LtftFormDto> response = controller.approveLtft(id);
+
+    assertThat("Unexpected response code.", response.getStatusCode(), is(NOT_FOUND));
+    assertThat("Unexpected response body.", response.getBody(), nullValue());
+  }
+
+  @Test
+  void shouldReturnApprovedFormWhenFormApproved() throws MethodArgumentNotValidException {
+    UUID id = UUID.randomUUID();
+    LtftFormDto dto = LtftFormDto.builder().id(id).build();
+    when(service.updateStatusAsAdmin(id, APPROVED, null)).thenReturn(Optional.of(dto));
+
+    ResponseEntity<LtftFormDto> response = controller.approveLtft(id);
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
     assertThat("Unexpected response body.", response.getBody(), sameInstance(dto));

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/RestResponseEntityExceptionHandlerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/RestResponseEntityExceptionHandlerTest.java
@@ -93,9 +93,9 @@ class RestResponseEntityExceptionHandlerTest {
     assertThat("Unexpected problem.", problem, notNullValue());
     assertThat("Unexpected problem title.", problem.getTitle(), is("Validation failure"));
     assertThat("Unexpected problem status.", problem.getStatus(), is(STATUS_CODE.value()));
-    assertThat("Unexpected problem status.", problem.getInstance(), nullValue());
-    assertThat("Unexpected problem status.", problem.getType(), is(URI.create("about:blank")));
-    assertThat("Unexpected problem status.", problem.getDetail(), nullValue());
+    assertThat("Unexpected problem instance.", problem.getInstance(), nullValue());
+    assertThat("Unexpected problem type.", problem.getType(), is(URI.create("about:blank")));
+    assertThat("Unexpected problem detail.", problem.getDetail(), nullValue());
 
     Map<String, Object> problemProperties = problem.getProperties();
     assertThat("Unexpected problem properties.", problemProperties, notNullValue());
@@ -150,9 +150,9 @@ class RestResponseEntityExceptionHandlerTest {
     assertThat("Unexpected problem.", problem, notNullValue());
     assertThat("Unexpected problem title.", problem.getTitle(), is("Validation failure"));
     assertThat("Unexpected problem status.", problem.getStatus(), is(STATUS_CODE.value()));
-    assertThat("Unexpected problem status.", problem.getInstance(), nullValue());
-    assertThat("Unexpected problem status.", problem.getType(), is(URI.create("about:blank")));
-    assertThat("Unexpected problem status.", problem.getDetail(), nullValue());
+    assertThat("Unexpected problem instance.", problem.getInstance(), nullValue());
+    assertThat("Unexpected problem type.", problem.getType(), is(URI.create("about:blank")));
+    assertThat("Unexpected problem detail.", problem.getDetail(), nullValue());
 
     Map<String, Object> problemProperties = problem.getProperties();
     assertThat("Unexpected problem properties.", problemProperties, notNullValue());

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/RestResponseEntityExceptionHandlerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/RestResponseEntityExceptionHandlerTest.java
@@ -1,0 +1,221 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.api;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.validation.constraints.NotNull;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.method.MethodValidationResult;
+import org.springframework.validation.method.ParameterValidationResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import uk.nhs.hee.tis.trainee.forms.api.RestResponseEntityExceptionHandler.BodyValidationError;
+import uk.nhs.hee.tis.trainee.forms.api.RestResponseEntityExceptionHandler.ParameterValidationError;
+
+class RestResponseEntityExceptionHandlerTest {
+
+  private static final HttpStatusCode STATUS_CODE = HttpStatusCode.valueOf(
+      new Random().nextInt(400, 500));
+
+  private RestResponseEntityExceptionHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new RestResponseEntityExceptionHandler();
+  }
+
+  @Test
+  void shouldHandleMethodArgumentNotValid() {
+    BeanPropertyBindingResult result = new BeanPropertyBindingResult(null, "dto");
+    result.addError(new FieldError("dto", "field2", "detail3"));
+    result.addError(new FieldError("dto", "field1", "detail2"));
+    result.addError(new FieldError("dto", "field1", "detail1"));
+    result.addError(new FieldError("dto", "field1.subField", "detail4"));
+    MethodArgumentNotValidException exception = new MethodArgumentNotValidException(
+        mock(MethodParameter.class), result);
+
+    HttpHeaders headers = HttpHeaders.EMPTY;
+    WebRequest request = new ServletWebRequest(new MockHttpServletRequest());
+
+    ResponseEntity<Object> response = handler.handleMethodArgumentNotValid(exception, headers,
+        STATUS_CODE, request);
+
+    assertThat("Unexpected response.", response, notNullValue());
+    assertThat("Unexpected headers.", response.getHeaders(), is(headers));
+    assertThat("Unexpected response code.", response.getStatusCode(), is(STATUS_CODE));
+    assertThat("Unexpected response type.", response.getBody(), instanceOf(ProblemDetail.class));
+
+    ProblemDetail problem = (ProblemDetail) response.getBody();
+    assertThat("Unexpected problem.", problem, notNullValue());
+    assertThat("Unexpected problem title.", problem.getTitle(), is("Validation failure"));
+    assertThat("Unexpected problem status.", problem.getStatus(), is(STATUS_CODE.value()));
+    assertThat("Unexpected problem status.", problem.getInstance(), nullValue());
+    assertThat("Unexpected problem status.", problem.getType(), is(URI.create("about:blank")));
+    assertThat("Unexpected problem status.", problem.getDetail(), nullValue());
+
+    Map<String, Object> problemProperties = problem.getProperties();
+    assertThat("Unexpected problem properties.", problemProperties, notNullValue());
+    assertThat("Unexpected property count.", problemProperties.size(), is(1));
+
+    Object errors = problemProperties.get("errors");
+    assertThat("Unexpected errors type.", errors, instanceOf(List.class));
+
+    List<BodyValidationError> errorsList = (List<BodyValidationError>) errors;
+    assertThat("Unexpected errors count.", errorsList.size(), is(4));
+
+    BodyValidationError error = errorsList.get(0);
+    assertThat("Unexpected error pointer.", error.pointer(), is("#/field1"));
+    assertThat("Unexpected error detail.", error.detail(), is("detail1"));
+
+    error = errorsList.get(1);
+    assertThat("Unexpected error pointer.", error.pointer(), is("#/field1"));
+    assertThat("Unexpected error detail.", error.detail(), is("detail2"));
+
+    error = errorsList.get(2);
+    assertThat("Unexpected error pointer.", error.pointer(), is("#/field1/subField"));
+    assertThat("Unexpected error detail.", error.detail(), is("detail4"));
+
+    error = errorsList.get(3);
+    assertThat("Unexpected error pointer.", error.pointer(), is("#/field2"));
+    assertThat("Unexpected error detail.", error.detail(), is("detail3"));
+  }
+
+  @Test
+  void shouldHandleMethodValidationException() {
+    // Use a linked hash map to allow verification of sorting.
+    Map<String, List<String>> parametersToMessages = new LinkedHashMap<>();
+    parametersToMessages.put("parameter2", List.of("detail3"));
+    parametersToMessages.put("parameter1", List.of("detail2", "detail1"));
+    MethodValidationResultStub validationResult = new MethodValidationResultStub(
+        parametersToMessages);
+    HandlerMethodValidationException exception = new HandlerMethodValidationException(
+        validationResult);
+
+    HttpHeaders headers = HttpHeaders.EMPTY;
+    WebRequest request = new ServletWebRequest(new MockHttpServletRequest());
+
+    ResponseEntity<Object> response = handler.handleHandlerMethodValidationException(exception,
+        headers, STATUS_CODE, request);
+
+    assertThat("Unexpected response.", response, notNullValue());
+    assertThat("Unexpected headers.", response.getHeaders(), is(headers));
+    assertThat("Unexpected response code.", response.getStatusCode(), is(STATUS_CODE));
+    assertThat("Unexpected response type.", response.getBody(), instanceOf(ProblemDetail.class));
+
+    ProblemDetail problem = (ProblemDetail) response.getBody();
+    assertThat("Unexpected problem.", problem, notNullValue());
+    assertThat("Unexpected problem title.", problem.getTitle(), is("Validation failure"));
+    assertThat("Unexpected problem status.", problem.getStatus(), is(STATUS_CODE.value()));
+    assertThat("Unexpected problem status.", problem.getInstance(), nullValue());
+    assertThat("Unexpected problem status.", problem.getType(), is(URI.create("about:blank")));
+    assertThat("Unexpected problem status.", problem.getDetail(), nullValue());
+
+    Map<String, Object> problemProperties = problem.getProperties();
+    assertThat("Unexpected problem properties.", problemProperties, notNullValue());
+    assertThat("Unexpected property count.", problemProperties.size(), is(1));
+
+    Object errors = problemProperties.get("errors");
+    assertThat("Unexpected errors type.", errors, instanceOf(List.class));
+
+    List<ParameterValidationError> errorsList = (List<ParameterValidationError>) errors;
+    assertThat("Unexpected errors count.", errorsList.size(), is(3));
+
+    ParameterValidationError error = errorsList.get(0);
+    assertThat("Unexpected error parameter.", error.parameter(), is("parameter1"));
+    assertThat("Unexpected error detail.", error.detail(), is("detail1"));
+
+    error = errorsList.get(1);
+    assertThat("Unexpected error parameter.", error.parameter(), is("parameter1"));
+    assertThat("Unexpected error detail.", error.detail(), is("detail2"));
+
+    error = errorsList.get(2);
+    assertThat("Unexpected error parameter.", error.parameter(), is("parameter2"));
+    assertThat("Unexpected error detail.", error.detail(), is("detail3"));
+  }
+
+  /**
+   * A test stub for {@link MethodValidationResult}.
+   *
+   * @param parametersToMessages A map where the key is parameter names and the value is a list of
+   *                             error messages.
+   */
+  private record MethodValidationResultStub(
+      Map<String, List<String>> parametersToMessages) implements MethodValidationResult {
+
+    @Override
+    public @NotNull Object getTarget() {
+      return "testTarget";
+    }
+
+    @Override
+    public Method getMethod() {
+      return null;
+    }
+
+    @Override
+    public boolean isForReturnValue() {
+      return false;
+    }
+
+    @Override
+    public @NotNull List<ParameterValidationResult> getAllValidationResults() {
+      return parametersToMessages.entrySet().stream()
+          .map(entry -> {
+            String parameterName = entry.getKey();
+            MethodParameter parameter = mock(MethodParameter.class);
+            when(parameter.getParameterName()).thenReturn(parameterName);
+
+            List<DefaultMessageSourceResolvable> messages = entry.getValue().stream()
+                .map(msg -> new DefaultMessageSourceResolvable(null, null, msg))
+                .toList();
+
+            return new ParameterValidationResult(parameter, null, messages, null, null, null);
+          })
+          .toList();
+    }
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -27,6 +27,10 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -35,10 +39,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.DRAFT;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMITTED;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.UNSUBMITTED;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -46,12 +54,15 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.ArgumentCaptor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.CctChangeDto;
@@ -92,6 +103,9 @@ class LtftServiceTest {
   private static final String TRAINEE_EMAIL = "email";
   private static final String TRAINEE_NAME = "name";
   private static final String TRAINEE_ROLE = "TRAINEE";
+
+  private static final String ADMIN_NAME = "Ad Min";
+  private static final String ADMIN_EMAIL = "ad.min@example.com";
   private static final String ADMIN_GROUP = "abc-123";
   private static final UUID ID = UUID.randomUUID();
 
@@ -102,6 +116,8 @@ class LtftServiceTest {
   @BeforeEach
   void setUp() {
     AdminIdentity adminIdentity = new AdminIdentity();
+    adminIdentity.setName(ADMIN_NAME);
+    adminIdentity.setEmail(ADMIN_EMAIL);
     adminIdentity.setGroups(Set.of(ADMIN_GROUP));
 
     TraineeIdentity traineeIdentity = new TraineeIdentity();
@@ -198,7 +214,7 @@ class LtftServiceTest {
   void shouldCountAllNonDraftAdminLtftsWhenFiltersEmpty(Set<LifecycleState> states) {
     when(ltftRepository
         .countByStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
-            Set.of(LifecycleState.DRAFT), Set.of(ADMIN_GROUP))).thenReturn(40L);
+            Set.of(DRAFT), Set.of(ADMIN_GROUP))).thenReturn(40L);
 
     long count = service.getAdminLtftCount(states);
 
@@ -211,7 +227,7 @@ class LtftServiceTest {
 
   @Test
   void shouldCountFilteredAdminLtftsWhenFiltersNotEmpty() {
-    Set<LifecycleState> states = Set.of(LifecycleState.SUBMITTED);
+    Set<LifecycleState> states = Set.of(SUBMITTED);
     when(ltftRepository
         .countByStatus_Current_StateInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(states,
             Set.of(ADMIN_GROUP))).thenReturn(40L);
@@ -227,7 +243,7 @@ class LtftServiceTest {
 
   @Test
   void shouldNotCountDraftAdminLtftsWhenFiltersNotEmpty() {
-    Set<LifecycleState> states = Set.of(LifecycleState.DRAFT, LifecycleState.SUBMITTED);
+    Set<LifecycleState> states = Set.of(DRAFT, SUBMITTED);
 
     service.getAdminLtftCount(states);
 
@@ -238,7 +254,7 @@ class LtftServiceTest {
 
     Set<LifecycleState> filteredStates = statesCaptor.getValue();
     assertThat("Unexpected state count.", filteredStates, hasSize(1));
-    assertThat("Unexpected states.", filteredStates, hasItems(LifecycleState.SUBMITTED));
+    assertThat("Unexpected states.", filteredStates, hasItems(SUBMITTED));
   }
 
   @ParameterizedTest
@@ -256,7 +272,7 @@ class LtftServiceTest {
 
     when(ltftRepository
         .findByStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
-            Set.of(LifecycleState.DRAFT), Set.of(ADMIN_GROUP), pageRequest))
+            Set.of(DRAFT), Set.of(ADMIN_GROUP), pageRequest))
         .thenReturn(new PageImpl<>(List.of(entity1, entity2)));
 
     Page<LtftAdminSummaryDto> dtos = service.getAdminLtftSummaries(states, pageRequest);
@@ -274,7 +290,7 @@ class LtftServiceTest {
 
   @Test
   void shouldGetFilteredAdminLtftsWhenFiltersNotEmpty() {
-    Set<LifecycleState> states = Set.of(LifecycleState.SUBMITTED);
+    Set<LifecycleState> states = Set.of(SUBMITTED);
     PageRequest pageRequest = PageRequest.of(1, 1);
 
     LtftForm entity1 = new LtftForm();
@@ -305,7 +321,7 @@ class LtftServiceTest {
 
   @Test
   void shouldNotGetDraftAdminLtftsWhenFiltersNotEmpty() {
-    Set<LifecycleState> states = Set.of(LifecycleState.DRAFT, LifecycleState.SUBMITTED);
+    Set<LifecycleState> states = Set.of(DRAFT, SUBMITTED);
     PageRequest pageRequest = PageRequest.of(1, 1);
 
     when(ltftRepository
@@ -321,7 +337,7 @@ class LtftServiceTest {
 
     Set<LifecycleState> filteredStates = statesCaptor.getValue();
     assertThat("Unexpected state count.", filteredStates, hasSize(1));
-    assertThat("Unexpected states.", filteredStates, hasItems(LifecycleState.SUBMITTED));
+    assertThat("Unexpected states.", filteredStates, hasItems(SUBMITTED));
   }
 
   @Test
@@ -339,7 +355,7 @@ class LtftServiceTest {
 
     verify(ltftRepository)
         .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
-            any(), eq(Set.of(LifecycleState.DRAFT)), any());
+            any(), eq(Set.of(DRAFT)), any());
   }
 
   @Test
@@ -812,8 +828,8 @@ class LtftServiceTest {
 
     LtftContent content = LtftContent.builder()
         .assignedAdmin(Person.builder()
-            .name("Ad Min")
-            .email("ad.min@example.com")
+            .name(ADMIN_NAME)
+            .email(ADMIN_EMAIL)
             .role("ADMIN")
             .build())
         .build();
@@ -829,8 +845,8 @@ class LtftServiceTest {
 
     LtftFormDto dto = optionalDto.get();
     PersonDto assignedAdmin = dto.assignedAdmin();
-    assertThat("Unexpected admin name.", assignedAdmin.name(), is("Ad Min"));
-    assertThat("Unexpected admin email.", assignedAdmin.email(), is("ad.min@example.com"));
+    assertThat("Unexpected admin name.", assignedAdmin.name(), is(ADMIN_NAME));
+    assertThat("Unexpected admin email.", assignedAdmin.email(), is(ADMIN_EMAIL));
     assertThat("Unexpected admin role.", assignedAdmin.role(), is("ADMIN"));
   }
 
@@ -867,7 +883,7 @@ class LtftServiceTest {
 
     entity.setStatus(Status.builder()
         .current(StatusInfo.builder()
-            .state(LifecycleState.SUBMITTED)
+            .state(SUBMITTED)
             .detail(AbstractAuditedForm.Status.StatusDetail.builder()
                 .reason("Submitted Detail")
                 .build())
@@ -881,7 +897,7 @@ class LtftServiceTest {
             .build())
         .history(List.of(
             StatusInfo.builder()
-                .state(LifecycleState.DRAFT)
+                .state(DRAFT)
                 .detail(AbstractAuditedForm.Status.StatusDetail.builder()
                     .reason("Draft Detail")
                     .build())
@@ -894,7 +910,7 @@ class LtftServiceTest {
                     .build())
                 .build(),
             StatusInfo.builder()
-                .state(LifecycleState.SUBMITTED)
+                .state(SUBMITTED)
                 .detail(AbstractAuditedForm.Status.StatusDetail.builder()
                     .reason("Submitted Detail")
                     .build())
@@ -920,7 +936,7 @@ class LtftServiceTest {
     LtftFormDto dto = optionalDto.get();
     StatusDto status = dto.status();
     StatusInfoDto currentStatus = status.current();
-    assertThat("Unexpected state.", currentStatus.state(), is(LifecycleState.SUBMITTED));
+    assertThat("Unexpected state.", currentStatus.state(), is(SUBMITTED));
     assertThat("Unexpected detail.", currentStatus.detail().reason(), is("Submitted Detail"));
     assertThat("Unexpected timestamp.", currentStatus.timestamp(), is(Instant.EPOCH));
     assertThat("Unexpected revision.", currentStatus.revision(), is(1));
@@ -934,7 +950,7 @@ class LtftServiceTest {
     assertThat("Unexpected history count.", statusHistory, hasSize(2));
 
     StatusInfoDto history1 = statusHistory.get(0);
-    assertThat("Unexpected state.", history1.state(), is(LifecycleState.DRAFT));
+    assertThat("Unexpected state.", history1.state(), is(DRAFT));
     assertThat("Unexpected detail.", history1.detail().reason(), is("Draft Detail"));
     assertThat("Unexpected timestamp.", history1.timestamp(), is(Instant.MIN));
     assertThat("Unexpected revision.", history1.revision(), is(0));
@@ -945,7 +961,7 @@ class LtftServiceTest {
     assertThat("Unexpected modified role.", modifiedBy.role(), is("TRAINEE"));
 
     StatusInfoDto history2 = statusHistory.get(1);
-    assertThat("Unexpected state.", history2.state(), is(LifecycleState.SUBMITTED));
+    assertThat("Unexpected state.", history2.state(), is(SUBMITTED));
     assertThat("Unexpected detail.", history2.detail().reason(), is("Submitted Detail"));
     assertThat("Unexpected timestamp.", history2.timestamp(), is(Instant.EPOCH));
     assertThat("Unexpected revision.", history2.revision(), is(1));
@@ -976,6 +992,340 @@ class LtftServiceTest {
     StatusDto status = dto.status();
     assertThat("Unexpected state.", status.current(), nullValue());
     assertThat("Unexpected history count.", status.history(), nullValue());
+  }
+
+  @ParameterizedTest
+  @EnumSource(LifecycleState.class)
+  void shouldReturnEmptyUpdatingStatusWhenFormNotFound(LifecycleState state)
+      throws MethodArgumentNotValidException {
+    when(ltftRepository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.empty());
+
+    Optional<LtftFormDto> form = service.updateStatusAsAdmin(ID, state, null);
+
+    assertThat("Unexpected form presence.", form.isPresent(), is(false));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = EXCLUDE, names = "SUBMITTED")
+  void shouldThrowExceptionUpdatingStatusWhenTransitionFromDraftInvalid(
+      LifecycleState targetState) {
+    LtftForm form = new LtftForm();
+    form.setLifecycleState(DRAFT);
+
+    when(ltftRepository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.of(form));
+
+    MethodArgumentNotValidException exception = assertThrows(MethodArgumentNotValidException.class,
+        () -> service.updateStatusAsAdmin(ID, targetState, null));
+
+    List<FieldError> fieldErrors = exception.getFieldErrors();
+    assertThat("Unexpected error count.", fieldErrors, hasSize(1));
+
+    FieldError fieldError = fieldErrors.get(0);
+    assertThat("Unexpected object name.", fieldError.getObjectName(), is("LtftForm"));
+    assertThat("Unexpected field.", fieldError.getField(), is("status.current.state"));
+    assertThat("Unexpected message.", fieldError.getDefaultMessage(),
+        is("can not be transitioned to " + targetState.name()));
+
+    verify(ltftRepository, never()).save(any());
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = INCLUDE, names = "SUBMITTED")
+  void shouldUpdateStatusWhenTransitionFromDraftValid(
+      LifecycleState targetState) throws MethodArgumentNotValidException {
+    LtftForm entity = new LtftForm();
+    entity.setLifecycleState(DRAFT);
+
+    when(ltftRepository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.of(entity));
+    when(ltftRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    Optional<LtftFormDto> optionalDto = service.updateStatusAsAdmin(ID, targetState,
+        LftfStatusInfoDetailDto.builder()
+            .reason("detail reason")
+            .message("detail message")
+            .build()
+    );
+
+    assertThat("Unexpected form presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+
+    StatusInfoDto current = dto.status().current();
+    assertThat("Unexpected current state.", current.state(), is(targetState));
+    assertThat("Unexpected current revision.", current.revision(), is(0));
+    assertThat("Unexpected current timestamp.", current.timestamp(), notNullValue());
+
+    LftfStatusInfoDetailDto detail = current.detail();
+    assertThat("Unexpected current reason.", detail.reason(), is("detail reason"));
+    assertThat("Unexpected current message.", detail.message(), is("detail message"));
+
+    PersonDto modifiedBy = current.modifiedBy();
+    assertThat("Unexpected modified name.", modifiedBy.name(), is(ADMIN_NAME));
+    assertThat("Unexpected modified email.", modifiedBy.email(), is(ADMIN_EMAIL));
+    assertThat("Unexpected modified role.", modifiedBy.role(), is("ADMIN"));
+
+    List<StatusInfoDto> history = dto.status().history();
+    assertThat("Unexpected history count.", history, hasSize(2));
+    assertThat("Unexpected history state.", history.get(0).state(), is(DRAFT));
+    assertThat("Unexpected history state.", history.get(1).state(), is(targetState));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = EXCLUDE, names = {"APPROVED", "REJECTED",
+      "UNSUBMITTED", "WITHDRAWN"})
+  void shouldThrowExceptionUpdatingStatusWhenTransitionFromSubmittedInvalid(
+      LifecycleState targetState) {
+    LtftForm form = new LtftForm();
+    form.setLifecycleState(SUBMITTED);
+
+    when(ltftRepository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.of(form));
+
+    MethodArgumentNotValidException exception = assertThrows(MethodArgumentNotValidException.class,
+        () -> service.updateStatusAsAdmin(ID, targetState, null));
+
+    List<FieldError> fieldErrors = exception.getFieldErrors();
+    assertThat("Unexpected error count.", fieldErrors, hasSize(1));
+
+    FieldError fieldError = fieldErrors.get(0);
+    assertThat("Unexpected object name.", fieldError.getObjectName(), is("LtftForm"));
+    assertThat("Unexpected field.", fieldError.getField(), is("status.current.state"));
+    assertThat("Unexpected message.", fieldError.getDefaultMessage(),
+        is("can not be transitioned to " + targetState.name()));
+
+    verify(ltftRepository, never()).save(any());
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = INCLUDE, names = {"APPROVED", "REJECTED",
+      "UNSUBMITTED", "WITHDRAWN"})
+  void shouldUpdateStatusWhenTransitionFromSubmittedValid(
+      LifecycleState targetState) throws MethodArgumentNotValidException {
+    LtftForm entity = new LtftForm();
+    entity.setLifecycleState(SUBMITTED);
+
+    when(ltftRepository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.of(entity));
+    when(ltftRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    Optional<LtftFormDto> optionalDto = service.updateStatusAsAdmin(ID, targetState,
+        LftfStatusInfoDetailDto.builder()
+            .reason("detail reason")
+            .message("detail message")
+            .build()
+    );
+
+    assertThat("Unexpected form presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+
+    StatusInfoDto current = dto.status().current();
+    assertThat("Unexpected current state.", current.state(), is(targetState));
+    assertThat("Unexpected current revision.", current.revision(), is(0));
+    assertThat("Unexpected current timestamp.", current.timestamp(), notNullValue());
+
+    LftfStatusInfoDetailDto detail = current.detail();
+    assertThat("Unexpected current reason.", detail.reason(), is("detail reason"));
+    assertThat("Unexpected current message.", detail.message(), is("detail message"));
+
+    PersonDto modifiedBy = current.modifiedBy();
+    assertThat("Unexpected modified name.", modifiedBy.name(), is(ADMIN_NAME));
+    assertThat("Unexpected modified email.", modifiedBy.email(), is(ADMIN_EMAIL));
+    assertThat("Unexpected modified role.", modifiedBy.role(), is("ADMIN"));
+
+    List<StatusInfoDto> history = dto.status().history();
+    assertThat("Unexpected history count.", history, hasSize(2));
+    assertThat("Unexpected history state.", history.get(0).state(), is(SUBMITTED));
+    assertThat("Unexpected history state.", history.get(1).state(), is(targetState));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = EXCLUDE, names = {"SUBMITTED", "WITHDRAWN"})
+  void shouldThrowExceptionUpdatingStatusWhenTransitionFromUnsubmittedInvalid(
+      LifecycleState targetState) {
+    LtftForm form = new LtftForm();
+    form.setLifecycleState(UNSUBMITTED);
+
+    when(ltftRepository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.of(form));
+
+    MethodArgumentNotValidException exception = assertThrows(MethodArgumentNotValidException.class,
+        () -> service.updateStatusAsAdmin(ID, targetState, null));
+
+    List<FieldError> fieldErrors = exception.getFieldErrors();
+    assertThat("Unexpected error count.", fieldErrors, hasSize(1));
+
+    FieldError fieldError = fieldErrors.get(0);
+    assertThat("Unexpected object name.", fieldError.getObjectName(), is("LtftForm"));
+    assertThat("Unexpected field.", fieldError.getField(), is("status.current.state"));
+    assertThat("Unexpected message.", fieldError.getDefaultMessage(),
+        is("can not be transitioned to " + targetState.name()));
+
+    verify(ltftRepository, never()).save(any());
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = INCLUDE, names = {"SUBMITTED", "WITHDRAWN"})
+  void shouldUpdateStatusWhenTransitionFromUnsubmittedValid(
+      LifecycleState targetState) throws MethodArgumentNotValidException {
+    LtftForm entity = new LtftForm();
+    entity.setLifecycleState(UNSUBMITTED);
+
+    when(ltftRepository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.of(entity));
+    when(ltftRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    Optional<LtftFormDto> optionalDto = service.updateStatusAsAdmin(ID, targetState,
+        LftfStatusInfoDetailDto.builder()
+            .reason("detail reason")
+            .message("detail message")
+            .build()
+    );
+
+    assertThat("Unexpected form presence.", optionalDto.isPresent(), is(true));
+
+    LtftFormDto dto = optionalDto.get();
+
+    StatusInfoDto current = dto.status().current();
+    assertThat("Unexpected current state.", current.state(), is(targetState));
+    assertThat("Unexpected current revision.", current.revision(), is(0));
+    assertThat("Unexpected current timestamp.", current.timestamp(), notNullValue());
+
+    LftfStatusInfoDetailDto detail = current.detail();
+    assertThat("Unexpected current reason.", detail.reason(), is("detail reason"));
+    assertThat("Unexpected current message.", detail.message(), is("detail message"));
+
+    PersonDto modifiedBy = current.modifiedBy();
+    assertThat("Unexpected modified name.", modifiedBy.name(), is(ADMIN_NAME));
+    assertThat("Unexpected modified email.", modifiedBy.email(), is(ADMIN_EMAIL));
+    assertThat("Unexpected modified role.", modifiedBy.role(), is("ADMIN"));
+
+    List<StatusInfoDto> history = dto.status().history();
+    assertThat("Unexpected history count.", history, hasSize(2));
+    assertThat("Unexpected history state.", history.get(0).state(), is(UNSUBMITTED));
+    assertThat("Unexpected history state.", history.get(1), is(current));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = EXCLUDE, names = {"DRAFT", "SUBMITTED",
+      "UNSUBMITTED"})
+  void shouldThrowExceptionUpdatingStatusWhenTransitionFromFinalState(LifecycleState currentState) {
+    LtftForm form = new LtftForm();
+    form.setLifecycleState(currentState);
+
+    when(ltftRepository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.of(form));
+
+    Arrays.stream(LifecycleState.values()).forEach(targetState -> {
+      MethodArgumentNotValidException exception = assertThrows(
+          MethodArgumentNotValidException.class,
+          () -> service.updateStatusAsAdmin(ID, targetState, LftfStatusInfoDetailDto.builder()
+              .reason("detail reason")
+              .message("detail message")
+              .build()
+          ));
+
+      List<FieldError> fieldErrors = exception.getFieldErrors();
+      assertThat("Unexpected error count.", fieldErrors, hasSize(1));
+
+      FieldError fieldError = fieldErrors.get(0);
+      assertThat("Unexpected object name.", fieldError.getObjectName(), is("LtftForm"));
+      assertThat("Unexpected field.", fieldError.getField(), is("status.current.state"));
+      assertThat("Unexpected message.", fieldError.getDefaultMessage(),
+          is("can not be transitioned to " + targetState.name()));
+    });
+
+    verify(ltftRepository, never()).save(any());
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      DRAFT | SUBMITTED
+      SUBMITTED | APPROVED
+      """)
+  void shouldNotThrowExceptionUpdatingStatusWhenOptionalStatusDetailNull(
+      LifecycleState currentState, LifecycleState targetState) {
+    LtftForm form = new LtftForm();
+    form.setLifecycleState(currentState);
+
+    when(ltftRepository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.of(form));
+    when(ltftRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    assertDoesNotThrow(() -> service.updateStatusAsAdmin(ID, targetState, null));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      DRAFT | SUBMITTED
+      SUBMITTED | APPROVED
+      """)
+  void shouldNotThrowExceptionUpdatingStatusWhenOptionalStatusDetailReasonNull(
+      LifecycleState currentState, LifecycleState targetState) {
+    LtftForm form = new LtftForm();
+    form.setLifecycleState(currentState);
+
+    when(ltftRepository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.of(form));
+    when(ltftRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    assertDoesNotThrow(() -> service.updateStatusAsAdmin(ID, targetState,
+        LftfStatusInfoDetailDto.builder().build()));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = INCLUDE, names = {"REJECTED", "UNSUBMITTED",
+      "WITHDRAWN"})
+  void shouldThrowExceptionUpdatingStatusWhenRequiredStatusDetailNull(LifecycleState targetState) {
+    LtftForm form = new LtftForm();
+    form.setLifecycleState(SUBMITTED);
+
+    when(ltftRepository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.of(form));
+
+    MethodArgumentNotValidException exception = assertThrows(MethodArgumentNotValidException.class,
+        () -> service.updateStatusAsAdmin(ID, targetState, null));
+
+    List<FieldError> fieldErrors = exception.getFieldErrors();
+    assertThat("Unexpected error count.", fieldErrors, hasSize(1));
+
+    FieldError fieldError = fieldErrors.get(0);
+    assertThat("Unexpected object name.", fieldError.getObjectName(), is("StatusInfo"));
+    assertThat("Unexpected field.", fieldError.getField(), is("detail"));
+    assertThat("Unexpected message.", fieldError.getDefaultMessage(),
+        is("must not be null when transitioning to " + targetState.name()));
+
+    verify(ltftRepository, never()).save(any());
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = INCLUDE, names = {"REJECTED", "UNSUBMITTED",
+      "WITHDRAWN"})
+  void shouldThrowExceptionUpdatingStatusWhenRequiredStatusDetailReasonNull(
+      LifecycleState targetState) {
+    LtftForm form = new LtftForm();
+    form.setLifecycleState(SUBMITTED);
+
+    when(ltftRepository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.of(form));
+
+    MethodArgumentNotValidException exception = assertThrows(MethodArgumentNotValidException.class,
+        () -> service.updateStatusAsAdmin(ID, targetState,
+            LftfStatusInfoDetailDto.builder().build()));
+
+    List<FieldError> fieldErrors = exception.getFieldErrors();
+    assertThat("Unexpected error count.", fieldErrors, hasSize(1));
+
+    FieldError fieldError = fieldErrors.get(0);
+    assertThat("Unexpected object name.", fieldError.getObjectName(), is("StatusInfo"));
+    assertThat("Unexpected field.", fieldError.getField(), is("detail.reason"));
+    assertThat("Unexpected message.", fieldError.getDefaultMessage(),
+        is("must not be null when transitioning to " + targetState.name()));
+
+    verify(ltftRepository, never()).save(any());
   }
 
   @Test
@@ -1136,7 +1486,7 @@ class LtftServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = LifecycleState.class, names = {"DRAFT"}, mode = EnumSource.Mode.EXCLUDE)
+  @EnumSource(value = LifecycleState.class, names = {"DRAFT"}, mode = EXCLUDE)
   void shouldReturnFalseIfFormCannotTransitionToDeleted(LifecycleState lifecycleState) {
     LtftForm form = new LtftForm();
     form.setId(ID);
@@ -1157,7 +1507,7 @@ class LtftServiceTest {
     LtftForm form = new LtftForm();
     form.setId(ID);
     form.setTraineeTisId(TRAINEE_ID);
-    form.setLifecycleState(LifecycleState.DRAFT);
+    form.setLifecycleState(DRAFT);
 
     when(ltftRepository.findByTraineeTisIdAndId(TRAINEE_ID, ID)).thenReturn(Optional.of(form));
 
@@ -1237,7 +1587,7 @@ class LtftServiceTest {
     LtftForm form = new LtftForm();
     form.setId(ID);
     form.setTraineeTisId(TRAINEE_ID);
-    form.setLifecycleState(LifecycleState.DRAFT);
+    form.setLifecycleState(DRAFT);
     form.setContent(LtftContent.builder().name("test").build());
 
     when(ltftRepository.findByTraineeTisIdAndId(TRAINEE_ID, ID)).thenReturn(Optional.of(form));
@@ -1255,7 +1605,7 @@ class LtftServiceTest {
     form.setId(ID);
     form.setRevision(2);
     form.setTraineeTisId(TRAINEE_ID);
-    form.setLifecycleState(LifecycleState.DRAFT);
+    form.setLifecycleState(DRAFT);
     form.setContent(LtftContent.builder().name("test").build());
 
     LftfStatusInfoDetailDto detail = new LftfStatusInfoDetailDto("reason", "message");

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -60,6 +60,7 @@ import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.DiscussionsDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.ProgrammeMembershipDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.ReasonsDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto.LftfStatusInfoDetailDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto.StatusInfoDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.PersonDto;
@@ -90,7 +91,7 @@ class LtftServiceTest {
   private static final String TRAINEE_ID = "40";
   private static final String TRAINEE_EMAIL = "email";
   private static final String TRAINEE_NAME = "name";
-  private static final String TRAINEE_ROLE = TraineeIdentity.ROLE;
+  private static final String TRAINEE_ROLE = "TRAINEE";
   private static final String ADMIN_GROUP = "abc-123";
   private static final UUID ID = UUID.randomUUID();
 
@@ -1171,8 +1172,8 @@ class LtftServiceTest {
   @EnumSource(value = LifecycleState.class, names = {"SUBMITTED", "UNSUBMITTED", "WITHDRAWN"})
   void shouldReturnEmptyWhenTransitionFormNotFound(LifecycleState targetState) {
     when(ltftRepository.findByTraineeTisIdAndId(any(), any())).thenReturn(Optional.empty());
-    LtftFormDto.StatusDto.LftfStatusInfoDetailDto detail
-        = new LtftFormDto.StatusDto.LftfStatusInfoDetailDto("reason", "message");
+    LftfStatusInfoDetailDto detail
+        = new LftfStatusInfoDetailDto("reason", "message");
 
     Optional<LtftFormDto> result = service.changeLtftFormState(ID, detail, targetState);
     assertThat("Unexpected transition result when form not found.", result.isPresent(), is(false));
@@ -1186,8 +1187,7 @@ class LtftServiceTest {
     form.setTraineeTisId(TRAINEE_ID);
     form.setLifecycleState(LifecycleState.APPROVED); //cannot transition to any of the given states
     form.setContent(LtftContent.builder().name("test").build());
-    LtftFormDto.StatusDto.LftfStatusInfoDetailDto detail
-        = new LtftFormDto.StatusDto.LftfStatusInfoDetailDto("reason", "message");
+    LftfStatusInfoDetailDto detail = new LftfStatusInfoDetailDto("reason", "message");
 
     when(ltftRepository.findByTraineeTisIdAndId(TRAINEE_ID, ID)).thenReturn(Optional.of(form));
 
@@ -1221,8 +1221,7 @@ class LtftServiceTest {
     form.setTraineeTisId(TRAINEE_ID);
     form.setLifecycleState(LifecycleState.SUBMITTED);
     form.setContent(LtftContent.builder().name("test").build());
-    LtftFormDto.StatusDto.LftfStatusInfoDetailDto detail
-        = new LtftFormDto.StatusDto.LftfStatusInfoDetailDto(null, "message");
+    LftfStatusInfoDetailDto detail = new LftfStatusInfoDetailDto(null, "message");
 
     when(ltftRepository.findByTraineeTisIdAndId(TRAINEE_ID, ID)).thenReturn(Optional.of(form));
 
@@ -1259,8 +1258,7 @@ class LtftServiceTest {
     form.setLifecycleState(LifecycleState.DRAFT);
     form.setContent(LtftContent.builder().name("test").build());
 
-    LtftFormDto.StatusDto.LftfStatusInfoDetailDto detail
-        = new LtftFormDto.StatusDto.LftfStatusInfoDetailDto("reason", "message");
+    LftfStatusInfoDetailDto detail = new LftfStatusInfoDetailDto("reason", "message");
 
     when(ltftRepository.findByTraineeTisIdAndId(TRAINEE_ID, ID)).thenReturn(Optional.of(form));
     when(ltftRepository.save(any())).thenReturn(form);
@@ -1290,8 +1288,7 @@ class LtftServiceTest {
     form.setLifecycleState(LifecycleState.SUBMITTED);
     form.setContent(LtftContent.builder().name("test").build());
 
-    LtftFormDto.StatusDto.LftfStatusInfoDetailDto detail
-        = new LtftFormDto.StatusDto.LftfStatusInfoDetailDto("reason", "message");
+    LftfStatusInfoDetailDto detail = new LftfStatusInfoDetailDto("reason", "message");
 
     when(ltftRepository.findByTraineeTisIdAndId(TRAINEE_ID, ID)).thenReturn(Optional.of(form));
     when(ltftRepository.save(any())).thenReturn(form);
@@ -1321,8 +1318,7 @@ class LtftServiceTest {
     form.setLifecycleState(LifecycleState.SUBMITTED);
     form.setContent(LtftContent.builder().name("test").build());
 
-    LtftFormDto.StatusDto.LftfStatusInfoDetailDto detail
-        = new LtftFormDto.StatusDto.LftfStatusInfoDetailDto("reason", "message");
+    LftfStatusInfoDetailDto detail = new LftfStatusInfoDetailDto("reason", "message");
 
     when(ltftRepository.findByTraineeTisIdAndId(TRAINEE_ID, ID)).thenReturn(Optional.of(form));
     when(ltftRepository.save(any())).thenReturn(form);


### PR DESCRIPTION
# refactor(ltft): extract shared status update logic
Extract the status update code that can be shared between statuses to
LtftService.updateStatus().

TIS21-6716
TIS21-7061
TIS21-7016

---

# feat(ltft): admin approval endpoint
Create an admin approval endpoint
`/api/forms/admin/ltft/{formId}/approve`.

TIS21-6716
TIS21-7061
TIS21-7016