### PR TITLE
feat(ltft): restrict readonly properties on create

### DIFF
--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceIntegrationTest.java
@@ -99,7 +99,7 @@ class LtftServiceIntegrationTest {
             .build())
         .build();
 
-    LtftFormDto saved = service.saveLtftForm(dto).orElseThrow();
+    LtftFormDto saved = service.createLtftForm(dto).orElseThrow();
     assertThat("Unexpected form ref.", saved.formRef(), nullValue());
   }
 
@@ -119,8 +119,8 @@ class LtftServiceIntegrationTest {
             .build())
         .build();
 
-    LtftFormDto draft1 = service.saveLtftForm(dto).orElseThrow();
-    LtftFormDto draft2 = service.saveLtftForm(dto).orElseThrow();
+    LtftFormDto draft1 = service.createLtftForm(dto).orElseThrow();
+    LtftFormDto draft2 = service.createLtftForm(dto).orElseThrow();
     assertThat("Unexpected form ID.", draft1.id(), not(draft2.id()));
 
     LtftFormDto submitted1 = service.submitLtftForm(draft1.id(), null).orElseThrow();
@@ -144,8 +144,8 @@ class LtftServiceIntegrationTest {
             .build())
         .build();
 
-    LtftFormDto draft1 = service.saveLtftForm(dto).orElseThrow();
-    LtftFormDto draft2 = service.saveLtftForm(dto).orElseThrow();
+    LtftFormDto draft1 = service.createLtftForm(dto).orElseThrow();
+    LtftFormDto draft2 = service.createLtftForm(dto).orElseThrow();
     assertThat("Unexpected form ID.", draft1.id(), not(draft2.id()));
 
     LtftFormDto submitted1 = service.submitLtftForm(draft1.id(), null).orElseThrow();

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/LtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/LtftResource.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.forms.api;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
+import com.fasterxml.jackson.annotation.JsonView;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -38,8 +39,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftSummaryDto;
-import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.dto.validation.Create;
+import uk.nhs.hee.tis.trainee.forms.dto.views.Trainee;
 import uk.nhs.hee.tis.trainee.forms.service.LtftService;
 
 /**
@@ -83,9 +84,9 @@ public class LtftResource {
    */
   @PostMapping
   public ResponseEntity<LtftFormDto> createLtft(
-      @RequestBody @Validated(Create.class) LtftFormDto dto) {
+      @RequestBody @JsonView(Trainee.Write.class) @Validated(Create.class) LtftFormDto dto) {
     log.info("Request to save new LTFT form: {}", dto);
-    Optional<LtftFormDto> savedLtft = service.saveLtftForm(dto);
+    Optional<LtftFormDto> savedLtft = service.createLtftForm(dto);
     return savedLtft.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.badRequest().build());
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.forms.dto;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.validation.constraints.Null;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -29,6 +30,7 @@ import java.util.UUID;
 import lombok.Builder;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.dto.validation.Create;
