### PR TITLE
refactor: token features

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.52.3"
+version = "0.52.4"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/TestJwtUtil.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/TestJwtUtil.java
@@ -32,11 +32,6 @@ import java.util.stream.Collectors;
  */
 public class TestJwtUtil {
 
-  public static final String TIS_ID_ATTRIBUTE = "custom:tisId";
-  public static final String EMAIL_ATTRIBUTE = "email";
-  public static final String GIVEN_NAME_ATTRIBUTE = "given_name";
-  public static final String FAMILY_NAME_ATTRIBUTE = "family_name";
-  public static final String FEATURES_ATTRIBUTE = "features";
   public static final UUID FEATURES_LTFT_PROGRAMME_INCLUDED = UUID.randomUUID();
 
   /**
@@ -62,15 +57,23 @@ public class TestJwtUtil {
    */
   public static String generateTokenForTrainee(String traineeTisId, String email, String givenName,
       String familyName) {
-    String features = String.format("{\"ltft\":true,"
-        + "\"ltftProgrammes\":[\"%s\"]}", FEATURES_LTFT_PROGRAMME_INCLUDED);
-    String payload = String.format("{\"%s\":\"%s\"", TIS_ID_ATTRIBUTE, traineeTisId)
-        + (email == null ? "" : String.format(",\"%s\":\"%s\"", EMAIL_ATTRIBUTE, email)
-        + (givenName == null ? "" : String.format(",\"%s\":\"%s\"", GIVEN_NAME_ATTRIBUTE, givenName)
-        + (familyName == null ? "" : String.format(",\"%s\":\"%s\"", FAMILY_NAME_ATTRIBUTE,
-        familyName))
-        + String.format(",\"%s\":%s", FEATURES_ATTRIBUTE, features)))
-        + "}"; // :tears:
+    String optionalClaims = (email == null ? "" : String.format("\"email\":\"%s\",", email))
+        + (givenName == null ? "" : String.format("\"given_name\":\"%s\",", givenName))
+        + (familyName == null ? "" : String.format("\"family_name\":\"%s\",", familyName));
+    String payload = """
+        {
+          "custom:tisId": "%s",
+          %s
+          "features": {
+            "forms": {
+              "ltft": {
+                "enabled": true,
+                "qualifyingProgrammes": ["%s"]
+              }
+            }
+          }
+        }
+        """.formatted(traineeTisId, optionalClaims, FEATURES_LTFT_PROGRAMME_INCLUDED);
     return generateToken(payload);
   }
 

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceIntegrationTest.java
@@ -52,6 +52,8 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import uk.nhs.hee.tis.trainee.forms.DockerImageNames;
 import uk.nhs.hee.tis.trainee.forms.dto.FeaturesDto;
+import uk.nhs.hee.tis.trainee.forms.dto.FeaturesDto.FormFeatures;
+import uk.nhs.hee.tis.trainee.forms.dto.FeaturesDto.FormFeatures.LtftFeatures;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
@@ -95,8 +97,12 @@ class LtftServiceIntegrationTest {
   void setUp() {
     traineeIdentity.setTraineeId(TRAINEE_ID);
     traineeIdentity.setFeatures(FeaturesDto.builder()
-        .ltft(true)
-        .ltftProgrammes(List.of(PM_UUID.toString()))
+        .forms(FormFeatures.builder()
+            .ltft(LtftFeatures.builder()
+                .enabled(true)
+                .qualifyingProgrammes(Set.of(PM_UUID.toString()))
+                .build())
+            .build())
         .build());
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtil.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtil.java
@@ -32,6 +32,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import uk.nhs.hee.tis.trainee.forms.dto.FeaturesDto;
+import uk.nhs.hee.tis.trainee.forms.dto.FeaturesDto.FormFeatures;
+import uk.nhs.hee.tis.trainee.forms.dto.FeaturesDto.FormFeatures.LtftFeatures;
 
 @Slf4j
 public class AuthTokenUtil {
@@ -83,7 +85,11 @@ public class AuthTokenUtil {
     FeaturesDto features = mapper.convertValue(payload.get("features"), FeaturesDto.class);
     if (features == null) {
       log.warn("No features found in the token payload {}.", token);
-      return FeaturesDto.builder().build();
+      return FeaturesDto.builder()
+          .forms(FormFeatures.builder()
+              .ltft(LtftFeatures.builder().build())
+              .build())
+          .build();
     }
     return features;
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FeaturesDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/FeaturesDto.java
@@ -21,14 +21,32 @@
 
 package uk.nhs.hee.tis.trainee.forms.dto;
 
-import java.util.List;
+import java.util.Set;
 import lombok.Builder;
 
 /**
  * A DTO for trainee details feature flags.
  */
 @Builder
-public record FeaturesDto(boolean ltft,
-                          List<String> ltftProgrammes) {
+public record FeaturesDto(FormFeatures forms) {
 
+  /**
+   * A sub-set of form features.
+   *
+   * @param ltft A sub-set of LTFT features.
+   */
+  @Builder
+  public record FormFeatures(LtftFeatures ltft) {
+
+    /**
+     * A sub-set of LTFT features.
+     *
+     * @param enabled              Whether LTFT is enabled.
+     * @param qualifyingProgrammes A set of programmes which qualify for LTFT.
+     */
+    @Builder
+    public record LtftFeatures(boolean enabled, Set<String> qualifyingProgrammes) {
+
+    }
+  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -50,6 +50,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import uk.nhs.hee.tis.trainee.forms.dto.FeaturesDto.FormFeatures.LtftFeatures;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto.LftfStatusInfoDetailDto;
@@ -464,7 +465,7 @@ public class LtftService {
             formId);
         return Optional.empty();
       }
-      LtftContent newContent =  form.getContent().withTpdEmailValidity(updatedEmailValidity);
+      LtftContent newContent = form.getContent().withTpdEmailValidity(updatedEmailValidity);
       form.setContent(newContent);
       LtftForm savedForm = ltftFormRepository.save(form);
       publishUpdateNotification(savedForm, FORM_ATTRIBUTE_TPD_STATUS,
@@ -677,14 +678,16 @@ public class LtftService {
       log.info("Trainee {} does not have features set.", traineeIdentity.getTraineeId());
       return false;
     }
-    if (!traineeIdentity.getFeatures().ltft()) {
+
+    LtftFeatures ltftFeatures = traineeIdentity.getFeatures().forms().ltft();
+
+    if (!ltftFeatures.enabled()) {
       log.info("Trainee {} is not LTFT-enabled.", traineeIdentity.getTraineeId());
       return false;
     }
     if (programmeMembershipId == null
-        || traineeIdentity.getFeatures().ltftProgrammes() == null
-        || !traineeIdentity.getFeatures().ltftProgrammes()
-        .contains(programmeMembershipId.toString())) {
+        || ltftFeatures.qualifyingProgrammes() == null
+        || !ltftFeatures.qualifyingProgrammes().contains(programmeMembershipId.toString())) {
       log.info("Trainee {} programme membership {} is null or not LTFT-enabled.",
           traineeIdentity.getTraineeId(), programmeMembershipId);
       return false;

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtilTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/util/AuthTokenUtilTest.java
@@ -36,6 +36,7 @@ import java.util.Base64;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import uk.nhs.hee.tis.trainee.forms.dto.FeaturesDto;
+import uk.nhs.hee.tis.trainee.forms.dto.FeaturesDto.FormFeatures.LtftFeatures;
 
 class AuthTokenUtilTest {
 
@@ -169,9 +170,10 @@ class AuthTokenUtilTest {
     String token = String.format("aa.%s.cc", encodedPayload);
 
     FeaturesDto features = AuthTokenUtil.getFeatures(token);
+    LtftFeatures ltftFeatures = features.forms().ltft();
 
-    assertThat("Unexpected features ltft value.", features.ltft(), is(false));
-    assertThat("Unexpected features ltft programmes value.", features.ltftProgrammes(),
+    assertThat("Unexpected features ltft value.", ltftFeatures.enabled(), is(false));
+    assertThat("Unexpected features ltft programmes value.", ltftFeatures.qualifyingProgrammes(),
         nullValue());
   }
 
@@ -181,11 +183,15 @@ class AuthTokenUtilTest {
         .encodeToString("""
              {
                 "features": {
-                  "ltft": true,
-                  "ltftProgrammes": [
-                    "LTFT Programme 1",
-                    "LTFT Programme 2"
-                  ]
+                  "forms": {
+                    "ltft": {
+                      "enabled": true,
+                      "qualifyingProgrammes": [
+                        "LTFT Programme 1",
+                        "LTFT Programme 2"
+                      ]
+                    }
+                  }
                 }
              }
             """
@@ -194,10 +200,12 @@ class AuthTokenUtilTest {
 
     FeaturesDto features = AuthTokenUtil.getFeatures(token);
 
-    assertThat("Unexpected features ltft value.", features.ltft(), is(true));
-    assertThat("Unexpected features ltft programmes count.", features.ltftProgrammes(),
-        hasSize(2));
-    assertThat("Unexpected features ltft programmes.", features.ltftProgrammes(),
+    LtftFeatures ltftFeatures = features.forms().ltft();
+    assertThat("Unexpected features ltft value.", ltftFeatures.enabled(), is(true));
+
+    Set<String> qualifyingProgrammes = ltftFeatures.qualifyingProgrammes();
+    assertThat("Unexpected features ltft programmes count.", qualifyingProgrammes, hasSize(2));
+    assertThat("Unexpected features ltft programmes.", qualifyingProgrammes,
         hasItems("LTFT Programme 1", "LTFT Programme 2"));
   }
 
@@ -208,11 +216,15 @@ class AuthTokenUtilTest {
              {
                 "features": {
                   "unknown": "feature",
-                  "ltft": true,
-                  "ltftProgrammes": [
-                    "LTFT Programme 1",
-                    "LTFT Programme 2"
-                  ]
+                  "forms": {
+                    "ltft": {
+                      "enabled": true,
+                      "qualifyingProgrammes": [
+                        "LTFT Programme 1",
+                        "LTFT Programme 2"
+                      ]
+                    }
+                  }
                 }
              }
             """

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -88,6 +88,8 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import uk.nhs.hee.tis.trainee.forms.dto.FeaturesDto;
+import uk.nhs.hee.tis.trainee.forms.dto.FeaturesDto.FormFeatures;
+import uk.nhs.hee.tis.trainee.forms.dto.FeaturesDto.FormFeatures.LtftFeatures;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.CctChangeDto;
@@ -161,8 +163,12 @@ class LtftServiceTest {
     traineeIdentity.setEmail(TRAINEE_EMAIL);
     traineeIdentity.setName(TRAINEE_NAME);
     traineeIdentity.setFeatures(FeaturesDto.builder()
-        .ltft(true)
-        .ltftProgrammes(List.of(PM_UUID.toString()))
+        .forms(FormFeatures.builder()
+            .ltft(LtftFeatures.builder()
+                .enabled(true)
+                .qualifyingProgrammes(Set.of(PM_UUID.toString()))
+                .build())
+            .build())
         .build());
 
     repository = mock(LtftFormRepository.class);
@@ -1970,8 +1976,12 @@ class LtftServiceTest {
     TraineeIdentity traineeIdentity = new TraineeIdentity();
     traineeIdentity.setTraineeId(TRAINEE_ID);
     traineeIdentity.setFeatures(FeaturesDto.builder()
-        .ltft(false)
-        .ltftProgrammes(List.of(PM_UUID.toString()))
+        .forms(FormFeatures.builder()
+            .ltft(LtftFeatures.builder()
+                .enabled(false)
+                .qualifyingProgrammes(Set.of(PM_UUID.toString()))
+                .build())
+            .build())
         .build());
 
     service = new LtftService(adminIdentity, traineeIdentity, repository, mongoTemplate,
@@ -2003,7 +2013,11 @@ class LtftServiceTest {
     TraineeIdentity traineeIdentity = new TraineeIdentity();
     traineeIdentity.setTraineeId(TRAINEE_ID);
     traineeIdentity.setFeatures(FeaturesDto.builder()
-        .ltft(true)
+        .forms(FormFeatures.builder()
+            .ltft(LtftFeatures.builder()
+                .enabled(true)
+                .build())
+            .build())
         .build());
 
     service = new LtftService(adminIdentity, traineeIdentity, repository, mongoTemplate, mapper,


### PR DESCRIPTION
The auth token's features have been reworked to make them more granular. The current `features.ltft` and `features.ltftProgrammes` have been replaced with `features.forms.ltft.enabled` and
`features.forms.ltft.qualifyingProgrammes` respectively.

TIS21-7657
TIS21-7824