### PR TITLE
Feat/post submit ltft

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.35.0"
+version = "0.36.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
@@ -65,6 +65,10 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import uk.nhs.hee.tis.trainee.forms.DockerImageNames;
 import uk.nhs.hee.tis.trainee.forms.TestJwtUtil;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.DeclarationsDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto.LftfStatusInfoDetailDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto.StatusInfoDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 import uk.nhs.hee.tis.trainee.forms.model.Person;
@@ -458,20 +462,20 @@ class LtftResourceIntegrationTest {
     form.setTraineeTisId(TRAINEE_ID);
     LtftForm formSaved = template.save(form);
 
-    LtftFormDto.DeclarationsDto declarationsDto = LtftFormDto.DeclarationsDto.builder()
+    DeclarationsDto declarationsDto = DeclarationsDto.builder()
         .discussedWithTpd(true)
         .informationIsCorrect(true)
         .notGuaranteed(true)
         .build();
-    LtftFormDto.StatusDto.LftfStatusInfoDetailDto detailsDto = LtftFormDto.StatusDto.LftfStatusInfoDetailDto.builder()
+    LftfStatusInfoDetailDto detailsDto = LftfStatusInfoDetailDto.builder()
         .reason("reason")
         .message("message")
         .build();
-    LtftFormDto.StatusDto.StatusInfoDto currentDto = LtftFormDto.StatusDto.StatusInfoDto.builder()
+    StatusInfoDto currentDto = StatusInfoDto.builder()
         .detail(detailsDto)
         .state(LifecycleState.DRAFT)
         .build();
-    LtftFormDto.StatusDto statusDto = LtftFormDto.StatusDto.builder()
+    StatusDto statusDto = StatusDto.builder()
         .current(currentDto)
         .history(List.of(currentDto))
         .build();
@@ -507,20 +511,20 @@ class LtftResourceIntegrationTest {
 
   @Test
   void shouldSubmitNewLtftForm() throws Exception {
-    LtftFormDto.DeclarationsDto declarationsDto = LtftFormDto.DeclarationsDto.builder()
+    DeclarationsDto declarationsDto = DeclarationsDto.builder()
         .discussedWithTpd(true)
         .informationIsCorrect(true)
         .notGuaranteed(true)
         .build();
-    LtftFormDto.StatusDto.LftfStatusInfoDetailDto detailsDto = LtftFormDto.StatusDto.LftfStatusInfoDetailDto.builder()
+    LftfStatusInfoDetailDto detailsDto = LftfStatusInfoDetailDto.builder()
         .reason("reason")
         .message("message")
         .build();
-    LtftFormDto.StatusDto.StatusInfoDto currentDto = LtftFormDto.StatusDto.StatusInfoDto.builder()
+    StatusInfoDto currentDto = StatusInfoDto.builder()
         .detail(detailsDto)
         .state(LifecycleState.DRAFT)
         .build();
-    LtftFormDto.StatusDto statusDto = LtftFormDto.StatusDto.builder()
+    StatusDto statusDto = StatusDto.builder()
         .current(currentDto)
         .history(List.of(currentDto))
         .build();

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/LtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/LtftResource.java
@@ -38,8 +38,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftSummaryDto;
-import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
-import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMITTED;
 import uk.nhs.hee.tis.trainee.forms.dto.validation.Create;
 import uk.nhs.hee.tis.trainee.forms.service.LtftService;
 
@@ -102,7 +100,7 @@ public class LtftResource {
       @RequestBody @Validated(Create.class) LtftFormDto dto) {
     log.info("Request to POST submit new LTFT form: {}", dto);
     Optional<LtftFormDto> optionalSavedLtft = service.saveLtftForm(dto);
-    Optional<LtftFormDto> submittedLtft = null;
+    Optional<LtftFormDto> submittedLtft = Optional.empty();
     if (optionalSavedLtft.isPresent()) {
       LtftFormDto savedLtft = optionalSavedLtft.get();
       submittedLtft = service.submitLtftForm(savedLtft.id(), savedLtft.status().current().detail());
@@ -138,10 +136,9 @@ public class LtftResource {
   @PutMapping("/{formId}/submit")
   public ResponseEntity<LtftFormDto> submitLtft(@PathVariable UUID formId,
       @RequestBody @Validated LtftFormDto dto) {
-    log.info("Request to submit an existing LTFT form {} with reason {}.",
-        formId, dto.status().current().detail());
+    log.info("Request to submit an existing LTFT form: {}", formId);
     Optional<LtftFormDto> optionalSavedLtft = service.updateLtftForm(formId, dto);
-    Optional<LtftFormDto> submittedLtft = null;
+    Optional<LtftFormDto> submittedLtft = Optional.empty();
     if (optionalSavedLtft.isPresent()) {
       LtftFormDto savedLtft = optionalSavedLtft.get();
       submittedLtft = service.submitLtftForm(formId, savedLtft.status().current().detail());

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/LtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/LtftResource.java
@@ -105,8 +105,7 @@ public class LtftResource {
     Optional<LtftFormDto> submittedLtft = null;
     if (optionalSavedLtft.isPresent()) {
       LtftFormDto savedLtft = optionalSavedLtft.get();
-      submittedLtft = service.changeLtftFormState(
-          savedLtft.id(), savedLtft.status().current().detail(), SUBMITTED);
+      submittedLtft = service.submitLtftForm(savedLtft.id(), savedLtft.status().current().detail());
     }
     return submittedLtft.map(ResponseEntity::ok)
         .orElseGet(() -> ResponseEntity.badRequest().build());
@@ -131,15 +130,22 @@ public class LtftResource {
   /**
    * Allow a trainee to submit an existing LTFT form.
    *
-   * @param formId The id of the LTFT form to submit.
+   * @param formId  The id of the LTFT form to submit.
+   * @param dto     The DTO of the form.
    *
    * @return The DTO of the submitted form, or a bad request if the form could not be submitted.
    */
   @PutMapping("/{formId}/submit")
   public ResponseEntity<LtftFormDto> submitLtft(@PathVariable UUID formId,
-      @RequestBody LtftFormDto.StatusDto.LftfStatusInfoDetailDto reason) {
-    log.info("Request to submit an existing LTFT form {} with reason {}.", formId, reason);
-    Optional<LtftFormDto> submittedLtft = service.submitLtftForm(formId, reason);
+      @RequestBody @Validated LtftFormDto dto) {
+    log.info("Request to submit an existing LTFT form {} with reason {}.",
+        formId, dto.status().current().detail());
+    Optional<LtftFormDto> optionalSavedLtft = service.updateLtftForm(formId, dto);
+    Optional<LtftFormDto> submittedLtft = null;
+    if (optionalSavedLtft.isPresent()) {
+      LtftFormDto savedLtft = optionalSavedLtft.get();
+      submittedLtft = service.submitLtftForm(formId, savedLtft.status().current().detail());
+    }
     return submittedLtft.map(ResponseEntity::ok)
         .orElseGet(() -> ResponseEntity.badRequest().build());
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -306,7 +306,7 @@ public class LtftService {
    * @return The DTO of the form after the state change, or empty if form not found or could not be
    *     changed to the target state.
    */
-  public Optional<LtftFormDto> changeLtftFormState(UUID formId, LftfStatusInfoDetailDto detail,
+  protected Optional<LtftFormDto> changeLtftFormState(UUID formId, LftfStatusInfoDetailDto detail,
       LifecycleState targetState) {
     String traineeId = traineeIdentity.getTraineeId();
     Optional<LtftForm> formOptional = ltftFormRepository.findByTraineeTisIdAndId(traineeId, formId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -195,7 +195,7 @@ public class LtftService {
     log.info("Saving LTFT form for trainee [{}]: {}", traineeId, dto);
     LtftForm form = mapper.toEntity(dto);
     if (!form.getTraineeTisId().equals(traineeId)) {
-      log.warn("Could not save form since it does belong to the logged-in trainee {}: {}",
+      log.warn("Could not save form since it does not belong to the logged-in trainee {}: {}",
           traineeId, dto);
       return Optional.empty();
     }
@@ -306,7 +306,7 @@ public class LtftService {
    * @return The DTO of the form after the state change, or empty if form not found or could not be
    *     changed to the target state.
    */
-  protected Optional<LtftFormDto> changeLtftFormState(UUID formId, LftfStatusInfoDetailDto detail,
+  public Optional<LtftFormDto> changeLtftFormState(UUID formId, LftfStatusInfoDetailDto detail,
       LifecycleState targetState) {
     String traineeId = traineeIdentity.getTraineeId();
     Optional<LtftForm> formOptional = ltftFormRepository.findByTraineeTisIdAndId(traineeId, formId);

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceTest.java
@@ -39,8 +39,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto;
-import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto.StatusInfoDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto.LftfStatusInfoDetailDto;
+import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto.StatusInfoDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.service.LtftService;
 
@@ -331,11 +331,10 @@ class LtftResourceTest {
     StatusDto statusDto = StatusDto.builder()
         .current(currentDto)
         .build();
-    LtftFormDto formDto = LtftFormDto.builder()
+    return LtftFormDto.builder()
         .id(ID)
         .traineeTisId("some trainee")
         .status(statusDto)
         .build();
-    return formDto;
   }
 }


### PR DESCRIPTION
- New POST endpoint `/api/ltft/submit` to submit new LTFT form that have not been saved before
- Update PUT endpoint `/api/ltft/{formId}/submit` to save the DTO before changing into SUBMITTED status. To fix the issue when part of the form was not saved, the changes would loss if the PUT submit only updated the status according to the formId.

TIS21-7057
TIS21-7119