### PR TITLE
fix(ltft): restrict trainee ability to modify forms

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.38.0"
+version = "0.38.1"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceIntegrationTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 import io.awspring.cloud.sns.core.SnsTemplate;
-import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,9 +42,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import uk.nhs.hee.tis.trainee.forms.DockerImageNames;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
-import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto;
-import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto.StatusInfoDto;
-import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.dto.identity.TraineeIdentity;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 
@@ -85,18 +81,9 @@ class LtftServiceIntegrationTest {
 
   @Test
   void shouldNotGenerateFormRefForDrafts() {
-    // TODO: stop manually setting DRAFT status once it is set by the backend.
-    StatusInfoDto draftStatus = StatusInfoDto.builder()
-        .state(LifecycleState.DRAFT)
-        .build();
-
     LtftFormDto dto = LtftFormDto.builder()
         .traineeTisId(TRAINEE_ID)
         .name("my test form")
-        .status(StatusDto.builder()
-            .current(draftStatus)
-            .history(List.of(draftStatus))
-            .build())
         .build();
 
     LtftFormDto saved = service.createLtftForm(dto).orElseThrow();
@@ -105,18 +92,9 @@ class LtftServiceIntegrationTest {
 
   @Test
   void shouldNotCountDraftsWhenGeneratingFormRefSuffix() {
-    // TODO: stop manually setting DRAFT status once it is set by the backend.
-    StatusInfoDto draftStatus = StatusInfoDto.builder()
-        .state(LifecycleState.DRAFT)
-        .build();
-
     LtftFormDto dto = LtftFormDto.builder()
         .traineeTisId(TRAINEE_ID)
         .name("my test form")
-        .status(StatusDto.builder()
-            .current(draftStatus)
-            .history(List.of(draftStatus))
-            .build())
         .build();
 
     LtftFormDto draft1 = service.createLtftForm(dto).orElseThrow();
@@ -130,18 +108,9 @@ class LtftServiceIntegrationTest {
 
   @Test
   void shouldCountSubmittedWhenGeneratingFormRefSuffix() {
-    // TODO: stop manually setting DRAFT status once it is set by the backend.
-    StatusInfoDto draftStatus = StatusInfoDto.builder()
-        .state(LifecycleState.DRAFT)
-        .build();
-
     LtftFormDto dto = LtftFormDto.builder()
         .traineeTisId(TRAINEE_ID)
         .name("my test form")
-        .status(StatusDto.builder()
-            .current(draftStatus)
-            .history(List.of(draftStatus))
-            .build())
         .build();
 
     LtftFormDto draft1 = service.createLtftForm(dto).orElseThrow();

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/LtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/LtftResource.java
@@ -40,6 +40,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.validation.Create;
+import uk.nhs.hee.tis.trainee.forms.dto.validation.Update;
 import uk.nhs.hee.tis.trainee.forms.dto.views.Trainee;
 import uk.nhs.hee.tis.trainee.forms.service.LtftService;
 
@@ -100,7 +101,7 @@ public class LtftResource {
    */
   @PutMapping("/{formId}")
   public ResponseEntity<LtftFormDto> updateLtft(@PathVariable UUID formId,
-      @RequestBody @Validated LtftFormDto dto) {
+      @RequestBody @JsonView(Trainee.Write.class) @Validated(Update.class) LtftFormDto dto) {
     log.info("Request to update LTFT form {}: {}", formId, dto);
     Optional<LtftFormDto> savedLtft = service.updateLtftForm(formId, dto);
     return savedLtft.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.badRequest().build());

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import lombok.Builder;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.dto.validation.Create;
+import uk.nhs.hee.tis.trainee.forms.dto.validation.Update;
 import uk.nhs.hee.tis.trainee.forms.dto.views.ReadOnly;
 import uk.nhs.hee.tis.trainee.forms.model.content.CctChangeType;
 
@@ -59,11 +60,11 @@ public record LtftFormDto(
     String traineeTisId,
 
     @JsonView(ReadOnly.class)
-    @Null(groups = Create.class)
+    @Null(groups = {Create.class, Update.class})
     String formRef,
 
     @JsonView(ReadOnly.class)
-    @Null(groups = Create.class)
+    @Null(groups = {Create.class, Update.class})
     Integer revision,
     String name,
     PersonalDetailsDto personalDetails,
@@ -74,19 +75,19 @@ public record LtftFormDto(
     ReasonsDto reasons,
 
     @JsonView(ReadOnly.class)
-    @Null(groups = Create.class)
+    @Null(groups = {Create.class, Update.class})
     PersonDto assignedAdmin,
 
     @JsonView(ReadOnly.class)
-    @Null(groups = Create.class)
+    @Null(groups = {Create.class, Update.class})
     StatusDto status,
 
     @JsonView(ReadOnly.class)
-    @Null(groups = Create.class)
+    @Null(groups = {Create.class, Update.class})
     Instant created,
 
     @JsonView(ReadOnly.class)
-    @Null(groups = Create.class)
+    @Null(groups = {Create.class, Update.class})
     Instant lastModified) {
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/validation/Update.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/validation/Update.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.dto.validation;
+
+import jakarta.validation.groups.Default;
+
+/**
+ * A validation group used when a resource is being updated.
+ */
+public interface Update extends Default {
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/LtftContent.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/LtftContent.java
@@ -25,6 +25,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
+import lombok.With;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.nhs.hee.tis.trainee.forms.model.Person;
@@ -50,6 +51,7 @@ public record LtftContent(
     Discussions discussions,
     CctChange change,
     Reasons reasons,
+    @With
     Person assignedAdmin) implements FormContent {
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -63,6 +63,7 @@ import uk.nhs.hee.tis.trainee.forms.mapper.LtftMapper;
 import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status.StatusDetail;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 import uk.nhs.hee.tis.trainee.forms.model.Person;
+import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
 import uk.nhs.hee.tis.trainee.forms.repository.LtftFormRepository;
 
 /**
@@ -259,8 +260,13 @@ public class LtftService {
       return Optional.empty();
     }
 
-    form.setCreated(existingForm.getCreated()); //explicitly set otherwise form saved as 'new'
-    LtftForm savedForm = ltftFormRepository.save(form);
+    // Merge the new content in to the existing form.
+    Person assignedAdmin =
+        existingForm.getContent() != null ? existingForm.getContent().assignedAdmin() : null;
+    LtftContent updatedContent = form.getContent().withAssignedAdmin(assignedAdmin);
+    existingForm.setContent(updatedContent);
+
+    LtftForm savedForm = ltftFormRepository.save(existingForm);
     return Optional.of(mapper.toDto(savedForm));
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -1809,8 +1809,9 @@ class LtftServiceTest {
     verifyNoMoreInteractions(repository);
   }
 
-  @Test
-  void shouldSaveIfUpdatingLtftFormForTrainee() {
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = EXCLUDE, names = {"DRAFT", "UNSUBMITTED"})
+  void shouldNotUpdateFormIfNotEditableState(LifecycleState state) {
     LtftFormDto dtoToSave = LtftFormDto.builder()
         .id(ID)
         .traineeTisId(TRAINEE_ID)
@@ -1819,6 +1820,30 @@ class LtftServiceTest {
     LtftForm existingForm = new LtftForm();
     existingForm.setId(ID);
     existingForm.setTraineeTisId(TRAINEE_ID);
+    existingForm.setLifecycleState(state);
+    existingForm.setContent(LtftContent.builder().name("test").build());
+    when(repository.findByTraineeTisIdAndId(TRAINEE_ID, ID))
+        .thenReturn(Optional.of(existingForm));
+
+    Optional<LtftFormDto> formDtoOptional = service.updateLtftForm(ID, dtoToSave);
+
+    assertThat("Unexpected form returned.", formDtoOptional.isPresent(), is(false));
+    verify(repository).findByTraineeTisIdAndId(TRAINEE_ID, ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = INCLUDE, names = {"DRAFT", "UNSUBMITTED"})
+  void shouldSaveIfUpdatingLtftFormForTrainee(LifecycleState state) {
+    LtftFormDto dtoToSave = LtftFormDto.builder()
+        .id(ID)
+        .traineeTisId(TRAINEE_ID)
+        .build();
+
+    LtftForm existingForm = new LtftForm();
+    existingForm.setId(ID);
+    existingForm.setTraineeTisId(TRAINEE_ID);
+    existingForm.setLifecycleState(state);
     existingForm.setContent(LtftContent.builder().name("test").build());
     when(repository.findByTraineeTisIdAndId(TRAINEE_ID, ID))
         .thenReturn(Optional.of(existingForm));


### PR DESCRIPTION
fix(ltft): restrict edits to DRAFT and UNSUBMITTED
Currently the API allows edits to forms in any state, this should be
restricted to only those in DRAFT or SUBMITTED states.

TIS21-7137
TIS21-7150

---

fix(ltft): ignore read-only fields on update
When a trainee updates an LTFT it is possible to provide values for the
following fields, which should be read only:
 - `formRef`
 - `revision`
 - `assignedAdmin`
 - `status`
 - `created`
 - `lastModified`

Update LtftFormDto and LtftResource to ensure that the above fields are
either validated or excluded from deserialization using JsonViews.

Update LtftService to update the existing form content instead of
persisting the user-provided data. The provided content will be
extracted and inserted in to the existing form, with the exception of
`assignedAdmin` which will be copied from the existing form.

TIS21-7137
TIS21-7150