### PR TITLE
Feat: formR PDF when submitted

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResource.java
@@ -106,7 +106,7 @@ public class FormRPartAResource {
 
     validator.validate(dto);
     FormRPartADto result = service.save(dto);
-    publishPdfIfSubmittedForm(dto);
+    publishPdfIfSubmittedForm(result);
 
     return ResponseEntity.created(new URI("/api/formr-parta/" + result.getId())).body(result);
   }
@@ -126,7 +126,6 @@ public class FormRPartAResource {
     log.info("REST request to update FormRPartA : {}", dto);
     if (dto.getId() == null) {
       return createFormRPartA(dto);
-      //TODO: could be submitted so might need to publish PDF here as well
     }
 
     if (!dto.getTraineeTisId().equals(loggedInTraineeIdentity.getTraineeId())) {
@@ -136,7 +135,7 @@ public class FormRPartAResource {
 
     validator.validate(dto);
     FormRPartADto result = service.save(dto);
-    publishPdfIfSubmittedForm(dto);
+    publishPdfIfSubmittedForm(result);
 
     return ResponseEntity.ok().body(result);
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResource.java
@@ -105,7 +105,7 @@ public class FormRPartBResource {
 
     validator.validate(dto);
     FormRPartBDto result = service.save(dto);
-    publishPdfIfSubmittedForm(dto);
+    publishPdfIfSubmittedForm(result);
 
     return ResponseEntity.created(new URI("/api/formr-partb/" + result.getId())).body(result);
   }
@@ -134,7 +134,7 @@ public class FormRPartBResource {
 
     validator.validate(dto);
     FormRPartBDto result = service.save(dto);
-    publishPdfIfSubmittedForm(dto);
+    publishPdfIfSubmittedForm(result);
 
     return ResponseEntity.ok().body(result);
   }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,6 +28,3 @@ spring:
         static: eu-west-2
       s3:
         path-style-access-enabled: true
-  data:
-    mongodb:
-      uri: mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:forms}?authSource=admin

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,3 +28,6 @@ spring:
         static: eu-west-2
       s3:
         path-style-access-enabled: true
+  data:
+    mongodb:
+      uri: mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:forms}?authSource=admin


### PR DESCRIPTION
This enables PDFs for submitted FormRs to be published, in the same way that CoJ PDF's are published.

They will be picked up by SNS (tis-trainee-[env]-pdf-generated.fifo), and a new subscription has been added (tis-trainee-notifications-[env]-formr-pdf-generated.fifo), filtered to only pick up formR form_types. 

A new listener will be added to the notifications service to generate the emails and attach the PDFs, and the existing listener for general saved form Rs that generates the generic email notification will be adjusted to ignore those that are SUBMITTED, to avoid duplication of emails for submitted formRs, but to allow any other form states to still generate these generic emails if the 'alwaysStoreFiles' config is ever set to true in future (cf. https://github.com/Health-Education-England/tis-trainee-forms/blob/9ec182c3ec96d6a88439edcf74ce2cc8a69ab477/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java#L99).

TIS21-6582