+import uk.nhs.hee.tis.trainee.forms.dto.views.ReadOnly;
 import uk.nhs.hee.tis.trainee.forms.model.content.CctChangeType;
 
 /**
@@ -55,8 +57,14 @@ public record LtftFormDto(
     @Null(groups = Create.class)
     UUID id,
     String traineeTisId,
+
+    @JsonView(ReadOnly.class)
+    @Null(groups = Create.class)
     String formRef,
-    int revision,
+
+    @JsonView(ReadOnly.class)
+    @Null(groups = Create.class)
+    Integer revision,
     String name,
     PersonalDetailsDto personalDetails,
     ProgrammeMembershipDto programmeMembership,
@@ -64,10 +72,21 @@ public record LtftFormDto(
     DiscussionsDto discussions,
     CctChangeDto change,
     ReasonsDto reasons,
+
+    @JsonView(ReadOnly.class)
+    @Null(groups = Create.class)
     PersonDto assignedAdmin,
+
+    @JsonView(ReadOnly.class)
+    @Null(groups = Create.class)
     StatusDto status,
 
+    @JsonView(ReadOnly.class)
+    @Null(groups = Create.class)
     Instant created,
+
+    @JsonView(ReadOnly.class)
+    @Null(groups = Create.class)
     Instant lastModified) {
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/views/ReadOnly.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/views/ReadOnly.java
@@ -1,0 +1,29 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.dto.views;
+
+/**
+ * A JSON view for read-only properties.
+ */
+public interface ReadOnly {
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/views/Trainee.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/views/Trainee.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.dto.views;
+
+/**
+ * A JSON view for trainees.
+ */
+public interface Trainee {
+
+  /**
+   * A JSON view for trainee write access.
+   */
+  interface Write {
+
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -200,10 +200,19 @@ public class LtftService {
    * @param dto The LTFT DTO to save.
    * @return The saved form DTO.
    */
-  public Optional<LtftFormDto> saveLtftForm(LtftFormDto dto) {
+  public Optional<LtftFormDto> createLtftForm(LtftFormDto dto) {
     String traineeId = traineeIdentity.getTraineeId();
     log.info("Saving LTFT form for trainee [{}]: {}", traineeId, dto);
     LtftForm form = mapper.toEntity(dto);
+
+    // Set initial DRAFT status.
+    Person modifiedBy = Person.builder()
+        .name(traineeIdentity.getName())
+        .email(traineeIdentity.getEmail())
+        .role(traineeIdentity.getRole())
+        .build();
+    form.setLifecycleState(DRAFT, null, modifiedBy, 0);
+
     if (!form.getTraineeTisId().equals(traineeId)) {
       log.warn("Could not save form since it does belong to the logged-in trainee {}: {}",
           traineeId, dto);

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceTest.java
@@ -96,7 +96,7 @@ class LtftResourceTest {
 
   @Test
   void shouldReturnBadRequestWhenServiceWontSaveLtftForm() {
-    when(service.saveLtftForm(any())).thenReturn(Optional.empty());
+    when(service.createLtftForm(any())).thenReturn(Optional.empty());
 
     ResponseEntity<LtftFormDto> response = controller.createLtft(LtftFormDto.builder().build());
 
@@ -127,7 +127,7 @@ class LtftResourceTest {
         .id(ID)
         .traineeTisId("some trainee")
         .build();
-    when(service.saveLtftForm(any())).thenReturn(Optional.of(savedForm));
+    when(service.createLtftForm(any())).thenReturn(Optional.of(savedForm));
 
     LtftFormDto newForm = LtftFormDto.builder()
         .traineeTisId("some trainee")

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -1729,7 +1729,7 @@ class LtftServiceTest {
         .traineeTisId("another trainee")
         .build();
 
-    Optional<LtftFormDto> formDtoOptional = service.saveLtftForm(dtoToSave);
+    Optional<LtftFormDto> formDtoOptional = service.createLtftForm(dtoToSave);
 
     assertThat("Unexpected form returned.", formDtoOptional.isPresent(), is(false));
     verifyNoInteractions(repository);
@@ -1747,7 +1747,7 @@ class LtftServiceTest {
     existingForm.setContent(LtftContent.builder().name("test").build());
     when(repository.save(any())).thenReturn(existingForm);
 
-    Optional<LtftFormDto> formDtoOptional = service.saveLtftForm(dtoToSave);
+    Optional<LtftFormDto> formDtoOptional = service.createLtftForm(dtoToSave);
 
     verify(repository).save(any());
     assertThat("Unexpected form returned.", formDtoOptional.isPresent(), is(true));


### PR DESCRIPTION
Several properties on the LTFT DTO should be read-only
 - `formRef`
 - `revision`
 - `assignedAdmin`
 - `status`
 - `created`
 - `lastModified`

Currently it is possible to create new LTFTs with user-provided values in these fields. Any given values should be rejected/ignored and server-generated values should be persisted and returned in the response instead.

Update LtftFormDto to add validation to ensure that the values for these properties is `null` during LTFT creation.
A `ReadOnly` JsonView should be used to make sure the deserialized DTO never contains values for these fields. This will cause the validation to always pass, but the dual-front approach ensures less chance of misconfiguration allowing values through.

TIS21-7137
TIS21-7149