### PR TITLE
feat: snapshot submitted LTFT forms

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.39.0"
+version = "0.40.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
@@ -79,6 +79,7 @@ import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto.StatusInfoDto;
 import uk.nhs.hee.tis.trainee.forms.dto.PersonDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
+import uk.nhs.hee.tis.trainee.forms.model.LtftSubmissionHistory;
 import uk.nhs.hee.tis.trainee.forms.model.Person;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent.Discussions;
@@ -112,6 +113,7 @@ class LtftResourceIntegrationTest {
   @AfterEach
   void tearDown() {
     template.findAllAndRemove(new Query(), LtftForm.class);
+    template.findAllAndRemove(new Query(), LtftSubmissionHistory.class);
   }
 
 

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/LtftSubmissionHistoryRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/LtftSubmissionHistoryRepositoryIntegrationTest.java
@@ -1,0 +1,232 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.repository;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.data.domain.Sort.Direction.ASC;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.mongodb.client.FindIterable;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.IndexField;
+import org.springframework.data.mongodb.core.index.IndexInfo;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.forms.DockerImageNames;
+import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
+import uk.nhs.hee.tis.trainee.forms.model.LtftSubmissionHistory;
+import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+class LtftSubmissionHistoryRepositoryIntegrationTest {
+
+  private static final String TRAINEE_ID = "40";
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MongoTemplate template;
+
+  @AfterEach
+  void tearDown() {
+    template.findAllAndRemove(new Query(), LtftSubmissionHistory.class);
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      _id_                                           | _id
+      traineeTisId                                   | traineeTisId
+      formRef                                        | formRef
+      content.personalDetails.forenames              | content.personalDetails.forenames
+      content.personalDetails.gdcNumber              | content.personalDetails.gdcNumber
+      content.personalDetails.gmcNumber              | content.personalDetails.gmcNumber
+      content.personalDetails.surname                | content.personalDetails.surname
+      content.programmeMembership.id                 | content.programmeMembership.id
+      content.programmeMembership.designatedBodyCode | content.programmeMembership.designatedBodyCode
+      content.programmeMembership.name               | content.programmeMembership.name
+      status.current.state                           | status.current.state
+      status.history.state                           | status.history.state
+       """)
+  void shouldCreateSingleFieldIndexes(String indexName, String fieldName) {
+    IndexOperations indexOperations = template.indexOps(LtftSubmissionHistory.class);
+    List<IndexInfo> indexes = indexOperations.getIndexInfo();
+
+    assertThat("Unexpected index count.", indexes, hasSize(13)); // 12 + 1 compound index
+
+    IndexInfo index = indexes.stream()
+        .filter(i -> i.getName().equals(indexName))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Expected index not found."));
+
+    List<IndexField> indexFields = index.getIndexFields();
+    assertThat("Unexpected index field count.", indexFields, hasSize(1));
+
+    IndexField indexField = indexFields.get(0);
+    assertThat("Unexpected index field key.", indexField.getKey(), is(fieldName));
+    assertThat("Unexpected index field direction.", indexField.getDirection(), is(ASC));
+
+    assertThat("Unexpected hidden index.", index.isHidden(), is(false));
+    assertThat("Unexpected hashed index.", index.isHashed(), is(false));
+    assertThat("Unexpected sparse index.", index.isSparse(), is(false));
+    assertThat("Unexpected unique index.", index.isUnique(), is(false));
+    assertThat("Unexpected wildcard index.", index.isWildcard(), is(false));
+  }
+
+  @Test
+  void shouldCreateCompoundFieldIndexes() {
+    IndexOperations indexOperations = template.indexOps(LtftSubmissionHistory.class);
+    List<IndexInfo> indexes = indexOperations.getIndexInfo();
+
+    assertThat("Unexpected index count.", indexes, hasSize(13));
+
+    IndexInfo index = indexes.stream()
+        .filter(i -> i.getName().equals("formRef_1_revision_1"))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Expected index not found."));
+
+    List<IndexField> indexFields = index.getIndexFields();
+    assertThat("Unexpected index field count.", indexFields, hasSize(2));
+
+    IndexField formRefField = indexFields.get(0);
+    assertThat("Unexpected formRef field key.", formRefField.getKey(), is("formRef"));
+    assertThat("Unexpected formRef field direction.", formRefField.getDirection(), is(ASC));
+
+    IndexField revisionField = indexFields.get(1);
+    assertThat("Unexpected revision field key.", revisionField.getKey(), is("revision"));
+    assertThat("Unexpected revision field direction.", revisionField.getDirection(), is(ASC));
+  }
+
+  @Test
+  void shouldStoreWithUuidIdType() throws JsonProcessingException {
+    template.insert(new LtftSubmissionHistory());
+
+    String document = template.execute(LtftSubmissionHistory.class, collection -> {
+      FindIterable<Document> documents = collection.find();
+      return documents.cursor().next().toJson();
+    });
+
+    ObjectNode jsonDocument = (ObjectNode) new ObjectMapper().readTree(document);
+
+    String idType = jsonDocument.get("_id").get("$binary").get("subType").textValue();
+    assertThat("Unexpected ID format.", idType, is("04"));
+  }
+
+  @Test
+  void shouldNotStoreUnexpectedFields() throws JsonProcessingException {
+    template.insert(new LtftSubmissionHistory());
+
+    String document = template.execute(LtftSubmissionHistory.class, collection -> {
+      FindIterable<Document> documents = collection.find();
+      return documents.cursor().next().toJson();
+    });
+
+    ObjectNode jsonDocument = (ObjectNode) new ObjectMapper().readTree(document);
+    List<String> fieldNames = new ArrayList<>();
+    jsonDocument.fieldNames().forEachRemaining(fieldNames::add);
+
+    assertThat("Unexpected field count.", fieldNames, hasSize(5));
+    assertThat("Unexpected fields.", fieldNames,
+        hasItems("_id", "revision", "created", "lastModified", "_class"));
+  }
+
+  @Test
+  void shouldSetCreatedAndLastModifiedWhenSave() {
+    LtftSubmissionHistory submissionHistory = new LtftSubmissionHistory();
+    submissionHistory.setTraineeTisId(TRAINEE_ID);
+    submissionHistory.setContent(LtftContent.builder().name("name").build());
+    template.insert(submissionHistory);
+
+    List<LtftSubmissionHistory> savedRecords
+        = template.find(new Query(), LtftSubmissionHistory.class);
+    assertThat("Unexpected saved records.", savedRecords.size(), is(1));
+    LtftSubmissionHistory savedRecord = savedRecords.get(0);
+    assertThat("Unexpected saved record name.", savedRecord.getContent().name(), is("name"));
+    assertThat("Unexpected saved record trainee id.", savedRecord.getTraineeTisId(),
+        is(TRAINEE_ID));
+    assertThat("Unexpected saved record id.", savedRecord.getId(), is(notNullValue()));
+    Instant roughlyNow = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+    Instant roughlyCreated = savedRecord.getCreated().truncatedTo(ChronoUnit.SECONDS);
+    assertThat("Unexpected saved record created timestamp.",
+        roughlyCreated.equals(roughlyNow), is(true));
+    Instant roughlyLastModified = savedRecord.getLastModified().truncatedTo(ChronoUnit.SECONDS);
+    assertThat("Unexpected saved record last modified timestamp.",
+        roughlyLastModified.equals(roughlyNow), is(true));
+  }
+
+  @Test
+  void shouldUpdateLastModifiedWhenUpdate() throws InterruptedException {
+    LtftSubmissionHistory submissionHistory = new LtftSubmissionHistory();
+    submissionHistory.setTraineeTisId(TRAINEE_ID);
+    submissionHistory.setContent(LtftContent.builder().name("name").build());
+    template.insert(submissionHistory);
+
+    List<LtftSubmissionHistory> savedRecords
+        = template.find(new Query(), LtftSubmissionHistory.class);
+    assertThat("Unexpected saved records.", savedRecords.size(), is(1));
+    LtftSubmissionHistory savedRecord = savedRecords.get(0);
+    Instant savedCreated = savedRecord.getCreated();
+    Instant savedLastModified = savedRecord.getLastModified();
+
+    submissionHistory.setId(savedRecord.getId());
+    Thread.sleep(1000);
+    template.save(submissionHistory);
+
+    List<LtftSubmissionHistory> updatedRecords
+        = template.find(new Query(), LtftSubmissionHistory.class);
+    assertThat("Unexpected updated records.", updatedRecords.size(), is(1));
+    LtftSubmissionHistory updatedRecord = updatedRecords.get(0);
+    Instant updatedCreated = updatedRecord.getCreated();
+    Instant updatedLastModified = updatedRecord.getLastModified();
+
+    assertThat("Unexpected updated record created timestamp.",
+        updatedCreated.equals(savedCreated), is(true));
+    assertThat("Unexpected updated record last modified timestamp.",
+        updatedLastModified.isAfter(savedLastModified), is(true));
+  }
+}

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/service/LtftSubmissionHistoryServiceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/service/LtftSubmissionHistoryServiceIntegrationTest.java
@@ -23,12 +23,12 @@ package uk.nhs.hee.tis.trainee.forms.service;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 import io.awspring.cloud.sns.core.SnsTemplate;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -65,11 +65,6 @@ class LtftSubmissionHistoryServiceIntegrationTest {
   @MockBean
   private SnsTemplate snsTemplate;
 
-  @BeforeEach
-  void setUp() {
-
-  }
-
   @AfterEach
   void tearDown() {
     template.remove(new Query(), LtftSubmissionHistory.class);
@@ -90,7 +85,7 @@ class LtftSubmissionHistoryServiceIntegrationTest {
     assert savedSubmissionHistory != null;
 
     assertThat("Unexpected saved submission ID.",
-        savedSubmissionHistory.getId().equals(form.getId()), is(false));
+        savedSubmissionHistory.getId(), not(form.getId()));
     assertThat("Unexpected saved submission created.",
         savedSubmissionHistory.getCreated(), notNullValue());
     assertThat("Unexpected saved submission last modified.",

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
@@ -47,6 +47,7 @@ import uk.nhs.hee.tis.trainee.forms.dto.PersonDto;
 import uk.nhs.hee.tis.trainee.forms.dto.PersonalDetailsDto;
 import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status.StatusDetail;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
+import uk.nhs.hee.tis.trainee.forms.model.LtftSubmissionHistory;
 import uk.nhs.hee.tis.trainee.forms.model.Person;
 import uk.nhs.hee.tis.trainee.forms.model.content.CctChange;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
@@ -142,6 +143,17 @@ public abstract class LtftMapper {
   @Mapping(target = "reasons", source = "content.reasons")
   @Mapping(target = "assignedAdmin", source = "assignedAdmin")
   public abstract LtftFormDto toDto(LtftForm entity);
+
+  /**
+   * Convert a {@link LtftForm} to a {@link LtftSubmissionHistory} entity.
+   *
+   * @param entity The form to convert.
+   * @return The equivalent submission history.
+   */
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "created", ignore = true)
+  @Mapping(target = "lastModified", ignore = true)
+  public abstract LtftSubmissionHistory toSubmissionHistory(LtftForm entity);
 
   /**
    * Convert a {@link LtftFormDto} DTO to a {@link LtftForm}.

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/LtftSubmissionHistory.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/LtftSubmissionHistory.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.model;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
+
+/**
+ * A LTFT form submission entity.
+ */
+@Document("LtftSubmissionHistory")
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@CompoundIndex(def = "{'formRef': 1, 'revision': 1}", unique = true)
+public class LtftSubmissionHistory extends AbstractAuditedForm<LtftContent> {
+
+  @Override
+  public String getFormType() {
+    return "ltftSubmissionHistory";
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftSubmissionHistoryRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftSubmissionHistoryRepository.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.repository;
+
+import java.util.UUID;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import uk.nhs.hee.tis.trainee.forms.model.LtftSubmissionHistory;
+
+/**
+ * A repository for LTFT submission history items.
+ */
+@Repository
+public interface LtftSubmissionHistoryRepository
+    extends MongoRepository<LtftSubmissionHistory, UUID> {
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftSubmissionHistoryService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftSubmissionHistoryService.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.service;
+
+import com.amazonaws.xray.spring.aop.XRayEnabled;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.forms.mapper.LtftMapper;
+import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
+import uk.nhs.hee.tis.trainee.forms.model.LtftSubmissionHistory;
+import uk.nhs.hee.tis.trainee.forms.repository.LtftSubmissionHistoryRepository;
+
+/**
+ * A service for managing LTFT submission history.
+ */
+@Slf4j
+@Service
+@XRayEnabled
+public class LtftSubmissionHistoryService {
+
+  private final LtftSubmissionHistoryRepository ltftHistoryRepository;
+
+  private final LtftMapper mapper;
+
+  /**
+   * Constructor for LtftSubmissionHistoryService.
+   *
+   * @param ltftHistoryRepository The repository for LTFT submission history.
+   * @param mapper                The mapper for converting LTFT and LTFT submission history items.
+   */
+  public LtftSubmissionHistoryService(
+      LtftSubmissionHistoryRepository ltftHistoryRepository, LtftMapper mapper) {
+    this.ltftHistoryRepository = ltftHistoryRepository;
+    this.mapper = mapper;
+  }
+
+  /**
+   * Take a snapshot of the submitted LTFT form and save it to the repository.
+   *
+   * @param ltftForm The LTFT form to be saved.
+   */
+  public void takeSnapshot(LtftForm ltftForm) {
+    log.info("Taking snapshot of submitted form {}", ltftForm.getId());
+    LtftSubmissionHistory submissionHistory = mapper.toSubmissionHistory(ltftForm);
+    ltftHistoryRepository.save(submissionHistory);
+  }
+
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/model/LtftSubmissionHistoryTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/model/LtftSubmissionHistoryTest.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.model;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class LtftSubmissionHistoryTest {
+
+  @Test
+  void shouldGetFormType() {
+    assertThat("Unexpected form type.", new LtftSubmissionHistory().getFormType(),
+        is("ltftSubmissionHistory"));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -136,6 +136,7 @@ class LtftServiceTest {
   private MongoTemplate mongoTemplate;
   private LtftMapper mapper;
   private SnsTemplate snsTemplate;
+  private LtftSubmissionHistoryService ltftSubmissionHistoryService;
 
   @BeforeEach
   void setUp() {
@@ -152,10 +153,11 @@ class LtftServiceTest {
     repository = mock(LtftFormRepository.class);
     mongoTemplate = mock(MongoTemplate.class);
     snsTemplate = mock(SnsTemplate.class);
+    ltftSubmissionHistoryService = mock(LtftSubmissionHistoryService.class);
 
     mapper = new LtftMapperImpl(new TemporalMapperImpl());
     service = new LtftService(adminIdentity, traineeIdentity, repository, mongoTemplate, mapper,
-        snsTemplate, LTFT_STATUS_UPDATE_TOPIC);
+        snsTemplate, LTFT_STATUS_UPDATE_TOPIC, ltftSubmissionHistoryService);
   }
 
   @Test
@@ -1484,6 +1486,8 @@ class LtftServiceTest {
     assertThat("Unexpected history count.", history, hasSize(2));
     assertThat("Unexpected history state.", history.get(0).state(), is(DRAFT));
     assertThat("Unexpected history state.", history.get(1).state(), is(targetState));
+
+    verify(ltftSubmissionHistoryService).takeSnapshot(entity);
   }
 
   @ParameterizedTest
@@ -1553,6 +1557,8 @@ class LtftServiceTest {
     assertThat("Unexpected history count.", history, hasSize(2));
     assertThat("Unexpected history state.", history.get(0).state(), is(SUBMITTED));
     assertThat("Unexpected history state.", history.get(1).state(), is(targetState));
+
+    verifyNoInteractions(ltftSubmissionHistoryService);
   }
 
   @ParameterizedTest
@@ -2674,6 +2680,7 @@ class LtftServiceTest {
         is(notNullValue()));
     assertThat("Unexpected form revision.", form.getRevision(), is(2));
     verify(repository).save(form);
+    verify(ltftSubmissionHistoryService).takeSnapshot(form);
   }
 
   @ParameterizedTest
@@ -2701,6 +2708,7 @@ class LtftServiceTest {
     assertThat("Unexpected result when form is submitted.", result.isPresent(), is(true));
     assertThat("Unexpected form ref.", form.getFormRef(), is("ltft_" + TRAINEE_ID + refSuffix));
     verify(repository).save(form);
+    verify(ltftSubmissionHistoryService).takeSnapshot(form);
   }
 
   @Test
@@ -2724,6 +2732,7 @@ class LtftServiceTest {
     assertThat("Unexpected result when form is submitted.", result.isPresent(), is(true));
     assertThat("Unexpected form ref.", form.getFormRef(), is(formRef));
     verify(repository).save(form);
+    verify(ltftSubmissionHistoryService).takeSnapshot(form);
   }
 
   @Test
@@ -2756,6 +2765,7 @@ class LtftServiceTest {
     assertThat("Unexpected form revision.", form.getRevision(), is(3));
     assertThat("Unexpected form ref.", form.getFormRef(), is("formRef_001"));
     verify(repository).save(form);
+    verifyNoInteractions(ltftSubmissionHistoryService);
   }
 
   @Test
@@ -2789,6 +2799,7 @@ class LtftServiceTest {
     assertThat("Unexpected form revision.", form.getRevision(), is(2));
     assertThat("Unexpected form ref.", form.getFormRef(), is("formRef_001"));
     verify(repository).save(form);
+    verifyNoInteractions(ltftSubmissionHistoryService);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftSubmissionHistoryServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftSubmissionHistoryServiceTest.java
@@ -1,0 +1,87 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import uk.nhs.hee.tis.trainee.forms.mapper.LtftMapper;
+import uk.nhs.hee.tis.trainee.forms.mapper.LtftMapperImpl;
+import uk.nhs.hee.tis.trainee.forms.mapper.TemporalMapperImpl;
+import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
+import uk.nhs.hee.tis.trainee.forms.model.LtftSubmissionHistory;
+import uk.nhs.hee.tis.trainee.forms.repository.LtftSubmissionHistoryRepository;
+
+class LtftSubmissionHistoryServiceTest {
+
+  private static final UUID ID = UUID.randomUUID();
+  private static final String TRAINEE_ID = "123";
+
+  private LtftSubmissionHistoryService service;
+
+  private LtftSubmissionHistoryRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(LtftSubmissionHistoryRepository.class);
+    LtftMapper mapper = new LtftMapperImpl(new TemporalMapperImpl());
+    service = new LtftSubmissionHistoryService(repository, mapper);
+  }
+
+  @Test
+  void shouldSaveSnapshotWithoutIdAndCreatedAndLastModifiedDate() {
+    LtftForm form = new LtftForm();
+    form.setId(ID);
+    form.setTraineeTisId(TRAINEE_ID);
+    form.setRevision(1);
+    form.setCreated(Instant.EPOCH);
+    form.setLastModified(Instant.now());
+
+    service.takeSnapshot(form);
+
+    ArgumentCaptor<LtftSubmissionHistory> captor
+        = ArgumentCaptor.forClass(LtftSubmissionHistory.class);
+    verify(repository).save(captor.capture());
+    LtftSubmissionHistory submissionHistory = captor.getValue();
+    assertThat("Unexpected ID.", submissionHistory.getId(), is(nullValue()));
+    assertThat("Unexpected created date.", submissionHistory.getCreated(),
+        is(nullValue()));
+    assertThat("Unexpected last modified date.", submissionHistory.getLastModified(),
+        is(nullValue()));
+
+    assertThat("Unexpected revision.", submissionHistory.getRevision(), is(form.getRevision()));
+    assertThat("Unexpected trainee ID.", submissionHistory.getTraineeTisId(),
+        is(form.getTraineeTisId()));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftSubmissionHistoryServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftSubmissionHistoryServiceTest.java
@@ -22,14 +22,10 @@
 package uk.nhs.hee.tis.trainee.forms.service;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.UUID;


### PR DESCRIPTION
There is a rather expansive collection of indexes for the new collection, but it didn't feel worth refactoring the AbstractAuditedForm inheritance given we may in future need search functionality that depends on those indexes.

TIS21-7097