### PR TITLE
feat: limit admin/ltft endpoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.46.0"
+version = "0.47.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/TestJwtUtil.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/TestJwtUtil.java
@@ -95,7 +95,8 @@ public class TestJwtUtil {
           "email": "ad.min@example.com",
           "given_name": "Ad",
           "family_name": "Min",
-          "cognito:groups": [%s]
+          "cognito:groups": [%s],
+          "cognito:roles": ["NHSE LTFT Admin"]
         }
         """.formatted(groupString);
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/interceptor/AdminIdentityInterceptor.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/interceptor/AdminIdentityInterceptor.java
@@ -82,7 +82,7 @@ public class AdminIdentityInterceptor implements HandlerInterceptor {
 
     // LTFT endpoints require the appropriate role to access.
     if (request.getRequestURI().matches("^/api/admin/ltft(/.+)?$")
-       && (adminRoles == null || !adminRoles.contains("NHSE LTFT Admin"))) {
+        && (adminRoles == null || !adminRoles.contains("NHSE LTFT Admin"))) {
       response.setStatus(HttpStatus.FORBIDDEN.value());
       return false;
     }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/interceptor/AdminIdentityInterceptor.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/interceptor/AdminIdentityInterceptor.java
@@ -42,6 +42,7 @@ public class AdminIdentityInterceptor implements HandlerInterceptor {
   private static final String GIVEN_NAME_ATTRIBUTE = "given_name";
   private static final String FAMILY_NAME_ATTRIBUTE = "family_name";
   private static final String GROUPS_ATTRIBUTE = "cognito:groups";
+  private static final String ROLES_ATTRIBUTE = "cognito:roles";
 
   private final AdminIdentity adminIdentity;
 
@@ -52,6 +53,8 @@ public class AdminIdentityInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
       Object handler) {
+    Set<String> adminRoles = null;
+
     String authToken = request.getHeader(HttpHeaders.AUTHORIZATION);
 
     if (authToken != null) {
@@ -60,6 +63,7 @@ public class AdminIdentityInterceptor implements HandlerInterceptor {
         adminIdentity.setEmail(email);
         Set<String> adminGroups = AuthTokenUtil.getAttributes(authToken, GROUPS_ATTRIBUTE);
         adminIdentity.setGroups(adminGroups);
+        adminRoles = AuthTokenUtil.getAttributes(authToken, ROLES_ATTRIBUTE);
 
         String givenName = AuthTokenUtil.getAttribute(authToken, GIVEN_NAME_ATTRIBUTE);
         String familyName = AuthTokenUtil.getAttribute(authToken, FAMILY_NAME_ATTRIBUTE);
@@ -75,6 +79,14 @@ public class AdminIdentityInterceptor implements HandlerInterceptor {
       response.setStatus(HttpStatus.FORBIDDEN.value());
       return false;
     }
+
+    // LTFT endpoints require the appropriate role to access.
+    if (request.getRequestURI().matches("^/api/admin/ltft(/.+)?$")
+       && (adminRoles == null || !adminRoles.contains("NHSE LTFT Admin"))) {
+      response.setStatus(HttpStatus.FORBIDDEN.value());
+      return false;
+    }
+
     return true;
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/interceptor/AdminIdentityInterceptorTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/interceptor/AdminIdentityInterceptorTest.java
@@ -29,6 +29,8 @@ import static org.hamcrest.Matchers.hasSize;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -43,6 +45,8 @@ class AdminIdentityInterceptorTest {
   private static final String FULL_NAME = "Ad Min";
   private static final String GROUP_1 = "123456";
   private static final String GROUP_2 = "ABCDEF";
+  private static final String ROLE_1 = "TSS Support Admin";
+  private static final String ROLE_2 = "NHSE LTFT Admin";
 
   private AdminIdentityInterceptor interceptor;
   private AdminIdentity adminIdentity;
@@ -201,6 +205,53 @@ class AdminIdentityInterceptorTest {
     assertThat("Unexpected admin group count.", adminIdentity.getGroups(), hasSize(0));
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"/api/admin/ltft", "/api/admin/ltft/abc"})
+  void shouldReturnFalseAndPopulateIdentityWhenAllFieldsAndNoRolesInAuthToken(String uri) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI(uri);
+    String token = TestJwtUtil.generateToken("""
+        {
+          "email": "%s",
+          "given_name": "%s",
+          "family_name": "%s",
+          "cognito:groups": [
+            "%s",
+            "%s"
+          ]
+        }
+        """.formatted(EMAIL, GIVEN_NAME, FAMILY_NAME, GROUP_1, GROUP_2));
+    request.addHeader(HttpHeaders.AUTHORIZATION, token);
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat("Unexpected result.", result, is(false));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/api/admin/ltft", "/api/admin/ltft/abc"})
+  void shouldReturnFalseAndPopulateIdentityWhenAllFieldsAndEmptyRolesInAuthToken(String uri) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI(uri);
+    String token = TestJwtUtil.generateToken("""
+        {
+          "email": "%s",
+          "given_name": "%s",
+          "family_name": "%s",
+          "cognito:groups": [
+            "%s",
+            "%s"
+          ],
+          "cognito:roles": []
+        }
+        """.formatted(EMAIL, GIVEN_NAME, FAMILY_NAME, GROUP_1, GROUP_2));
+    request.addHeader(HttpHeaders.AUTHORIZATION, token);
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat("Unexpected result.", result, is(false));
+  }
+
   @Test
   void shouldReturnTrueAndPopulateIdentityWhenAllFieldsAndGroupsInAuthToken() {
     MockHttpServletRequest request = new MockHttpServletRequest();
@@ -215,6 +266,37 @@ class AdminIdentityInterceptorTest {
           ]
         }
         """.formatted(EMAIL, GIVEN_NAME, FAMILY_NAME, GROUP_1, GROUP_2));
+    request.addHeader(HttpHeaders.AUTHORIZATION, token);
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat("Unexpected result.", result, is(true));
+    assertThat("Unexpected admin email.", adminIdentity.getEmail(), is(EMAIL));
+    assertThat("Unexpected admin name.", adminIdentity.getName(), is(FULL_NAME));
+    assertThat("Unexpected admin group count.", adminIdentity.getGroups(), hasSize(2));
+    assertThat("Unexpected admin groups.", adminIdentity.getGroups(), hasItems(GROUP_1, GROUP_2));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/api/admin/ltft", "/api/admin/ltft/abc"})
+  void shouldReturnTrueAndPopulateIdentityWhenAllFieldsAndLtftRoleInAuthToken(String uri) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI(uri);
+    String token = TestJwtUtil.generateToken("""
+        {
+          "email": "%s",
+          "given_name": "%s",
+          "family_name": "%s",
+          "cognito:groups": [
+            "%s",
+            "%s"
+          ],
+          "cognito:roles": [
+            "%s",
+            "%s"
+          ]
+        }
+        """.formatted(EMAIL, GIVEN_NAME, FAMILY_NAME, GROUP_1, GROUP_2, ROLE_1, ROLE_2));
     request.addHeader(HttpHeaders.AUTHORIZATION, token);
 
     boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());


### PR DESCRIPTION
Based on cognito role. Same approach as used in tis-trainee-details cct endpoints, fwiw.

TIS21-7304