### PR TITLE
feat(ltft): capture history of assigned admins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.41.0"
+version = "0.42.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
@@ -423,9 +423,6 @@ class AdminLtftResourceIntegrationTest {
 
     LtftForm form = new LtftForm();
     form.setTraineeTisId("47165");
-    form.setAssignedAdmin(Person.builder()
-        .name("Ad Min").email("ad.min@example.com").role("ADMIN")
-        .build());
 
     LtftContent content = LtftContent.builder()
         .personalDetails(PersonalDetails.builder()
@@ -450,7 +447,10 @@ class AdminLtftResourceIntegrationTest {
     LocalDate latestSubmittedDate = LocalDate.ofInstant(latestSubmitted, timezone);
 
     StatusInfo statusInfo = StatusInfo.builder()
-        .state(SUBMITTED).timestamp(Instant.now())
+        .state(SUBMITTED)
+        .assignedAdmin(
+            Person.builder().name("Ad Min").email("ad.min@example.com").role("ADMIN").build())
+        .timestamp(Instant.now())
         .build();
     form.setStatus(Status.builder()
         .current(statusInfo)
@@ -752,9 +752,6 @@ class AdminLtftResourceIntegrationTest {
 
     LtftForm form = new LtftForm();
     form.setTraineeTisId("47165");
-    form.setAssignedAdmin(Person.builder()
-        .name("Ad Min").email("ad.min@example.com").role("ADMIN")
-        .build());
 
     LtftContent content = LtftContent.builder()
         .personalDetails(PersonalDetails.builder()
@@ -778,7 +775,10 @@ class AdminLtftResourceIntegrationTest {
     Instant latestSubmitted = Instant.now().plus(Duration.ofDays(7));
 
     StatusInfo statusInfo = StatusInfo.builder()
-        .state(SUBMITTED).timestamp(Instant.now())
+        .state(SUBMITTED)
+        .assignedAdmin(
+            Person.builder().name("Ad Min").email("ad.min@example.com").role("ADMIN").build())
+        .timestamp(Instant.now())
         .build();
     form.setStatus(Status.builder()
         .current(statusInfo)
@@ -808,9 +808,9 @@ class AdminLtftResourceIntegrationTest {
         .andExpect(jsonPath("$.reasons.selected", hasItems("Caring responsibilities", "Other")))
         .andExpect(jsonPath("$.discussions.tpdEmail", is("tpd@example.com")))
         .andExpect(jsonPath("$.status.current.state", is(SUBMITTED.name())))
-        .andExpect(jsonPath("$.assignedAdmin.name", is("Ad Min")))
-        .andExpect(jsonPath("$.assignedAdmin.email", is("ad.min@example.com")))
-        .andExpect(jsonPath("$.assignedAdmin.role", is("ADMIN")));
+        .andExpect(jsonPath("$.status.current.assignedAdmin.name", is("Ad Min")))
+        .andExpect(jsonPath("$.status.current.assignedAdmin.email", is("ad.min@example.com")))
+        .andExpect(jsonPath("$.status.current.assignedAdmin.role", is("ADMIN")));
   }
 
   @Test
@@ -830,7 +830,6 @@ class AdminLtftResourceIntegrationTest {
     LtftForm form = new LtftForm();
     form.setTraineeTisId("47165");
     form.setFormRef("ltft_47165_001");
-    form.setAssignedAdmin(Person.builder().build());
 
     LtftContent content = LtftContent.builder()
         .personalDetails(PersonalDetails.builder().build())
@@ -847,7 +846,9 @@ class AdminLtftResourceIntegrationTest {
     Instant latestSubmitted = Instant.now().plus(Duration.ofDays(7));
 
     StatusInfo statusInfo = StatusInfo.builder()
-        .state(SUBMITTED).timestamp(Instant.now())
+        .state(SUBMITTED)
+        .assignedAdmin(Person.builder().build())
+        .timestamp(Instant.now())
         .build();
     form.setStatus(Status.builder()
         .current(statusInfo)
@@ -895,7 +896,6 @@ class AdminLtftResourceIntegrationTest {
   void shouldGetDetailPdfPersonalDetailsWhenLtftWithMatchingDbcIsNotDraft() throws Exception {
     LtftForm form = new LtftForm();
     form.setTraineeTisId("47165");
-    form.setAssignedAdmin(Person.builder().build());
 
     LtftContent content = LtftContent.builder()
         .personalDetails(PersonalDetails.builder()
@@ -922,7 +922,9 @@ class AdminLtftResourceIntegrationTest {
     Instant latestSubmitted = Instant.now().plus(Duration.ofDays(7));
 
     StatusInfo statusInfo = StatusInfo.builder()
-        .state(SUBMITTED).timestamp(Instant.now())
+        .state(SUBMITTED)
+        .assignedAdmin(Person.builder().build())
+        .timestamp(Instant.now())
         .build();
     form.setStatus(Status.builder()
         .current(statusInfo)
@@ -970,7 +972,7 @@ class AdminLtftResourceIntegrationTest {
   void shouldGetDetailPdfProgrammeDetailsWhenLtftWithMatchingDbcIsNotDraft() throws Exception {
     LtftForm form = new LtftForm();
     form.setTraineeTisId("47165");
-    form.setAssignedAdmin(Person.builder().build());
+    form.setAssignedAdmin(Person.builder().build(), null);
 
     LocalDate startDate = LocalDate.now();
     LocalDate endDate = startDate.plusYears(1);
@@ -1041,7 +1043,7 @@ class AdminLtftResourceIntegrationTest {
   void shouldGetDetailPdfChangeDetailsWhenLtftWithMatchingDbcIsNotDraft() throws Exception {
     LtftForm form = new LtftForm();
     form.setTraineeTisId("47165");
-    form.setAssignedAdmin(Person.builder().build());
+    form.setAssignedAdmin(Person.builder().build(), null);
 
     LocalDate startDate = LocalDate.now();
     LocalDate endDate = startDate.plusYears(1);
@@ -1115,7 +1117,7 @@ class AdminLtftResourceIntegrationTest {
   void shouldGetDetailPdfReasonDetailsWhenLtftWithMatchingDbcIsNotDraft() throws Exception {
     LtftForm form = new LtftForm();
     form.setTraineeTisId("47165");
-    form.setAssignedAdmin(Person.builder().build());
+    form.setAssignedAdmin(Person.builder().build(), null);
 
     LtftContent content = LtftContent.builder()
         .personalDetails(PersonalDetails.builder().build())
@@ -1177,7 +1179,7 @@ class AdminLtftResourceIntegrationTest {
   void shouldGetDetailPdfDeclarationDetailsWhenLtftWithMatchingDbcIsNotDraft() throws Exception {
     LtftForm form = new LtftForm();
     form.setTraineeTisId("47165");
-    form.setAssignedAdmin(Person.builder().build());
+    form.setAssignedAdmin(Person.builder().build(), null);
 
     LtftContent content = LtftContent.builder()
         .personalDetails(PersonalDetails.builder().build())
@@ -1238,7 +1240,6 @@ class AdminLtftResourceIntegrationTest {
   void shouldGetDetailPdfDiscussionsDetailsWhenLtftWithMatchingDbcIsNotDraft() throws Exception {
     LtftForm form = new LtftForm();
     form.setTraineeTisId("47165");
-    form.setAssignedAdmin(Person.builder().build());
 
     LtftContent content = LtftContent.builder()
         .personalDetails(PersonalDetails.builder().build())
@@ -1270,7 +1271,9 @@ class AdminLtftResourceIntegrationTest {
     Instant latestSubmitted = Instant.now().plus(Duration.ofDays(7));
 
     StatusInfo statusInfo = StatusInfo.builder()
-        .state(SUBMITTED).timestamp(Instant.now())
+        .state(SUBMITTED)
+        .assignedAdmin(Person.builder().build())
+        .timestamp(Instant.now())
         .build();
     form.setStatus(Status.builder()
         .current(statusInfo)

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
@@ -345,10 +345,14 @@ class LtftResourceIntegrationTest {
     LtftFormDto formToSave = LtftFormDto.builder()
         .traineeTisId(TRAINEE_ID)
         .name("test")
-        .assignedAdmin(PersonDto.builder()
-            .name("Ad Min")
-            .email("ad.min@example.com")
-            .role("ADMIN")
+        .status(StatusDto.builder()
+            .current(StatusInfoDto.builder()
+                .assignedAdmin(PersonDto.builder()
+                    .name("Ad Min")
+                    .email("ad.min@example.com")
+                    .role("ADMIN")
+                    .build())
+                .build())
             .build())
         .build();
     String formToSaveJson = mapper.writeValueAsString(formToSave);
@@ -358,7 +362,7 @@ class LtftResourceIntegrationTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(formToSaveJson))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.assignedAdmin", nullValue()));
+        .andExpect(jsonPath("$.status.current.assignedAdmin", nullValue()));
   }
 
   @Test
@@ -560,8 +564,11 @@ class LtftResourceIntegrationTest {
         .traineeTisId(TRAINEE_ID)
         .formRef("ref_123")
         .revision(3)
-        .assignedAdmin(PersonDto.builder().name("Ad Min").build())
-        .status(StatusDto.builder().build())
+        .status(StatusDto.builder()
+            .current(StatusInfoDto.builder()
+                .assignedAdmin(PersonDto.builder().name("Ad Min").build())
+                .build())
+            .build())
         .created(Instant.EPOCH)
         .lastModified(Instant.EPOCH)
         .build();
@@ -577,8 +584,8 @@ class LtftResourceIntegrationTest {
         .andExpect(jsonPath("$.traineeTisId").value(TRAINEE_ID))
         .andExpect(jsonPath("$.formRef", nullValue()))
         .andExpect(jsonPath("$.revision").value(0))
-        .andExpect(jsonPath("$.assignedAdmin", nullValue()))
         .andExpect(jsonPath("$.status.current.state", is("DRAFT")))
+        .andExpect(jsonPath("$.status.current.assignedAdmin", nullValue()))
         .andExpect(jsonPath("$.created").value(
             formSaved.getCreated().truncatedTo(ChronoUnit.MILLIS).toString()))
         .andExpect(jsonPath("$.lastModified",

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
@@ -48,7 +48,6 @@ import uk.nhs.hee.tis.trainee.forms.model.content.CctChangeType;
  * @param discussions         Discussions which took place as part of the LTFT process.
  * @param change              The calculated LTFT change.
  * @param reasons             The reasons for applying for LTFT.
- * @param assignedAdmin       The administration assigned to the LTFT application.
  * @param status              The status of the LTFT application, both current and audit history.
  * @param created             When the LTFT application was first created.
  * @param lastModified        When the LTFT application was last modified.
@@ -73,10 +72,6 @@ public record LtftFormDto(
     DiscussionsDto discussions,
     CctChangeDto change,
     ReasonsDto reasons,
-
-    @JsonView(ReadOnly.class)
-    @Null(groups = {Create.class, Update.class})
-    PersonDto assignedAdmin,
 
     @JsonView(ReadOnly.class)
     @Null(groups = {Create.class, Update.class})
@@ -181,17 +176,19 @@ public record LtftFormDto(
     /**
      * Form status information.
      *
-     * @param state      The lifecycle state of the form.
-     * @param detail     Status reason detail.
-     * @param modifiedBy The Person who made this status change.
-     * @param timestamp  The timestamp of the status change.
-     * @param revision   The revision number associated with this status change.
+     * @param state         The lifecycle state of the form.
+     * @param detail        Status reason detail.
+     * @param assignedAdmin The admin who is assigned to process the form.
+     * @param modifiedBy    The Person who made this status change.
+     * @param timestamp     The timestamp of the status change.
+     * @param revision      The revision number associated with this status change.
      */
     @Builder
     public record StatusInfoDto(
 
         LifecycleState state,
         LftfStatusInfoDetailDto detail,
+        PersonDto assignedAdmin,
         PersonDto modifiedBy,
         Instant timestamp,
         Integer revision

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
@@ -82,8 +82,8 @@ public abstract class LtftMapper {
   @Mapping(target = "tpd.email", source = "content.discussions.tpdEmail")
   @Mapping(target = "tpd.emailStatus", constant = "UNKNOWN") // TODO: not yet available (TIS21-7022)
   @Mapping(target = "status", source = "status.current.state")
-  @Mapping(target = "assignedAdmin.name", source = "assignedAdmin.name")
-  @Mapping(target = "assignedAdmin.email", source = "assignedAdmin.email")
+  @Mapping(target = "assignedAdmin.name", source = "status.current.assignedAdmin.name")
+  @Mapping(target = "assignedAdmin.email", source = "status.current.assignedAdmin.email")
   @Mapping(target = "assignedAdmin.role", ignore = true)
   public abstract LtftAdminSummaryDto toAdminSummaryDto(LtftForm entity);
 
@@ -144,7 +144,6 @@ public abstract class LtftMapper {
   @Mapping(target = "discussions", source = "content.discussions")
   @Mapping(target = "change", source = "content.change")
   @Mapping(target = "reasons", source = "content.reasons")
-  @Mapping(target = "assignedAdmin", source = "assignedAdmin")
   public abstract LtftFormDto toDto(LtftForm entity);
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -64,7 +64,6 @@ import uk.nhs.hee.tis.trainee.forms.mapper.LtftMapper;
 import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status.StatusDetail;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 import uk.nhs.hee.tis.trainee.forms.model.Person;
-import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
 import uk.nhs.hee.tis.trainee.forms.repository.LtftFormRepository;
 
 /**
@@ -372,7 +371,7 @@ public class LtftService {
    * Assign an admin to the LTFT application.
    *
    * @param formId The ID of the LTFT application.
-   * @param admin The admin to assign to the application.
+   * @param admin  The admin to assign to the application.
    * @return The updated LTFT, empty if the form did not exist or did not belong to the admin's
    *     local office.
    */
@@ -386,8 +385,15 @@ public class LtftService {
 
     if (form.isPresent()) {
       LtftForm ltftForm = form.get();
-      Person adminEntity = mapper.toEntity(admin).withRole("ADMIN");
-      ltftForm.setAssignedAdmin(adminEntity);
+
+      Person assignedAdmin = mapper.toEntity(admin).withRole("ADMIN");
+      Person modifiedBy = Person.builder()
+          .name(adminIdentity.getName())
+          .email(adminIdentity.getEmail())
+          .role(adminIdentity.getRole())
+          .build();
+
+      ltftForm.setAssignedAdmin(assignedAdmin, modifiedBy);
       LtftForm updatedForm = ltftFormRepository.save(ltftForm);
       return Optional.of(mapper.toDto(updatedForm));
     } else {
@@ -543,8 +549,8 @@ public class LtftService {
         .map(e -> {
           String property = switch (e.getKey()) {
             case "formRef" -> e.getKey();
-            case "assignedAdmin.name" -> "content.assignedAdmin.name";
-            case "assignedAdmin.email" -> "content.assignedAdmin.email";
+            case "assignedAdmin.name" -> "status.current.assignedAdmin.name";
+            case "assignedAdmin.email" -> "status.current.assignedAdmin.email";
             case "personalDetails.forenames" -> "content.personalDetails.forenames";
             case "personalDetails.gdcNumber" -> "content.personalDetails.gdcNumber";
             case "personalDetails.gmcNumber" -> "content.personalDetails.gmcNumber";

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/model/AbstractAuditedFormTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/model/AbstractAuditedFormTest.java
@@ -23,12 +23,14 @@ package uk.nhs.hee.tis.trainee.forms.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.APPROVED;
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.DRAFT;
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMITTED;
 
@@ -42,6 +44,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status.StatusDetail;
 import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status.StatusInfo;
 
 class AbstractAuditedFormTest {
@@ -153,9 +156,9 @@ class AbstractAuditedFormTest {
   @Test
   void shouldOverwriteExistingLifecycleState() {
     form.setLifecycleState(LifecycleState.DRAFT);
-    form.setLifecycleState(LifecycleState.APPROVED);
+    form.setLifecycleState(APPROVED);
 
-    assertEquals(LifecycleState.APPROVED, form.getLifecycleState(),
+    assertEquals(APPROVED, form.getLifecycleState(),
         "Unexpected lifecycle state.");
   }
 
@@ -174,6 +177,173 @@ class AbstractAuditedFormTest {
     assertThat("Unexpected status history items.",
         form.getStatus().history().stream().map(StatusInfo::state).toList(),
         is(List.of(DRAFT, SUBMITTED)));
+  }
+
+  @Test
+  void shouldRetainAssignedAdminWhenSettingLifecycleState() {
+    StatusInfo assignedStatus = StatusInfo.builder()
+        .state(SUBMITTED)
+        .assignedAdmin(Person.builder()
+            .name("Ad Min")
+            .email("ad.min@example.com")
+            .role("ADMIN")
+            .build())
+        .build();
+
+    form.setStatus(Status.builder()
+        .current(assignedStatus)
+        .history(List.of(assignedStatus))
+        .build());
+
+    form.setLifecycleState(APPROVED);
+
+    Person approvedAdmin = form.getStatus().current().assignedAdmin();
+    assertThat("Unexpected assigned admin name.", approvedAdmin.name(), is("Ad Min"));
+    assertThat("Unexpected assigned admin email.", approvedAdmin.email(), is("ad.min@example.com"));
+    assertThat("Unexpected assigned admin role.", approvedAdmin.role(), is("ADMIN"));
+
+    Person historyAdmin1 = form.getStatus().history().get(0).assignedAdmin();
+    assertThat("Unexpected historical assigned admin.", historyAdmin1, is(approvedAdmin));
+
+    Person historyAdmin2 = form.getStatus().history().get(1).assignedAdmin();
+    assertThat("Unexpected historical assigned admin.", historyAdmin2, is(approvedAdmin));
+  }
+
+  @Test
+  void shouldSetAssignedAdmin() {
+    form.setRevision(1);
+    form.setStatus(null);
+    form.setAssignedAdmin(
+        Person.builder().name("Ad Min").email("ad.min@example.com").role("ADMIN").build(),
+        Person.builder().name("Mo Defy").email("mo.defy@example.com").role("ADMIN").build()
+    );
+
+    Person assignedAdmin = form.getStatus().current().assignedAdmin();
+    assertThat("Unexpected assigned admin name.", assignedAdmin.name(), is("Ad Min"));
+    assertThat("Unexpected assigned admin email.", assignedAdmin.email(), is("ad.min@example.com"));
+    assertThat("Unexpected assigned admin role.", assignedAdmin.role(), is("ADMIN"));
+
+    Person modifiedBy = form.getStatus().current().modifiedBy();
+    assertThat("Unexpected modified by name.", modifiedBy.name(), is("Mo Defy"));
+    assertThat("Unexpected modified by email.", modifiedBy.email(), is("mo.defy@example.com"));
+    assertThat("Unexpected modified by role.", modifiedBy.role(), is("ADMIN"));
+
+    List<StatusInfo> history = form.getStatus().history();
+    assertThat("Unexpected history count.", history, hasSize(1));
+
+    StatusInfo historicalStatus = history.get(0);
+    assertThat("Unexpected assigned admin history.", historicalStatus.assignedAdmin(),
+        is(assignedAdmin));
+    assertThat("Unexpected modified by history.", historicalStatus.modifiedBy(), is(modifiedBy));
+  }
+
+  @Test
+  void shouldSetAssignedAdminIfCurrentIsMissing() {
+    form.setStatus(Status.builder().build());
+    form.setAssignedAdmin(Person.builder()
+            .name("Ad Min").email("ad.min@example.com").role("ADMIN").build(),
+        Person.builder().name("Mo Defy").email("mo.defy@example.com").role("ADMIN").build()
+    );
+
+    Person assignedAdmin = form.getStatus().current().assignedAdmin();
+    assertThat("Unexpected assigned admin name.", assignedAdmin.name(), is("Ad Min"));
+    assertThat("Unexpected assigned admin email.", assignedAdmin.email(), is("ad.min@example.com"));
+    assertThat("Unexpected assigned admin role.", assignedAdmin.role(), is("ADMIN"));
+
+    Person modifiedBy = form.getStatus().current().modifiedBy();
+    assertThat("Unexpected modified by name.", modifiedBy.name(), is("Mo Defy"));
+    assertThat("Unexpected modified by email.", modifiedBy.email(), is("mo.defy@example.com"));
+    assertThat("Unexpected modified by role.", modifiedBy.role(), is("ADMIN"));
+
+    List<StatusInfo> history = form.getStatus().history();
+    assertThat("Unexpected history count.", history, hasSize(1));
+
+    StatusInfo historicalStatus = history.get(0);
+    assertThat("Unexpected assigned admin history.", historicalStatus.assignedAdmin(),
+        is(assignedAdmin));
+    assertThat("Unexpected modified by history.", historicalStatus.modifiedBy(), is(modifiedBy));
+  }
+
+  @Test
+  void shouldOverwriteExistingAssignedAdmin() {
+    form.setAssignedAdmin(Person.builder().build(), null);
+    form.setAssignedAdmin(Person.builder()
+            .name("Ad Min").email("ad.min@example.com").role("ADMIN").build(),
+        Person.builder().name("Mo Defy").email("mo.defy@example.com").role("ADMIN").build()
+    );
+
+    Person assignedAdmin = form.getStatus().current().assignedAdmin();
+    assertThat("Unexpected assigned admin name.", assignedAdmin.name(), is("Ad Min"));
+    assertThat("Unexpected assigned admin email.", assignedAdmin.email(), is("ad.min@example.com"));
+    assertThat("Unexpected assigned admin role.", assignedAdmin.role(), is("ADMIN"));
+
+    Person modifiedBy = form.getStatus().current().modifiedBy();
+    assertThat("Unexpected modified by name.", modifiedBy.name(), is("Mo Defy"));
+    assertThat("Unexpected modified by email.", modifiedBy.email(), is("mo.defy@example.com"));
+    assertThat("Unexpected modified by role.", modifiedBy.role(), is("ADMIN"));
+
+    List<StatusInfo> history = form.getStatus().history();
+    assertThat("Unexpected history count.", history, hasSize(2));
+
+    StatusInfo historicalStatus1 = history.get(0);
+    assertThat("Unexpected assigned admin history.", historicalStatus1.assignedAdmin(), is(
+        Person.builder().build()));
+    assertThat("Unexpected modified by history.", historicalStatus1.modifiedBy(), nullValue());
+
+    StatusInfo historicalStatus2 = history.get(1);
+    assertThat("Unexpected assigned admin history.", historicalStatus2.assignedAdmin(),
+        is(assignedAdmin));
+    assertThat("Unexpected modified by history.", historicalStatus2.modifiedBy(), is(modifiedBy));
+  }
+
+  @Test
+  void shouldHandleNullAssignedAdmin() {
+    form.setAssignedAdmin(null, null);
+
+    assertThat("Unexpected assigned admin.", form.getStatus().current().assignedAdmin(),
+        nullValue());
+  }
+
+  @Test
+  void shouldAddAssignedAdminToHistory() {
+    form.setAssignedAdmin(Person.builder().name("First Admin").build(), null);
+    form.setAssignedAdmin(Person.builder().name("Second Admin").build(), null);
+
+    assertThat("Unexpected assigned admin history items.",
+        form.getStatus().history().stream()
+            .map(StatusInfo::assignedAdmin)
+            .map(Person::name)
+            .toList(),
+        is(List.of("First Admin", "Second Admin")));
+  }
+
+  @Test
+  void shouldRetainLifecycleStateWhenSettingAssignedAdmin() {
+    StatusInfo submittedStatus = StatusInfo.builder()
+        .state(SUBMITTED)
+        .detail(StatusDetail.builder()
+            .reason("test reason")
+            .message("test message")
+            .build())
+        .revision(2)
+        .build();
+
+    form.setStatus(Status.builder()
+        .current(submittedStatus)
+        .history(List.of(submittedStatus))
+        .build());
+
+    form.setAssignedAdmin(
+        Person.builder().name("Ad Min").email("ad.min@example.com").role("ADMIN").build(),
+        Person.builder().name("Mo Defy").email("mo.defy@example.com").role("ADMIN").build()
+    );
+
+    assertThat("Unexpected lifecycle state.", form.getLifecycleState(), is(SUBMITTED));
+    assertThat("Unexpected revision.", form.getStatus().current().revision(), is(2));
+    assertThat("Unexpected status detail reason.", form.getStatus().current().detail().reason(),
+        is("test reason"));
+    assertThat("Unexpected status detail message.", form.getStatus().current().detail().message(),
+        is("test message"));
   }
 
   @ParameterizedTest

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -328,8 +328,8 @@ class LtftServiceTest {
   @ParameterizedTest
   @CsvSource(delimiter = '|', textBlock = """
       formRef | formRef
-      assignedAdmin.name | content.assignedAdmin.name
-      assignedAdmin.email | content.assignedAdmin.email
+      assignedAdmin.name | status.current.assignedAdmin.name
+      assignedAdmin.email | status.current.assignedAdmin.email
       personalDetails.forenames | content.personalDetails.forenames
       personalDetails.gdcNumber | content.personalDetails.gdcNumber
       personalDetails.gmcNumber | content.personalDetails.gmcNumber
@@ -354,8 +354,8 @@ class LtftServiceTest {
   @ParameterizedTest
   @CsvSource(delimiter = '|', textBlock = """
       formRef | formRef
-      assignedAdmin.name | content.assignedAdmin.name
-      assignedAdmin.email | content.assignedAdmin.email
+      assignedAdmin.name | status.current.assignedAdmin.name
+      assignedAdmin.email | status.current.assignedAdmin.email
       personalDetails.forenames | content.personalDetails.forenames
       personalDetails.gdcNumber | content.personalDetails.gdcNumber
       personalDetails.gmcNumber | content.personalDetails.gmcNumber
@@ -544,8 +544,8 @@ class LtftServiceTest {
   @ParameterizedTest
   @CsvSource(delimiter = '|', textBlock = """
       formRef | formRef
-      assignedAdmin.name | content.assignedAdmin.name
-      assignedAdmin.email | content.assignedAdmin.email
+      assignedAdmin.name | status.current.assignedAdmin.name
+      assignedAdmin.email | status.current.assignedAdmin.email
       personalDetails.forenames | content.personalDetails.forenames
       personalDetails.gdcNumber | content.personalDetails.gdcNumber
       personalDetails.gmcNumber | content.personalDetails.gmcNumber
@@ -573,8 +573,8 @@ class LtftServiceTest {
   @ParameterizedTest
   @CsvSource(delimiter = '|', textBlock = """
       formRef | formRef
-      assignedAdmin.name | content.assignedAdmin.name
-      assignedAdmin.email | content.assignedAdmin.email
+      assignedAdmin.name | status.current.assignedAdmin.name
+      assignedAdmin.email | status.current.assignedAdmin.email
       personalDetails.forenames | content.personalDetails.forenames
       personalDetails.gdcNumber | content.personalDetails.gdcNumber
       personalDetails.gmcNumber | content.personalDetails.gmcNumber
@@ -1219,11 +1219,14 @@ class LtftServiceTest {
   void shouldGetAdminLtftAssignedAdminDetailWhenFormFound() {
     LtftForm entity = new LtftForm();
     entity.setId(ID);
-    entity.setAssignedAdmin(Person.builder()
-        .name(ADMIN_NAME)
-        .email(ADMIN_EMAIL)
-        .role("ADMIN")
-        .build());
+    entity.setAssignedAdmin(
+        Person.builder()
+            .name(ADMIN_NAME)
+            .email(ADMIN_EMAIL)
+            .role("ADMIN")
+            .build(),
+        Person.builder().build()
+    );
 
     when(repository
         .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
@@ -1234,7 +1237,7 @@ class LtftServiceTest {
     assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
 
     LtftFormDto dto = optionalDto.get();
-    PersonDto assignedAdmin = dto.assignedAdmin();
+    PersonDto assignedAdmin = dto.status().current().assignedAdmin();
     assertThat("Unexpected admin name.", assignedAdmin.name(), is(ADMIN_NAME));
     assertThat("Unexpected admin email.", assignedAdmin.email(), is(ADMIN_EMAIL));
     assertThat("Unexpected admin role.", assignedAdmin.role(), is("ADMIN"));
@@ -1244,7 +1247,7 @@ class LtftServiceTest {
   void shouldGetAdminLtftAssignedAdminDetailWithDefaultValuesWhenFormFoundWithNullValues() {
     LtftForm entity = new LtftForm();
     entity.setId(ID);
-    entity.setAssignedAdmin(Person.builder().build());
+    entity.setAssignedAdmin(Person.builder().build(), null);
 
     when(repository
         .findByIdAndStatus_Current_StateNotInAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
@@ -1255,7 +1258,7 @@ class LtftServiceTest {
     assertThat("Unexpected dto presence.", optionalDto.isPresent(), is(true));
 
     LtftFormDto dto = optionalDto.get();
-    PersonDto assignedAdmin = dto.assignedAdmin();
+    PersonDto assignedAdmin = dto.status().current().assignedAdmin();
     assertThat("Unexpected admin name.", assignedAdmin.name(), nullValue());
     assertThat("Unexpected admin email.", assignedAdmin.email(), nullValue());
     assertThat("Unexpected admin role.", assignedAdmin.role(), nullValue());
@@ -1393,7 +1396,7 @@ class LtftServiceTest {
   @Test
   void shouldReturnAssignedFormWhenFormFoundAndNoPreviousAdmin() {
     LtftForm form = new LtftForm();
-    form.setAssignedAdmin(null);
+    form.setAssignedAdmin(null, null);
     when(repository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
         ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.of(form));
     when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -1407,7 +1410,7 @@ class LtftServiceTest {
 
     assertThat("Unexpected form presence.", optionalForm.isPresent(), is(true));
 
-    PersonDto assignedAdmin = optionalForm.get().assignedAdmin();
+    PersonDto assignedAdmin = optionalForm.get().status().current().assignedAdmin();
     assertThat("Unexpected admin name.", assignedAdmin.name(), is("Ad Min"));
     assertThat("Unexpected admin email.", assignedAdmin.email(), is("ad.min@example.com"));
     assertThat("Unexpected admin role.", assignedAdmin.role(), is("ADMIN"));
@@ -1416,11 +1419,14 @@ class LtftServiceTest {
   @Test
   void shouldReturnAssignedFormWhenFormFoundAndHasPreviousAdmin() {
     LtftForm form = new LtftForm();
-    form.setAssignedAdmin(Person.builder()
-        .name("current admin")
-        .email("current.admin@example.com")
-        .role("current role")
-        .build());
+    form.setAssignedAdmin(
+        Person.builder()
+            .name(ADMIN_NAME)
+            .email(ADMIN_EMAIL)
+            .role("ADMIN")
+            .build(),
+        null
+    );
     when(repository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
         ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.of(form));
     when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -1435,7 +1441,7 @@ class LtftServiceTest {
 
     assertThat("Unexpected form presence.", optionalForm.isPresent(), is(true));
 
-    PersonDto assignedAdmin = optionalForm.get().assignedAdmin();
+    PersonDto assignedAdmin = optionalForm.get().status().current().assignedAdmin();
     assertThat("Unexpected admin name.", assignedAdmin.name(), is("new admin"));
     assertThat("Unexpected admin email.", assignedAdmin.email(), is("new.admin@example.com"));
     assertThat("Unexpected admin role.", assignedAdmin.role(), is("ADMIN"));
@@ -2348,10 +2354,14 @@ class LtftServiceTest {
     LtftFormDto dtoToSave = LtftFormDto.builder()
         .id(ID)
         .traineeTisId(TRAINEE_ID)
-        .assignedAdmin(PersonDto.builder()
-            .name("new admin")
-            .email("new.admin@example.com")
-            .role("NEW_ADMIN")
+        .status(StatusDto.builder()
+            .current(StatusInfoDto.builder()
+                .assignedAdmin(PersonDto.builder()
+                    .name("new admin")
+                    .email("new.admin@example.com")
+                    .role("NEW_ADMIN")
+                    .build())
+                .build())
             .build())
         .build();
 
@@ -2368,7 +2378,8 @@ class LtftServiceTest {
     assertThat("Unexpected form returned.", formDtoOptional.isPresent(), is(true));
 
     LtftFormDto formDto = formDtoOptional.get();
-    assertThat("Unexpected assigned admin.", formDto.assignedAdmin(), nullValue());
+    assertThat("Unexpected assigned admin.", formDto.status().current().assignedAdmin(),
+        nullValue());
   }
 
   @ParameterizedTest
@@ -2378,10 +2389,14 @@ class LtftServiceTest {
     LtftFormDto dtoToSave = LtftFormDto.builder()
         .id(ID)
         .traineeTisId(TRAINEE_ID)
-        .assignedAdmin(PersonDto.builder()
-            .name("new admin")
-            .email("new.admin@example.com")
-            .role("NEW_ADMIN")
+        .status(StatusDto.builder()
+            .current(StatusInfoDto.builder()
+                .assignedAdmin(PersonDto.builder()
+                    .name("new admin")
+                    .email("new.admin@example.com")
+                    .role("NEW_ADMIN")
+                    .build())
+                .build())
             .build())
         .build();
 
@@ -2398,7 +2413,8 @@ class LtftServiceTest {
     assertThat("Unexpected form returned.", formDtoOptional.isPresent(), is(true));
 
     LtftFormDto formDto = formDtoOptional.get();
-    assertThat("Unexpected assigned admin.", formDto.assignedAdmin(), nullValue());
+    assertThat("Unexpected assigned admin.", formDto.status().current().assignedAdmin(),
+        nullValue());
   }
 
   @ParameterizedTest
@@ -2408,10 +2424,14 @@ class LtftServiceTest {
     LtftFormDto dtoToSave = LtftFormDto.builder()
         .id(ID)
         .traineeTisId(TRAINEE_ID)
-        .assignedAdmin(PersonDto.builder()
-            .name("new admin")
-            .email("new.admin@example.com")
-            .role("NEW_ADMIN")
+        .status(StatusDto.builder()
+            .current(StatusInfoDto.builder()
+                .assignedAdmin(PersonDto.builder()
+                    .name("new admin")
+                    .email("new.admin@example.com")
+                    .role("NEW_ADMIN")
+                    .build())
+                .build())
             .build())
         .build();
 
@@ -2419,11 +2439,14 @@ class LtftServiceTest {
     existingForm.setId(ID);
     existingForm.setTraineeTisId(TRAINEE_ID);
     existingForm.setLifecycleState(state);
-    existingForm.setAssignedAdmin(Person.builder()
-        .name("Ad Min")
-        .email("ad.min@example.com")
-        .role("ADMIN")
-        .build());
+    existingForm.setAssignedAdmin(
+        Person.builder()
+            .name("Ad Min")
+            .email("ad.min@example.com")
+            .role("ADMIN")
+            .build(),
+        null
+    );
 
     when(repository.findByTraineeTisIdAndId(TRAINEE_ID, ID)).thenReturn(Optional.of(existingForm));
     when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -2432,7 +2455,7 @@ class LtftServiceTest {
     assertThat("Unexpected form returned.", formDtoOptional.isPresent(), is(true));
 
     LtftFormDto formDto = formDtoOptional.get();
-    PersonDto assignedAdmin = formDto.assignedAdmin();
+    PersonDto assignedAdmin = formDto.status().current().assignedAdmin();
 
     assertThat("Unexpected assigned admin name.", assignedAdmin.name(), is("Ad Min"));
     assertThat("Unexpected assigned admin email.", assignedAdmin.email(), is("ad.min@example.com"));


### PR DESCRIPTION
Refactor the AbstractAuditedForm to move the assignedAdmin property in to the StatusInfo. This allows it to be record both against the current status and in the history.

When updating the state of a form the previous assigned admin should be carried forward, similarly when assigning an admin the previous state should be carried forward.

TIS21-7082
TIS21-7086