### PR TITLE
feat(ltft): sorting and filtering admin endpoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.34.0"
+version = "0.35.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
@@ -208,7 +208,7 @@ class AdminLtftResourceIntegrationTest {
       """)
   void shouldReturnNotFoundWhenLtftDoesNotMatchDbc(HttpMethod method, String uriTemplate)
       throws Exception {
-    LtftForm form = createLtftForm(SUBMITTED, DBC_2);
+    LtftForm form = createLtftForm(SUBMITTED, DBC_2, null);
     form = template.save(form);
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
@@ -217,19 +217,6 @@ class AdminLtftResourceIntegrationTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content("{}")) // required by some endpoints
         .andExpect(status().isNotFound());
-  }
-
-  @ParameterizedTest
-  @CsvSource(delimiter = '|', textBlock = """
-      GET | /api/admin/ltft
-      GET | /api/admin/ltft/count
-      """)
-  void shouldReturnBadRequestWhenInvalidStatusFilter(HttpMethod method, URI uri) throws Exception {
-    String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
-    mockMvc.perform(request(method, uri)
-            .header(HttpHeaders.AUTHORIZATION, token)
-            .param("status", "INVALID_FILTER"))
-        .andExpect(status().isBadRequest());
   }
 
   @ParameterizedTest
@@ -247,7 +234,7 @@ class AdminLtftResourceIntegrationTest {
   @ParameterizedTest
   @NullAndEmptySource
   void shouldCountZeroWhenNoLtftsWithMatchingDbc(String statusFilter) throws Exception {
-    template.insert(createLtftForm(SUBMITTED, DBC_2));
+    template.insert(createLtftForm(SUBMITTED, DBC_2, null));
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
     mockMvc.perform(get("/api/admin/ltft/count")
@@ -261,7 +248,7 @@ class AdminLtftResourceIntegrationTest {
   @ParameterizedTest
   @NullAndEmptySource
   void shouldCountZeroWhenLtftWithMatchingDbcIsDraft(String statusFilter) throws Exception {
-    template.insert(createLtftForm(DRAFT, DBC_1));
+    template.insert(createLtftForm(DRAFT, DBC_1, null));
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
     mockMvc.perform(get("/api/admin/ltft/count")
@@ -276,12 +263,12 @@ class AdminLtftResourceIntegrationTest {
   @NullAndEmptySource
   void shouldOnlyCountLtftsWithMatchingDbcWhenNoStatusFilter(String statusFilter) throws Exception {
     List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
-        .map(s -> createLtftForm(s, DBC_1))
+        .map(s -> createLtftForm(s, DBC_1, null))
         .toList();
     template.insertAll(ltfts);
 
-    template.insert(createLtftForm(SUBMITTED, DBC_1));
-    template.insert(createLtftForm(SUBMITTED, DBC_2));
+    template.insert(createLtftForm(SUBMITTED, DBC_1, null));
+    template.insert(createLtftForm(SUBMITTED, DBC_2, null));
 
     // Total number of states, plus an additional SUBMITTED, minus DRAFT.
     int expectedCount = LifecycleState.values().length;
@@ -300,11 +287,11 @@ class AdminLtftResourceIntegrationTest {
   void shouldOnlyCountLtftsWithMatchingDbcWhenHasStatusFilter(LifecycleState status)
       throws Exception {
     List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
-        .map(s -> createLtftForm(s, DBC_1))
+        .map(s -> createLtftForm(s, DBC_1, null))
         .toList();
     template.insertAll(ltfts);
 
-    template.insert(createLtftForm(status, DBC_2));
+    template.insert(createLtftForm(status, DBC_2, null));
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
     mockMvc.perform(get("/api/admin/ltft/count")
@@ -318,11 +305,11 @@ class AdminLtftResourceIntegrationTest {
   @Test
   void shouldCountMatchingLtftsWhenMultipleDbcs() throws Exception {
     List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
-        .map(s -> createLtftForm(s, DBC_1))
+        .map(s -> createLtftForm(s, DBC_1, null))
         .toList();
     template.insertAll(ltfts);
 
-    template.insert(createLtftForm(SUBMITTED, DBC_2));
+    template.insert(createLtftForm(SUBMITTED, DBC_2, null));
 
     // Total number of states, plus an additional SUBMITTED, minus DRAFT.
     int expectedCount = LifecycleState.values().length;
@@ -338,11 +325,11 @@ class AdminLtftResourceIntegrationTest {
   @Test
   void shouldCountMatchingLtftsWhenMultipleStatusFilters() throws Exception {
     List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
-        .map(s -> createLtftForm(s, DBC_1))
+        .map(s -> createLtftForm(s, DBC_1, null))
         .toList();
     template.insertAll(ltfts);
 
-    template.insert(createLtftForm(SUBMITTED, DBC_1));
+    template.insert(createLtftForm(SUBMITTED, DBC_1, null));
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
     String statusFilter = "%s,%s".formatted(SUBMITTED, LifecycleState.UNSUBMITTED);
@@ -375,7 +362,7 @@ class AdminLtftResourceIntegrationTest {
   @ParameterizedTest
   @NullAndEmptySource
   void shouldReturnNoSummariesWhenNoLtftsWithMatchingDbc(String statusFilter) throws Exception {
-    template.insert(createLtftForm(SUBMITTED, DBC_2));
+    template.insert(createLtftForm(SUBMITTED, DBC_2, null));
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
     mockMvc.perform(get("/api/admin/ltft")
@@ -395,7 +382,7 @@ class AdminLtftResourceIntegrationTest {
   @ParameterizedTest
   @NullAndEmptySource
   void shouldReturnNoSummariesWhenLtftWithMatchingDbcIsDraft(String statusFilter) throws Exception {
-    template.insert(createLtftForm(DRAFT, DBC_1));
+    template.insert(createLtftForm(DRAFT, DBC_1, null));
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
     mockMvc.perform(get("/api/admin/ltft")
@@ -449,6 +436,7 @@ class AdminLtftResourceIntegrationTest {
         .build();
     form.setStatus(Status.builder()
         .current(statusInfo)
+        .submitted(latestSubmitted)
         .history(List.of(
             statusInfo,
             StatusInfo.builder().state(SUBMITTED).timestamp(latestSubmitted).build()))
@@ -494,12 +482,12 @@ class AdminLtftResourceIntegrationTest {
   void shouldOnlyReturnSummariesWithMatchingDbcWhenNoStatusFilter(String statusFilter)
       throws Exception {
     List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
-        .map(s -> createLtftForm(s, DBC_1))
+        .map(s -> createLtftForm(s, DBC_1, null))
         .toList();
     template.insertAll(ltfts);
 
-    template.insert(createLtftForm(SUBMITTED, DBC_1));
-    template.insert(createLtftForm(SUBMITTED, DBC_2));
+    template.insert(createLtftForm(SUBMITTED, DBC_1, null));
+    template.insert(createLtftForm(SUBMITTED, DBC_2, null));
 
     // Total number of states, plus an additional SUBMITTED, minus DRAFT.
     int expectedCount = LifecycleState.values().length;
@@ -524,11 +512,11 @@ class AdminLtftResourceIntegrationTest {
   void shouldOnlyReturnSummariesWithMatchingDbcWhenHasStatusFilter(LifecycleState status)
       throws Exception {
     List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
-        .map(s -> createLtftForm(s, DBC_1))
+        .map(s -> createLtftForm(s, DBC_1, null))
         .toList();
     template.insertAll(ltfts);
 
-    template.insert(createLtftForm(status, DBC_2));
+    template.insert(createLtftForm(status, DBC_2, null));
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
     mockMvc.perform(get("/api/admin/ltft")
@@ -549,11 +537,11 @@ class AdminLtftResourceIntegrationTest {
   @Test
   void shouldReturnMatchingLtftSummariesWhenMultipleDbcs() throws Exception {
     List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
-        .map(s -> createLtftForm(s, DBC_1))
+        .map(s -> createLtftForm(s, DBC_1, null))
         .toList();
     template.insertAll(ltfts);
 
-    template.insert(createLtftForm(SUBMITTED, DBC_2));
+    template.insert(createLtftForm(SUBMITTED, DBC_2, null));
 
     // Total number of states, plus an additional SUBMITTED, minus DRAFT.
     int expectedCount = LifecycleState.values().length;
@@ -575,11 +563,11 @@ class AdminLtftResourceIntegrationTest {
   @Test
   void shouldReturnMatchingLtftSummariesWhenMultipleStatusFilters() throws Exception {
     List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
-        .map(s -> createLtftForm(s, DBC_1))
+        .map(s -> createLtftForm(s, DBC_1, null))
         .toList();
     template.insertAll(ltfts);
 
-    template.insert(createLtftForm(SUBMITTED, DBC_1));
+    template.insert(createLtftForm(SUBMITTED, DBC_1, null));
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
     String statusFilter = "%s,%s".formatted(SUBMITTED, LifecycleState.UNSUBMITTED);
@@ -607,11 +595,11 @@ class AdminLtftResourceIntegrationTest {
   @ValueSource(ints = {0, 1, 2})
   void shouldPageLtftSummariesWhenTooManyResults(int pageNumber) throws Exception {
     List<LtftForm> ltfts = Arrays.stream(LifecycleState.values())
-        .map(s -> createLtftForm(s, DBC_1))
+        .map(s -> createLtftForm(s, DBC_1, null))
         .toList();
     template.insertAll(ltfts);
 
-    template.insert(createLtftForm(SUBMITTED, DBC_1));
+    template.insert(createLtftForm(SUBMITTED, DBC_1, null));
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
     String statusFilter = "%s,%s".formatted(SUBMITTED, LifecycleState.UNSUBMITTED);
@@ -639,6 +627,7 @@ class AdminLtftResourceIntegrationTest {
         .current(StatusInfo.builder()
             .state(SUBMITTED)
             .build())
+        .submitted(Instant.now())
         .build());
     form1.setContent(LtftContent.builder()
         .change(CctChange.builder()
@@ -654,6 +643,7 @@ class AdminLtftResourceIntegrationTest {
         .current(StatusInfo.builder()
             .state(SUBMITTED)
             .build())
+        .submitted(Instant.now())
         .build());
     form2.setContent(LtftContent.builder()
         .change(CctChange.builder()
@@ -669,6 +659,7 @@ class AdminLtftResourceIntegrationTest {
         .current(StatusInfo.builder()
             .state(SUBMITTED)
             .build())
+        .submitted(Instant.now())
         .build());
     form3.setContent(LtftContent.builder()
         .change(CctChange.builder()
@@ -699,20 +690,25 @@ class AdminLtftResourceIntegrationTest {
 
   @Test
   void shouldSortLtftSummariesByProvidedSortWhenSortProvided() throws Exception {
-    LtftForm form1 = template.insert(createLtftForm(UNSUBMITTED, DBC_1));
-    LtftForm form2 = template.insert(createLtftForm(SUBMITTED, DBC_1));
-    LtftForm form3 = template.insert(createLtftForm(APPROVED, DBC_1));
+    LtftForm form1 = createLtftForm(SUBMITTED, DBC_1, LocalDate.now().plusYears(1));
+    template.insert(form1);
+
+    LtftForm form2 = createLtftForm(SUBMITTED, DBC_1, LocalDate.now().minusYears(1));
+    template.insert(form2);
+
+    LtftForm form3 = createLtftForm(SUBMITTED, DBC_1, LocalDate.now());
+    template.insert(form3);
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
     mockMvc.perform(get("/api/admin/ltft")
             .header(HttpHeaders.AUTHORIZATION, token)
-            .param("sort", "status.current.state"))
+            .param("sort", "proposedStartDate"))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.content").isArray())
         .andExpect(jsonPath("$.content", hasSize(3)))
-        .andExpect(jsonPath("$.content[0].id", is(form3.getId().toString())))
-        .andExpect(jsonPath("$.content[1].id", is(form2.getId().toString())))
+        .andExpect(jsonPath("$.content[0].id", is(form2.getId().toString())))
+        .andExpect(jsonPath("$.content[1].id", is(form3.getId().toString())))
         .andExpect(jsonPath("$.content[2].id", is(form1.getId().toString())))
         .andExpect(jsonPath("$.page", aMapWithSize(4)))
         .andExpect(jsonPath("$.page.size", is(2000)))
@@ -723,7 +719,7 @@ class AdminLtftResourceIntegrationTest {
 
   @Test
   void shouldReturnNotFoundGettingDetailWhenLtftWithMatchingDbcIsDraft() throws Exception {
-    LtftForm form = createLtftForm(DRAFT, DBC_1);
+    LtftForm form = createLtftForm(DRAFT, DBC_1, null);
     form = template.save(form);
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
@@ -803,7 +799,7 @@ class AdminLtftResourceIntegrationTest {
   @EnumSource(value = LifecycleState.class, mode = EXCLUDE, names = "SUBMITTED")
   void shouldNotApproveLtftWhenStateTransitionNotAllowed(LifecycleState currentState)
       throws Exception {
-    LtftForm form = template.insert(createLtftForm(currentState, DBC_1));
+    LtftForm form = template.insert(createLtftForm(currentState, DBC_1, null));
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
     mockMvc.perform(put("/api/admin/ltft/{id}/approve", form.getId())
@@ -824,7 +820,7 @@ class AdminLtftResourceIntegrationTest {
   @ParameterizedTest
   @EnumSource(value = LifecycleState.class, mode = INCLUDE, names = "SUBMITTED")
   void shouldApproveLtftWhenStateTransitionAllowed(LifecycleState currentState) throws Exception {
-    LtftForm form = template.insert(createLtftForm(currentState, DBC_1));
+    LtftForm form = template.insert(createLtftForm(currentState, DBC_1, null));
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
     mockMvc.perform(put("/api/admin/ltft/{id}/approve", form.getId())
@@ -850,7 +846,7 @@ class AdminLtftResourceIntegrationTest {
   @EnumSource(value = LifecycleState.class, mode = EXCLUDE, names = "SUBMITTED")
   void shouldNotUnsubmitLtftWhenStateTransitionNotAllowed(LifecycleState currentState)
       throws Exception {
-    LtftForm form = template.insert(createLtftForm(currentState, DBC_1));
+    LtftForm form = template.insert(createLtftForm(currentState, DBC_1, null));
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
     mockMvc.perform(put("/api/admin/ltft/{id}/unsubmit", form.getId())
@@ -879,7 +875,7 @@ class AdminLtftResourceIntegrationTest {
   @EnumSource(value = LifecycleState.class, mode = INCLUDE, names = "SUBMITTED")
   void shouldNotUnsubmitLtftWhenStateTransitionAllowedButNoReasonGiven(LifecycleState currentState)
       throws Exception {
-    LtftForm form = template.insert(createLtftForm(currentState, DBC_1));
+    LtftForm form = template.insert(createLtftForm(currentState, DBC_1, null));
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
     mockMvc.perform(put("/api/admin/ltft/{id}/unsubmit", form.getId())
@@ -908,7 +904,7 @@ class AdminLtftResourceIntegrationTest {
   @EnumSource(value = LifecycleState.class, mode = INCLUDE, names = "SUBMITTED")
   void shouldUnsubmitLtftWhenStateTransitionAllowedAndReasonGiven(LifecycleState currentState)
       throws Exception {
-    LtftForm form = template.insert(createLtftForm(currentState, DBC_1));
+    LtftForm form = template.insert(createLtftForm(currentState, DBC_1, null));
 
     String token = TestJwtUtil.generateAdminTokenForGroups(List.of(DBC_1));
     mockMvc.perform(put("/api/admin/ltft/{id}/unsubmit", form.getId())
@@ -945,10 +941,13 @@ class AdminLtftResourceIntegrationTest {
    * @param dbc   The designated body code to include in the form's programme membership.
    * @return The created form.
    */
-  private LtftForm createLtftForm(LifecycleState state, String dbc) {
+  private LtftForm createLtftForm(LifecycleState state, String dbc, LocalDate changeStartDate) {
     LtftForm ltft = new LtftForm();
 
     LtftContent content = LtftContent.builder()
+        .change(CctChange.builder()
+            .startDate(changeStartDate)
+            .build())
         .programmeMembership(ProgrammeMembership.builder()
             .designatedBodyCode(dbc)
             .build())
@@ -961,6 +960,7 @@ class AdminLtftResourceIntegrationTest {
         .build();
     ltft.setStatus(Status.builder()
         .current(statusInfo)
+        .submitted(state != DRAFT ? Instant.now() : null)
         .history(List.of(statusInfo))
         .build()
     );

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
@@ -470,7 +470,8 @@ class LtftResourceIntegrationTest {
         .andExpect(jsonPath("$.status.current.detail.message").value("message"))
         .andExpect(jsonPath("$.status.current.modifiedBy.name").value("given family"))
         .andExpect(jsonPath("$.status.current.modifiedBy.email").value("email"))
-        .andExpect(jsonPath("$.status.current.modifiedBy.role").value("TRAINEE"));
+        .andExpect(jsonPath("$.status.current.modifiedBy.role").value("TRAINEE"))
+        .andExpect(jsonPath("$.status.submitted", notNullValue()));
   }
 
   @ParameterizedTest

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/LtftRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/LtftRepositoryIntegrationTest.java
@@ -82,8 +82,13 @@ class LtftRepositoryIntegrationTest {
       _id_                                           | _id
       traineeTisId                                   | traineeTisId
       formRef                                        | formRef
+      content.personalDetails.forenames              | content.personalDetails.forenames
+      content.personalDetails.gdcNumber              | content.personalDetails.gdcNumber
+      content.personalDetails.gmcNumber              | content.personalDetails.gmcNumber
+      content.personalDetails.surname                | content.personalDetails.surname
       content.programmeMembership.id                 | content.programmeMembership.id
       content.programmeMembership.designatedBodyCode | content.programmeMembership.designatedBodyCode
+      content.programmeMembership.name               | content.programmeMembership.name
       status.current.state                           | status.current.state
       status.history.state                           | status.history.state
        """)
