### PR TITLE
feat(ltft): publish LTFT on assignment update

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -41,6 +41,10 @@
           "valueFrom": "/tis/trainee/${environment}/queue-url/form-delete-event"
         },
         {
+          "name": "LTFT_ASSIGNMENT_UPDATE_TOPIC",
+          "valueFrom": "/tis/trainee/notifications/${environment}/topic-arn/ltft/assignment-update"
+        },
+        {
           "name": "LTFT_STATUS_UPDATE_TOPIC",
           "valueFrom": "/tis/trainee/notifications/${environment}/topic-arn/ltft/status-update"
         },

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.42.0"
+version = "0.42.1"
 
 configurations {
   compileOnly {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.42.1"
+version = "0.43.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceIntegrationTest.java
@@ -21,14 +21,12 @@
 
 package uk.nhs.hee.tis.trainee.forms.service;
 
-import static java.util.Collections.sort;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 import io.awspring.cloud.sns.core.SnsTemplate;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -156,7 +154,8 @@ class LtftServiceIntegrationTest {
     assertThat("Unexpected form ref.", resubmitted.formRef(), is("ltft_" + TRAINEE_ID + "_001"));
 
     Query query = new Query().with(Sort.by(Sort.Direction.ASC, "revision"));
-    List<LtftSubmissionHistory> savedSubmissionHistories = template.find(query, LtftSubmissionHistory.class);
+    List<LtftSubmissionHistory> savedSubmissionHistories = template.find(query,
+        LtftSubmissionHistory.class);
 
     assertThat("Unexpected number of submission histories.",
         savedSubmissionHistories.size(), is(2));

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -83,6 +83,7 @@ public class LtftService {
   private final LtftMapper mapper;
 
   private final SnsTemplate snsTemplate;
+  private final String ltftAssignmentUpdateTopic;
   private final String ltftStatusUpdateTopic;
 
   private final LtftSubmissionHistoryService ltftSubmissionHistoryService;
@@ -96,12 +97,14 @@ public class LtftService {
    * @param mongoTemplate                The Mongo template.
    * @param mapper                       The LTFT mapper.
    * @param snsTemplate                  The SNS template.
+   * @param ltftAssignmentUpdateTopic    The SNS topic for LTFT assignment updates.
    * @param ltftStatusUpdateTopic        The SNS topic for LTFT status updates.
    * @param ltftSubmissionHistoryService The service for LTFT submission history.
    */
   public LtftService(AdminIdentity adminIdentity, TraineeIdentity traineeIdentity,
       LtftFormRepository ltftFormRepository, MongoTemplate mongoTemplate, LtftMapper mapper,
       SnsTemplate snsTemplate,
+      @Value("${application.aws.sns.ltft-assignment-updated}") String ltftAssignmentUpdateTopic,
       @Value("${application.aws.sns.ltft-status-updated}") String ltftStatusUpdateTopic,
       LtftSubmissionHistoryService ltftSubmissionHistoryService) {
     this.adminIdentity = adminIdentity;
@@ -110,6 +113,7 @@ public class LtftService {
     this.mongoTemplate = mongoTemplate;
     this.mapper = mapper;
     this.snsTemplate = snsTemplate;
+    this.ltftAssignmentUpdateTopic = ltftAssignmentUpdateTopic;
     this.ltftStatusUpdateTopic = ltftStatusUpdateTopic;
     this.ltftSubmissionHistoryService = ltftSubmissionHistoryService;
   }
@@ -403,6 +407,9 @@ public class LtftService {
 
       ltftForm.setAssignedAdmin(assignedAdmin, modifiedBy);
       LtftForm updatedForm = ltftFormRepository.save(ltftForm);
+
+      publishUpdateNotification(updatedForm, ltftAssignmentUpdateTopic);
+
       return Optional.of(mapper.toDto(updatedForm));
     } else {
       log.warn("Could not assign admin to form {} since no form exists with this ID for DBCs [{}]",
@@ -506,7 +513,7 @@ public class LtftService {
       ltftSubmissionHistoryService.takeSnapshot(savedForm);
     }
 
-    publishStatusUpdateNotification(savedForm);
+    publishUpdateNotification(savedForm, ltftStatusUpdateTopic);
 
     return savedForm;
   }
@@ -589,13 +596,13 @@ public class LtftService {
    *
    * @param form The updated LTFT form
    */
-  private void publishStatusUpdateNotification(LtftForm form) {
-    log.info("Published status update notification for LTFT form {}", form.getId());
+  private void publishUpdateNotification(LtftForm form, String topic) {
+    log.info("Published update notification for LTFT form {}", form.getId());
     String groupId = form.getId() == null ? UUID.randomUUID().toString() : form.getId().toString();
     SnsNotification<LtftForm> notification = SnsNotification.builder(form)
         .groupId(groupId)
         .build();
 
-    snsTemplate.sendNotification(ltftStatusUpdateTopic, notification);
+    snsTemplate.sendNotification(topic, notification);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -387,6 +387,14 @@ public class LtftService {
       LtftForm ltftForm = form.get();
 
       Person assignedAdmin = mapper.toEntity(admin).withRole("ADMIN");
+
+      if (ltftForm.getStatus() != null && ltftForm.getStatus().current() != null
+          && Objects.equals(ltftForm.getStatus().current().assignedAdmin(), assignedAdmin)) {
+        log.info("Skipping assigning admin {} to LTFT form {}, as they are already assigned.",
+            admin.email(), formId);
+        return Optional.of(mapper.toDto(ltftForm));
+      }
+
       Person modifiedBy = Person.builder()
           .name(adminIdentity.getName())
           .email(adminIdentity.getEmail())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,7 @@ application:
   aws:
     sns:
       pdf-generated: ${PDF_GENERATED_TOPIC:}
+      ltft-assignment-updated: ${LTFT_ASSIGNMENT_UPDATE_TOPIC:}
       ltft-status-updated: ${LTFT_STATUS_UPDATE_TOPIC:}
     sqs:
       coj-received: ${COJ_RECEIVED_QUEUE:}


### PR DESCRIPTION
# feat(ltft): publish LTFT on assignment update

When a new admin is assigned to an LTFT the history is updated and the
LTFT should be published via SNS for other services to react to.
Specifically the NDW export should trigger to update the assignment
details in NDW reports.

TIS21-7082
TIS21-7086

---

# fix(ltft): stop duplicating assignment history

When an admin is assigned multiple times it causes an audit history
entry each time, even though nothing has changed.
Update AbstractAuditedForm to check if the new assignment matches the
existing assignment and skip the update if it does.

The whole Person object should be checked to account for any of name,
email or role changing and needing to be updated. But if all entries
match then no status/history update should be done.

This check is already covered for status history due to restricted
transitions stopping the same state from being set multiple times.

TIS21-7082