### PR TITLE
feat(ltft): add managing deanery to LTFT form

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.43.1"
+version = "0.44.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
@@ -138,6 +138,7 @@ public record LtftFormDto(
       UUID id,
       String name,
       String designatedBodyCode,
+      String managingDeanery,
       LocalDate startDate,
       LocalDate endDate,
       Double wte) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/LtftContent.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/LtftContent.java
@@ -100,6 +100,7 @@ public record LtftContent(
       String name,
       @Indexed(name = "dbc")
       String designatedBodyCode,
+      String managingDeanery,
       LocalDate startDate,
       LocalDate endDate,
       Double wte) {

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -914,6 +914,7 @@ class LtftServiceTest {
             .id(pmId)
             .name("Test PM")
             .designatedBodyCode("1-1DBC")
+            .managingDeanery("Test Deanery")
             .startDate(LocalDate.MIN)
             .endDate(LocalDate.MAX)
             .wte(0.75)
@@ -934,6 +935,7 @@ class LtftServiceTest {
     assertThat("Unexpected PM ID.", programmeMembership.id(), is(pmId));
     assertThat("Unexpected PM name.", programmeMembership.name(), is("Test PM"));
     assertThat("Unexpected PM DBC.", programmeMembership.designatedBodyCode(), is("1-1DBC"));
+    assertThat("Unexpected PM deanery.", programmeMembership.managingDeanery(), is("Test Deanery"));
     assertThat("Unexpected PM start date.", programmeMembership.startDate(), is(LocalDate.MIN));
     assertThat("Unexpected PM end date.", programmeMembership.endDate(), is(LocalDate.MAX));
     assertThat("Unexpected PM wte.", programmeMembership.wte(), is(0.75));
@@ -962,6 +964,7 @@ class LtftServiceTest {
     assertThat("Unexpected PM ID.", programmeMembership.id(), nullValue());
     assertThat("Unexpected PM name.", programmeMembership.name(), nullValue());
     assertThat("Unexpected PM DBC.", programmeMembership.designatedBodyCode(), nullValue());
+    assertThat("Unexpected PM deanery.", programmeMembership.managingDeanery(), nullValue());
     assertThat("Unexpected PM start date.", programmeMembership.startDate(), nullValue());
     assertThat("Unexpected PM end date.", programmeMembership.endDate(), nullValue());
     assertThat("Unexpected PM wte.", programmeMembership.wte(), nullValue());
@@ -2143,6 +2146,7 @@ class LtftServiceTest {
             .id(newId)
             .name("new programme")
             .designatedBodyCode("new DBC")
+            .managingDeanery("new deanery")
             .startDate(newStartDate)
             .endDate(newEndDate)
             .wte(0.5)
@@ -2158,6 +2162,7 @@ class LtftServiceTest {
             .id(UUID.randomUUID())
             .name("existing programme")
             .designatedBodyCode("existing DBC")
+            .managingDeanery("existing deanery")
             .startDate(LocalDate.MIN)
             .endDate(LocalDate.MAX)
             .wte(1.0)
@@ -2176,6 +2181,7 @@ class LtftServiceTest {
     assertThat("Unexpected ID.", programmeMembership.id(), is(newId));
     assertThat("Unexpected name.", programmeMembership.name(), is("new programme"));
     assertThat("Unexpected DBC.", programmeMembership.designatedBodyCode(), is("new DBC"));
+    assertThat("Unexpected deanery.", programmeMembership.managingDeanery(), is("new deanery"));
     assertThat("Unexpected start date.", programmeMembership.startDate(), is(newStartDate));
     assertThat("Unexpected end date.", programmeMembership.endDate(), is(newEndDate));
     assertThat("Unexpected WTE.", programmeMembership.wte(), is(0.5));


### PR DESCRIPTION
The managing deanery/local office name is needed by the notifications service to determine which links and contact addresses to use.

TIS21-6596
TIS21-6594