### PR TITLE
feat(ltft): admin details PDF

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.35.0"
+version = "0.36.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/PdfService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/PdfService.java
@@ -31,12 +31,14 @@ import io.awspring.cloud.sns.core.SnsNotification;
 import io.awspring.cloud.sns.core.SnsTemplate;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.helper.W3CDom;
@@ -47,7 +49,9 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.TemplateSpec;
 import org.thymeleaf.context.Context;
+import org.thymeleaf.templatemode.TemplateMode;
 import uk.nhs.hee.tis.trainee.forms.dto.ConditionsOfJoiningPdfRequestDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.PublishedPdf;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.GoldGuideVersion;
 import uk.nhs.hee.tis.trainee.forms.event.ConditionsOfJoiningPublishedEvent;
@@ -141,6 +145,23 @@ public class PdfService {
     }
 
     return uploaded;
+  }
+
+  /**
+   * Generate a PDF for a {@link LtftFormDto}.
+   *
+   * @param dto              The data object to convert to a PDF.
+   * @param templateFileName The name of the template file to use.
+   * @return The bytes of the generated PDF.
+   * @throws IOException If a valid PDF could not be created.
+   */
+  public byte[] generatePdf(LtftFormDto dto, String templateFileName) throws IOException {
+    log.info("Generating a PDF for LTFT '{}' modified '{}'", dto.formRef(), dto.lastModified());
+
+    TemplateSpec templateSpec = new TemplateSpec(
+        "ltft" + File.separatorChar + templateFileName + ".html",
+        Set.of(), TemplateMode.HTML, null);
+    return generatePdf(templateSpec, Map.of("var", dto));
   }
 
   /**

--- a/src/main/resources/static/css/override.css
+++ b/src/main/resources/static/css/override.css
@@ -1,0 +1,3 @@
+html {
+  background-color: white;
+}

--- a/src/main/resources/templates/ltft/admin.html
+++ b/src/main/resources/templates/ltft/admin.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Less Than Full Time</title>
+    <link href="/static/css/nhsuk-9.0.0.min.css" rel="stylesheet" />
+    <link href="/static/css/override.css" rel="stylesheet" />
+  </head>
+  <body>
+    <main class="nhsuk-u-margin-top-5">
+      <div class="nhsuk-card--no-border nhsuk-card--feature">
+        <div class="nhsuk-card nhsuk-card--feature">
+          <h2 class="nhsuk-card__heading nhsuk-card__heading--feature">LTFT Application Detail</h2>
+          <div>
+            <h3>Ref: [[${var.formRef}]]</h3>
+            <h3>Status: [[${var.status.current.state}]]</h3>
+            <div>Created: [[${#temporals.format(var.created, 'dd MMMM yyyy HH:mm (z)', timezone)}]]</div>
+            <div>Modified: [[${#temporals.format(var.lastModified, 'dd MMMM yyyy HH:mm (z)', timezone)}]]</div>
+          </div>
+          <div class="nhsuk-card__content nhsuk-card__content--feature">
+              <h3 class="card-heading-spaced-top">Personal Details</h3>
+              <dl class="nhsuk-summary-list" th:with="pd=${var.personalDetails}">
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">Title</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${pd.title}"/>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">Name</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${pd.forenames + ' ' + pd.surname}">test</dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">E-Mail</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${pd.email}">test</dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">Telephone</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${pd.telephoneNumber}">test</dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">Mobile</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${pd.mobileNumber}"></dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">GMC</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${pd.gmcNumber}"></dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">GDC</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${pd.gdcNumber}"></dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">Holds a Skilled Worker visa</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${pd.skilledWorkerVisaHolder}"></dd>
+                </div>
+              </dl>
+            </div>
+            <div class="nhsuk-card__content nhsuk-card__content--feature">
+              <h3 class="card-heading-spaced-top">Programme Membership</h3>
+              <dl class="nhsuk-summary-list" th:with="programme=${var.programmeMembership}">
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">Programme Name</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${programme.name}"></dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">Start Date</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${#temporals.format(programme.startDate, 'dd MMMM yyyy')}"></dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">End Date</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${#temporals.format(programme.endDate, 'dd MMMM yyyy')}"></dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">WTE (Current)</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${programme.wte}"></dd>
+                </div>
+              </dl>
+            </div>
+            <div class="nhsuk-card__content nhsuk-card__content--feature">
+              <h3 class="card-heading-spaced-top">Proposed Changes</h3>
+              <dl class="nhsuk-summary-list" th:with="change=${var.change}">
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">WTE</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${change.wte}"></dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">Start Date</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${#temporals.format(change.startDate, 'dd MMMM yyyy')}"></dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">End Date</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${#temporals.format(change.endDate, 'dd MMMM yyyy')}"></dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">Programme end date</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${#temporals.format(change.cctDate, 'dd MMMM yyyy')}"></dd>
+                </div>
+              </dl>
+            </div>
+            <div class="nhsuk-card__content nhsuk-card__content--feature">
+              <h3 class="card-heading-spaced-top">Reasons</h3>
+              <dl class="nhsuk-summary-list" th:with="reasons=${var.reasons}">
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">Selected</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${#strings.listJoin(reasons.selected, '<br>')}"></dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">Other Reason</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${reasons.otherDetail}"></dd>
+                </div>
+              </dl>
+            </div>
+            <div class="nhsuk-card__content nhsuk-card__content--feature">
+              <h3 class="card-heading-spaced-top">Declarations</h3>
+              <dl class="nhsuk-summary-list" th:with="declarations=${var.declarations}">
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">Information is correct</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${declarations.discussedWithTpd}"></dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">Discussed with TPD</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${declarations.informationIsCorrect}"></dd>
+                </div>
+                <div class="nhsuk-summary-list__row">
+                  <dt class="nhsuk-summary-list__key">Not guaranteed</dt>
+                  <dd class="nhsuk-summary-list__value" th:text="${declarations.notGuaranteed}"></dd>
+                </div>
+              </dl>
+            </div>
+          <div class="nhsuk-card__content nhsuk-card__content--feature">
+            <h3 class="card-heading-spaced-top">Discussions</h3>
+            <dl class="nhsuk-summary-list" th:with="discussions=${var.discussions}">
+              <div class="nhsuk-summary-list__row">
+                <dt class="nhsuk-summary-list__key">TPD name</dt>
+                <dd class="nhsuk-summary-list__value" th:text="${discussions.tpdName}"></dd>
+              </div>
+              <div class="nhsuk-summary-list__row">
+                <dt class="nhsuk-summary-list__key">TPD email</dt>
+                <dd class="nhsuk-summary-list__value" th:text="${discussions.tpdEmail}"></dd>
+              </div>
+              <div class="nhsuk-summary-list__row">
+                <dt class="nhsuk-summary-list__key">Other</dt>
+                <dd class="nhsuk-summary-list__value">
+                  <th:block th:each="person,iter: ${discussions.other}">
+                    <th:block th:text="|${person.name}, ${person.email} (${person.role})|"/><th:block th:if="${!iter.last}"><br></th:block>
+                  </th:block>
+                </dd>
+              </div>
+            </dl>
+          </div>
+          </div>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
Add an endpoint to allow TIS admins to download LTFT details as a PDF. The API path is the same as getting the JSON detail, but the `Accept` header should be set to `application/pdf`.

The PDF template is rough but data-wise complete. Further restructuring of the HTML and CSS styling will be needed.

TIS21-6635
TIS21-7177