### PR TITLE
feat(ltft): admin reject endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.51.0"
+version = "0.52.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.forms.api;
 
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.APPROVED;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.REJECTED;
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.UNSUBMITTED;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
@@ -153,6 +154,21 @@ public class AdminLtftResource {
   ResponseEntity<LtftFormDto> approveLtft(@PathVariable UUID id)
       throws MethodArgumentNotValidException {
     Optional<LtftFormDto> form = service.updateStatusAsAdmin(id, APPROVED, null);
+    return ResponseEntity.of(form);
+  }
+
+  /**
+   * Reject the form with the given ID, must be associated with the user's local office.
+   *
+   * @param id The ID of the form to unsubmit.
+   * @return The rejected form.
+   * @throws MethodArgumentNotValidException When the state transition was not valid.
+   */
+  @PutMapping("/{id}/reject")
+  ResponseEntity<LtftFormDto> rejectLtft(@PathVariable UUID id,
+      @RequestBody LftfStatusInfoDetailDto detail)
+      throws MethodArgumentNotValidException {
+    Optional<LtftFormDto> form = service.updateStatusAsAdmin(id, REJECTED, detail);
     return ResponseEntity.of(form);
   }
 


### PR DESCRIPTION
Add an endpoint to allow admins to reject an LTFT application, a reason must be provided.

TIS21-7445
TIS21-7776