### PR TITLE
fix: index name length

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.40.0"
+version = "0.40.1"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/LtftRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/LtftRepositoryIntegrationTest.java
@@ -79,19 +79,19 @@ class LtftRepositoryIntegrationTest {
 
   @ParameterizedTest
   @CsvSource(delimiter = '|', textBlock = """
-      _id_                                           | _id
-      traineeTisId                                   | traineeTisId
-      formRef                                        | formRef
-      content.personalDetails.forenames              | content.personalDetails.forenames
-      content.personalDetails.gdcNumber              | content.personalDetails.gdcNumber
-      content.personalDetails.gmcNumber              | content.personalDetails.gmcNumber
-      content.personalDetails.surname                | content.personalDetails.surname
-      content.programmeMembership.id                 | content.programmeMembership.id
-      content.programmeMembership.designatedBodyCode | content.programmeMembership.designatedBodyCode
-      content.programmeMembership.name               | content.programmeMembership.name
-      status.current.state                           | status.current.state
-      status.history.state                           | status.history.state
-       """)
+      _id_                                  | _id
+      traineeTisId                          | traineeTisId
+      formRef                               | formRef
+      content.personalDetails.forenames     | content.personalDetails.forenames
+      content.personalDetails.gdcNumber     | content.personalDetails.gdcNumber
+      content.personalDetails.gmcNumber     | content.personalDetails.gmcNumber
+      content.personalDetails.surname       | content.personalDetails.surname
+      content.programmeMembership.id        | content.programmeMembership.id
+      content.programmeMembership.dbc       | content.programmeMembership.designatedBodyCode
+      content.programmeMembership.name      | content.programmeMembership.name
+      status.current.state                  | status.current.state
+      status.history.state                  | status.history.state
+      """)
   void shouldCreateSingleFieldIndexes(String indexName, String fieldName) {
     IndexOperations indexOperations = template.indexOps(LtftForm.class);
     List<IndexInfo> indexes = indexOperations.getIndexInfo();

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/LtftSubmissionHistoryRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/LtftSubmissionHistoryRepositoryIntegrationTest.java
@@ -80,19 +80,19 @@ class LtftSubmissionHistoryRepositoryIntegrationTest {
 
   @ParameterizedTest
   @CsvSource(delimiter = '|', textBlock = """
-      _id_                                           | _id
-      traineeTisId                                   | traineeTisId
-      formRef                                        | formRef
-      content.personalDetails.forenames              | content.personalDetails.forenames
-      content.personalDetails.gdcNumber              | content.personalDetails.gdcNumber
-      content.personalDetails.gmcNumber              | content.personalDetails.gmcNumber
-      content.personalDetails.surname                | content.personalDetails.surname
-      content.programmeMembership.id                 | content.programmeMembership.id
-      content.programmeMembership.designatedBodyCode | content.programmeMembership.designatedBodyCode
-      content.programmeMembership.name               | content.programmeMembership.name
-      status.current.state                           | status.current.state
-      status.history.state                           | status.history.state
-       """)
+      _id_                                  | _id
+      traineeTisId                          | traineeTisId
+      formRef                               | formRef
+      content.personalDetails.forenames     | content.personalDetails.forenames
+      content.personalDetails.gdcNumber     | content.personalDetails.gdcNumber
+      content.personalDetails.gmcNumber     | content.personalDetails.gmcNumber
+      content.personalDetails.surname       | content.personalDetails.surname
+      content.programmeMembership.id        | content.programmeMembership.id
+      content.programmeMembership.dbc       | content.programmeMembership.designatedBodyCode
+      content.programmeMembership.name      | content.programmeMembership.name
+      status.current.state                  | status.current.state
+      status.history.state                  | status.history.state
+      """)
   void shouldCreateSingleFieldIndexes(String indexName, String fieldName) {
     IndexOperations indexOperations = template.indexOps(LtftSubmissionHistory.class);
     List<IndexInfo> indexes = indexOperations.getIndexInfo();

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/LtftContent.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/LtftContent.java
@@ -98,7 +98,7 @@ public record LtftContent(
       UUID id,
       @Indexed
       String name,
-      @Indexed
+      @Indexed(name = "dbc")
       String designatedBodyCode,
       LocalDate startDate,
       LocalDate endDate,


### PR DESCRIPTION
Service is currently failing to deploy with error
```
Failed to instantiate [org.springframework.data.mongodb.core.MongoTemplate]: Factory method 'mongoTemplate' threw exception with message: Cannot create index for 'content.programmeMembership.designatedBodyCode' in collection 'LtftSubmissionHistory' with keys 'Document{{content.programmeMembership.designatedBodyCode=1}}' and options 'Document{{name=content.programmeMembership.designatedBodyCode}}' 
...
Caused by: com.mongodb.MongoCommandException: Command failed with error 67: 'namespace name generated from index name is too long'
```

This fix assumes we are ok with manually deleting the existing index on this field in the LtftForm collection, since the name will change. Otherwise I'll cook-up a mongock.

NO-TICKET