@@ -91,7 +96,7 @@ class LtftRepositoryIntegrationTest {
     IndexOperations indexOperations = template.indexOps(LtftForm.class);
     List<IndexInfo> indexes = indexOperations.getIndexInfo();
 
-    assertThat("Unexpected index count.", indexes, hasSize(7));
+    assertThat("Unexpected index count.", indexes, hasSize(12));
 
     IndexInfo index = indexes.stream()
         .filter(i -> i.getName().equals(indexName))

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftAdminSummaryDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftAdminSummaryDto.java
@@ -44,6 +44,7 @@ import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 @Builder
 public record LtftAdminSummaryDto(
     UUID id,
+    String formRef,
     LtftAdminPersonalDetailsDto personalDetails,
     String programmeName,
     LocalDate proposedStartDate,

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
@@ -145,13 +145,15 @@ public record LtftFormDto(
   /**
    * The form status.
    *
-   * @param current The information for the current form status.
-   * @param history A list of form status history.
+   * @param current   The information for the current form status.
+   * @param submitted When the form was last submitted.
+   * @param history   A list of form status history.
    */
   @Builder
   public record StatusDto(
 
       StatusInfoDto current,
+      Instant submitted,
       List<StatusInfoDto> history) {
 
     /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
@@ -41,9 +41,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto.LtftAdminPersonalDetailsDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto.LftfStatusInfoDetailDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.PersonalDetailsDto;
-import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status.StatusDetail;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 import uk.nhs.hee.tis.trainee.forms.model.content.CctChange;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
@@ -69,7 +70,7 @@ public abstract class LtftMapper {
   @Mapping(target = "personalDetails", source = "entity")
   @Mapping(target = "programmeName", source = "content.programmeMembership.name")
   @Mapping(target = "proposedStartDate", source = "content.change.startDate")
-  @Mapping(target = "submissionDate", source = "submitted")
+  @Mapping(target = "submissionDate", source = "status.submitted")
   @Mapping(target = "reason", source = "content.reasons.selected",
       qualifiedByName = "JoinWithComma")
   @Mapping(target = "daysToStart", source = "content.change.startDate",
@@ -150,14 +151,12 @@ public abstract class LtftMapper {
   public abstract LtftForm toEntity(LtftFormDto dto);
 
   /**
-   * Convert a {@link LtftFormDto.StatusDto.LftfStatusInfoDetailDto} to a
-   * {@link AbstractAuditedForm.Status.StatusDetail}.
+   * Convert a {@link LftfStatusInfoDetailDto} to a {@link StatusDetail}.
    *
    * @param dto The DTO to convert.
    * @return The equivalent status detail.
    */
-  public abstract AbstractAuditedForm.Status.StatusDetail toStatusDetail(
-      LtftFormDto.StatusDto.LftfStatusInfoDetailDto dto);
+  public abstract StatusDetail toStatusDetail(LftfStatusInfoDetailDto dto);
 
   /**
    * Joins a list of strings with a comma, sorted alphabetically for consistency.
@@ -184,11 +183,11 @@ public abstract class LtftMapper {
   @Named("IsShortNotice")
   @Nullable
   Boolean isShortNotice(LtftForm entity) {
-    Instant submitted = entity.getSubmitted();
-
-    if (submitted == null) {
+    if (entity.getStatus() == null || entity.getStatus().submitted() == null) {
       return null;
     }
+
+    Instant submitted = entity.getStatus().submitted();
 
     // If the form is unsubmitted, use the current date instead of the last submission date.
     Instant referenceInstant =

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/LtftContent.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/LtftContent.java
@@ -68,12 +68,16 @@ public record LtftContent(
   @Builder
   public record PersonalDetails(
       String title,
+      @Indexed
       String forenames,
+      @Indexed
       String surname,
       String email,
       String telephoneNumber,
       String mobileNumber,
+      @Indexed
       String gmcNumber,
+      @Indexed
       String gdcNumber,
       Boolean skilledWorkerVisaHolder) {
 
@@ -94,6 +98,7 @@ public record LtftContent(
       @Indexed
       @Field("id")
       UUID id,
+      @Indexed
       String name,
       @Indexed
       String designatedBodyCode,

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
@@ -26,8 +26,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
@@ -38,26 +36,6 @@ import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
  */
 @Repository
 public interface LtftFormRepository extends MongoRepository<LtftForm, UUID> {
-
-  /**
-   * Count all LTFT forms with one of the given DBCs.
-   *
-   * @param states The states to exclude from the count.
-   * @param dbcs   The designated body codes to include in the count.
-   * @return The number of found LTFT forms.
-   */
-  long countByStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
-      Set<LifecycleState> states, Set<String> dbcs);
-
-  /**
-   * Count all LTFT forms with one of the given current states and DBCs.
-   *
-   * @param states The states to include in the count.
-   * @param dbcs   The designated body codes to include in the count.
-   * @return The number of found LTFT forms.
-   */
-  long countByStatus_Current_StateInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
-      Set<LifecycleState> states, Set<String> dbcs);
 
   /**
    * Find all LTFT forms belonging to the given trainee, ordered by last modified.
@@ -75,28 +53,6 @@ public interface LtftFormRepository extends MongoRepository<LtftForm, UUID> {
    * @return The LTFT form, or optional empty if not found (or does not belong to trainee).
    */
   Optional<LtftForm> findByTraineeTisIdAndId(String traineeId, UUID id);
-
-  /**
-   * Find all LTFT forms with one of the given DBCs.
-   *
-   * @param states   The states to exclude from the search.
-   * @param dbcs     The designated body codes to include in the search.
-   * @param pageable Page information to apply to the search.
-   * @return A page of found LTFT forms.
-   */
-  Page<LtftForm> findByStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
-      Set<LifecycleState> states, Set<String> dbcs, Pageable pageable);
-
-  /**
-   * Find all LTFT forms with one of the given current states and DBCs.
-   *
-   * @param states   The states to include in the search.
-   * @param dbcs     The designated body codes to include in the search.
-   * @param pageable Page information to apply to the search.
-   * @return A page of found LTFT forms.
-   */
-  Page<LtftForm> findByStatus_Current_StateInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
-      Set<LifecycleState> states, Set<String> dbcs, Pageable pageable);
 
   /**
    * Find the LTFT form with the given ID and one of the given DBCs.

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapperTest.java
@@ -24,8 +24,6 @@ package uk.nhs.hee.tis.trainee.forms.mapper;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -87,9 +85,21 @@ class LtftMapperTest {
   }
 
   @Test
+  void shouldReturnNullShortNoticeWhenStatusNull() {
+    LtftForm entity = new LtftForm();
+    entity.setStatus(null);
+
+    Boolean isShortNotice = mapper.isShortNotice(entity);
+
+    assertThat("Unexpected short notice value.", isShortNotice, nullValue());
+  }
+
+  @Test
   void shouldReturnNullShortNoticeWhenSubmittedNull() {
-    LtftForm entity = spy(new LtftForm());
-    when(entity.getSubmitted()).thenReturn(null);
+    LtftForm entity = new LtftForm();
+    entity.setStatus(Status.builder()
+        .submitted(null)
+        .build());
 
     Boolean isShortNotice = mapper.isShortNotice(entity);
 
@@ -98,12 +108,10 @@ class LtftMapperTest {
 
   @Test
   void shouldReturnNullShortNoticeWhenContentNull() {
-    LtftForm entity = spy(new LtftForm());
-    when(entity.getSubmitted()).thenReturn(Instant.now());
-
+    LtftForm entity = new LtftForm();
     entity.setStatus(Status.builder()
-        .current(StatusInfo.builder()
-            .build())
+        .current(StatusInfo.builder().build())
+        .submitted(Instant.now())
         .build());
 
     entity.setContent(null);
@@ -115,12 +123,10 @@ class LtftMapperTest {
 
   @Test
   void shouldReturnNullShortNoticeWhenChangeNull() {
-    LtftForm entity = spy(new LtftForm());
-    when(entity.getSubmitted()).thenReturn(Instant.now());
-
+    LtftForm entity = new LtftForm();
     entity.setStatus(Status.builder()
-        .current(StatusInfo.builder()
-            .build())
+        .current(StatusInfo.builder().build())
+        .submitted(Instant.now())
         .build());
 
     entity.setContent(LtftContent.builder()
@@ -134,12 +140,10 @@ class LtftMapperTest {
 
   @Test
   void shouldReturnNullShortNoticeWhenStartDateNull() {
-    LtftForm entity = spy(new LtftForm());
-    when(entity.getSubmitted()).thenReturn(Instant.now());
-
+    LtftForm entity = new LtftForm();
     entity.setStatus(Status.builder()
-        .current(StatusInfo.builder()
-            .build())
+        .current(StatusInfo.builder().build())
+        .submitted(Instant.now())
         .build());
 
     entity.setContent(LtftContent.builder()
@@ -156,12 +160,10 @@ class LtftMapperTest {
   @ParameterizedTest
   @ValueSource(ints = {0, 111})
   void shouldReturnTrueShortNoticeWhenSubmissionWithinNoticePeriod(int days) {
-    LtftForm entity = spy(new LtftForm());
-    when(entity.getSubmitted()).thenReturn(Instant.now());
-
+    LtftForm entity = new LtftForm();
     entity.setStatus(Status.builder()
-        .current(StatusInfo.builder()
-            .build())
+        .current(StatusInfo.builder().build())
+        .submitted(Instant.now())
         .build());
 
     entity.setContent(LtftContent.builder()
@@ -178,12 +180,10 @@ class LtftMapperTest {
   @ParameterizedTest
   @ValueSource(ints = {112, 113})
   void shouldReturnFalseShortNoticeWhenSubmissionOutsideOrEqualToNoticePeriod(int days) {
-    LtftForm entity = spy(new LtftForm());
-    when(entity.getSubmitted()).thenReturn(Instant.now());
-
+    LtftForm entity = new LtftForm();
     entity.setStatus(Status.builder()
-        .current(StatusInfo.builder()
-            .build())
+        .current(StatusInfo.builder().build())
+        .submitted(Instant.now())
         .build());
 
     entity.setContent(LtftContent.builder()
@@ -200,13 +200,12 @@ class LtftMapperTest {
   @ParameterizedTest
   @ValueSource(ints = {0, 111})
   void shouldReturnUseCurrentDateForShortNoticeWhenCurrentStatusUnsubmitted(int days) {
-    LtftForm entity = spy(new LtftForm());
-    when(entity.getSubmitted()).thenReturn(Instant.now().minus(Duration.ofDays(120)));
-
+    LtftForm entity = new LtftForm();
     entity.setStatus(Status.builder()
         .current(StatusInfo.builder()
             .state(LifecycleState.UNSUBMITTED)
             .build())
+        .submitted(Instant.now().minus(Duration.ofDays(120)))
         .build());
 
     entity.setContent(LtftContent.builder()


### PR DESCRIPTION
The sorting and filtering of admin endpoints is currently limited as the internal field names are required.
As the internal field names are not transparent to the client, it should be possible to sort and filter based on the DTO field names.

Update LtftService to translate the supported field names for both sorting and filtering. The user filters should be added on top of the filters for DBC and non-DRAFT LTFTs, but not replace them.

To enable sorting on `submissionDate`, which is a calculated field, it should be made in to an actual field on the database model. The `submitted` timestamp will be updated each time the LTFT is submitted. Refactor AbstractAuditedForm to add the new field and remove the existing `getSubmitted()` method.

Update `LtftAdminSummaryDto` to include the missing `formRef` field.

Update `LtftContent` to add indexes for the filterable fields. `assignedAdmin.name` and `assignedAdmin.email` will not yet have indexes due to the shared `Person` type. Indexes will need to be created programmatically using `indexOps`.

TIS21-6934
TIS21-7098
TIS21-7099
TIS21-6943