### PR TITLE
fix: ignore unknown JSON properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.52.2"
+version = "0.52.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtil.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtil.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.forms.api.util;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -36,6 +37,10 @@ import uk.nhs.hee.tis.trainee.forms.dto.FeaturesDto;
 public class AuthTokenUtil {
 
   private static final ObjectMapper mapper = new ObjectMapper();
+
+  static {
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  }
 
   private AuthTokenUtil() {
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtilTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtilTest.java
@@ -200,4 +200,25 @@ class AuthTokenUtilTest {
     assertThat("Unexpected features ltft programmes.", features.ltftProgrammes(),
         hasItems("LTFT Programme 1", "LTFT Programme 2"));
   }
+
+  @Test
+  void shouldNotFailOnUnknownFeature() {
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString("""
+             {
+                "features": {
+                  "unknown": "feature",
+                  "ltft": true,
+                  "ltftProgrammes": [
+                    "LTFT Programme 1",
+                    "LTFT Programme 2"
+                  ]
+                }
+             }
+            """
+            .getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    assertDoesNotThrow(() -> AuthTokenUtil.getFeatures(token));
+  }
 }


### PR DESCRIPTION
The AuthTokenUtil fails if the feature flag JSON contains unmapped/unknown properties.
Configure the ObjectMapper to ignore any unknown properties, so that the forms service can ignore any flags it does not care about.

TIS21-7657