### PR TITLE
fix(ltft): missing applications when paged

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.45.1"
+version = "0.45.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -546,6 +546,8 @@ public class LtftService {
     if (pageable.isUnpaged()) {
       query = new Query().with(sort);
     } else {
+      // Add ID sort to ensure consistent paged ordering when the sort field has duplicated values.
+      sort = sort.and(Sort.by("id"));
       pageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
       query = new Query().with(pageable);
     }


### PR DESCRIPTION
It is possible when sorting on a field with duplicate values, such as start date, for an application to be returned on multiple pages. Which causes another application to never be returned.

For example if there are 10 LTFT per page and the applications at positions 10 and 11 have the same start date, it can be random which one appears in which position in each result set. Sometimes creating "duplicates" and hiding the remaining application.

TIS21-7257