### PR TITLE
fix: ignore unknown features

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.52.2"
+version = "0.52.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FeaturesDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FeaturesDto.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.forms.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 import lombok.Builder;
 
@@ -28,6 +29,7 @@ import lombok.Builder;
  * A DTO for trainee details feature flags.
  */
 @Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record FeaturesDto(boolean ltft,
                           List<String> ltftProgrammes) {
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtilTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtilTest.java
@@ -200,4 +200,31 @@ class AuthTokenUtilTest {
     assertThat("Unexpected features ltft programmes.", features.ltftProgrammes(),
         hasItems("LTFT Programme 1", "LTFT Programme 2"));
   }
+
+  @Test
+  void getFeaturesShouldIgnoreExtraFeaturesInToken() throws IOException {
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString("""
+             {
+                "features": {
+                  "ltft": true,
+                  "ltftProgrammes": [
+                    "LTFT Programme 1",
+                    "LTFT Programme 2"
+                  ],
+                  "anotherFeature": "some value"
+                }
+             }
+            """
+            .getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    FeaturesDto features = AuthTokenUtil.getFeatures(token);
+
+    assertThat("Unexpected features ltft value.", features.ltft(), is(true));
+    assertThat("Unexpected features ltft programmes count.", features.ltftProgrammes(),
+        hasSize(2));
+    assertThat("Unexpected features ltft programmes.", features.ltftProgrammes(),
+        hasItems("LTFT Programme 1", "LTFT Programme 2"));
+  }
 }


### PR DESCRIPTION
To avoid
'com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "actions" (class
uk.nhs.hee.tis.trainee.forms.dto.FeaturesDto), not marked as ignorable (2 known properties: "ltftProgrammes", "ltft"])' errors as new feature flags are added.

No-TICKET