### PR TITLE
fix: LTFT exception handling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.45.0"
+version = "0.45.1"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
@@ -61,7 +61,6 @@ import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -1312,7 +1311,6 @@ class AdminLtftResourceIntegrationTest {
             + System.lineSeparator() + "(Test Data)" + System.lineSeparator()));
   }
 
-  @Disabled("Suddenly getting unhandled error response in workflows, unable to reproduce/resolve")
   @ParameterizedTest
   @EnumSource(value = LifecycleState.class, mode = EXCLUDE, names = "SUBMITTED")
   void shouldNotApproveLtftWhenStateTransitionNotAllowed(LifecycleState currentState)
@@ -1361,7 +1359,6 @@ class AdminLtftResourceIntegrationTest {
         .andExpect(jsonPath("$.status.current.timestamp", notNullValue()));
   }
 
-  @Disabled("Suddenly getting unhandled error response in workflows, unable to reproduce/resolve")
   @ParameterizedTest
   @EnumSource(value = LifecycleState.class, mode = EXCLUDE, names = "SUBMITTED")
   void shouldNotUnsubmitLtftWhenStateTransitionNotAllowed(LifecycleState currentState)
@@ -1391,7 +1388,6 @@ class AdminLtftResourceIntegrationTest {
             is("can not be transitioned to UNSUBMITTED")));
   }
 
-  @Disabled("Suddenly getting unhandled error response in workflows, unable to reproduce/resolve")
   @ParameterizedTest
   @EnumSource(value = LifecycleState.class, mode = INCLUDE, names = "SUBMITTED")
   void shouldNotUnsubmitLtftWhenStateTransitionAllowedButNoReasonGiven(LifecycleState currentState)

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/LtftResourceIntegrationTest.java
@@ -50,7 +50,6 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.number.IsCloseTo;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -253,7 +252,6 @@ class LtftResourceIntegrationTest {
         .andExpect(jsonPath("$.discussions.other[0].name").value("other person"));
   }
 
-  @Disabled("Suddenly getting unhandled error response in workflows, unable to reproduce/resolve")
   @Test
   void shouldBeBadRequestWhenCreatingLtftFormWithId() throws Exception {
     LtftFormDto formToSave = LtftFormDto.builder()
@@ -460,7 +458,6 @@ class LtftResourceIntegrationTest {
             TimestampCloseTo.closeTo(Instant.now().getEpochSecond(), 1)));
   }
 
-  @Disabled("Suddenly getting unhandled error response in workflows, unable to reproduce/resolve")
   @Test
   void shouldBeBadRequestWhenUpdatingLtftFormWithoutId() throws Exception {
     LtftFormDto formToUpdate = LtftFormDto.builder()

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ExceptionTranslator.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/exception/ExceptionTranslator.java
@@ -30,11 +30,16 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import uk.nhs.hee.tis.trainee.forms.api.ConditionsOfJoiningResource;
+import uk.nhs.hee.tis.trainee.forms.api.FormRPartAResource;
+import uk.nhs.hee.tis.trainee.forms.api.FormRPartBResource;
 
 /**
  * Controller advice to translate the server side exceptions to client-friendly json structures.
  */
-@ControllerAdvice
+// TODO: migrate all controllers to use Problem Detail (application/problem_json) responses.
+@ControllerAdvice(assignableTypes = {ConditionsOfJoiningResource.class, FormRPartAResource.class,
+    FormRPartBResource.class})
 public class ExceptionTranslator {
 
   /**


### PR DESCRIPTION
The integration tests for LTFT validation started failing due to changes on the build server. While the exact reason for the changed behaviour is unknown, it has highlighted a conflict between
`RestResponeEntityExceptionHandler` and `ExceptionTranslator`.

Update the `ExceptionTranslator` to specify which rest controllers it should be responsible for. The LTFT controllers will continue to use the Problem Detail response with `application/problem+json` content type.

NO-TICKET