### PR TITLE
fix: formR PDF template var

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.52.0"
+version = "0.52.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/PdfService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/PdfService.java
@@ -174,7 +174,7 @@ public class PdfService {
         type, traineeId, formId);
 
     TemplateSpec templateSpec = type.getFormRTemplate();
-    byte[] pdf = generatePdf(templateSpec, Map.of("var", request));
+    byte[] pdf = generatePdf(templateSpec, Map.of("var", request.form()));
 
     S3Resource uploaded = upload(traineeId, FORM_TYPE_FORMR_PARTA, formId, pdf);
 
@@ -205,7 +205,7 @@ public class PdfService {
         type, traineeId, formId);
 
     TemplateSpec templateSpec = type.getFormRTemplate();
-    byte[] pdf = generatePdf(templateSpec, Map.of("var", request));
+    byte[] pdf = generatePdf(templateSpec, Map.of("var", request.form()));
 
     S3Resource uploaded = upload(traineeId, FORM_TYPE_FORMR_PARTB, formId, pdf);
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/PdfServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/PdfServiceTest.java
@@ -436,7 +436,8 @@ class PdfServiceTest {
 
     Set<String> variableNames = context.getVariableNames();
     assertThat("Unexpected variable count.", variableNames.size(), is(2));
-    assertThat("Unexpected event value.", context.getVariable("var"), sameInstance(request));
+    assertThat("Unexpected event value.", context.getVariable("var"),
+        sameInstance(request.form()));
     assertThat("Unexpected timezone value.", context.getVariable("timezone"), is(TIMEZONE.getId()));
   }
 
@@ -555,7 +556,8 @@ class PdfServiceTest {
 
     Set<String> variableNames = context.getVariableNames();
     assertThat("Unexpected variable count.", variableNames.size(), is(2));
-    assertThat("Unexpected event value.", context.getVariable("var"), sameInstance(request));
+    assertThat("Unexpected event value.", context.getVariable("var"),
+        sameInstance(request.form()));
     assertThat("Unexpected timezone value.", context.getVariable("timezone"), is(TIMEZONE.getId()));
   }
 


### PR DESCRIPTION
The template works off the FormRPart[X]Dto, not the FormRPart[X]PdfRequestDto

NO-TICKET