### PR TITLE
feat: S3 forms no longer included in GET requests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.65.5"
+version = "0.66.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceIntegrationTest.java
@@ -285,7 +285,7 @@ class FormRPartAResourceIntegrationTest {
             .with(jwt().jwt(token)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$", hasSize(1)));
+        .andExpect(jsonPath("$", hasSize(2)));
   }
 
   @Test

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResourceIntegrationTest.java
@@ -263,7 +263,7 @@ class FormRPartBResourceIntegrationTest {
             .with(jwt().jwt(token)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$", hasSize(1)));
+        .andExpect(jsonPath("$", hasSize(2)));
   }
 
   @Test

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/AbstractCloudRepository.java
@@ -24,16 +24,10 @@ import static java.util.Map.entry;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.ParameterizedType;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
@@ -43,14 +37,9 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.DeleteType;
-import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.AbstractFormR;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
@@ -157,42 +146,6 @@ public abstract class AbstractCloudRepository<T extends AbstractFormR> {
   }
 
   /**
-   * Find forms for the trainee.
-   *
-   * @param traineeTisId the id of the trainee assigned by TIS
-   * @return a list of forms
-   */
-  public List<T> findByTraineeTisId(String traineeTisId) {
-    ListObjectsV2Request listRequest = ListObjectsV2Request.builder()
-        .bucket(bucketName)
-        .prefix(String.format(getObjectPrefixTemplate(), traineeTisId))
-        .build();
-    ListObjectsV2Response listing = s3Client.listObjectsV2(listRequest);
-    return listing.contents().stream().map(s3Object -> {
-      try {
-        HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
-            .bucket(bucketName)
-            .key(s3Object.key())
-            .build();
-        HeadObjectResponse headObject = s3Client.headObject(headObjectRequest);
-        Map<String, String> metadata = headObject.metadata();
-        T form = getTypeClass().getConstructor().newInstance();
-        form.setId(UUID.fromString(metadata.get("id")));
-        form.setTraineeTisId(metadata.get(TRAINEE_ID));
-        populateProgrammeMembershipId(form, metadata);
-        populateSubmissionDate(form, metadata);
-        form.setLifecycleState(
-            LifecycleState.valueOf(metadata.get(LIFECYCLE_STATE)
-                .toUpperCase()));
-        return form;
-      } catch (Exception e) {
-        log.error("Problem reading form [{}] from S3 bucket [{}]", s3Object.key(), bucketName, e);
-        return null;
-      }
-    }).filter(Objects::nonNull).collect(Collectors.toList());
-  }
-
-  /**
    * Get the form.
    *
    * @param id           The id of the form
@@ -255,30 +208,4 @@ public abstract class AbstractCloudRepository<T extends AbstractFormR> {
   protected abstract String getObjectKeyTemplate();
 
   protected abstract String getObjectPrefixTemplate();
-
-  private T populateProgrammeMembershipId(T form, Map<String, String> metadata) {
-    try {
-      if (metadata.get(PROGRAMME_MEMBERSHIP_ID) != null) {
-        form.setProgrammeMembershipId(UUID.fromString(metadata.get(PROGRAMME_MEMBERSHIP_ID)));
-      }
-    } catch (IllegalArgumentException e) {
-      log.debug("No linked programme membership for form id {}",
-          metadata.get("id"));
-    }
-    return form;
-  }
-
-  private T populateSubmissionDate(T form, Map<String, String> metadata) {
-    LocalDateTime localDateTime;
-    try {
-      form.setSubmissionDate(LocalDateTime.parse(metadata.get(SUBMISSION_DATE)));
-    } catch (DateTimeParseException e) {
-      log.debug("Existing date {} not in latest format, trying as LocalDate.",
-          e.getParsedString());
-      localDateTime = LocalDate.parse(metadata.get(SUBMISSION_DATE))
-          .atStartOfDay();
-      form.setSubmissionDate(localDateTime);
-    }
-    return form;
-  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
@@ -147,11 +147,8 @@ public class FormRPartAService {
   public List<FormRPartSimpleDto> getFormRPartAs() {
     String traineeTisId = traineeIdentity.getTraineeId();
     log.info("Request to get FormRPartA list by trainee profileId : {}", traineeTisId);
-    List<FormRPartA> storedFormRPartAs = cloudObjectRepository.findByTraineeTisId(traineeTisId);
-    List<FormRPartA> formRPartAList = repository
-        .findByTraineeTisIdAndLifecycleState(traineeTisId, LifecycleState.DRAFT);
-    storedFormRPartAs.addAll(formRPartAList);
-    return mapper.toSimpleDtos(storedFormRPartAs);
+    List<FormRPartA> formRPartAList = repository.findByTraineeTisId(traineeTisId);
+    return mapper.toSimpleDtos(formRPartAList);
   }
 
   /**
@@ -175,25 +172,10 @@ public class FormRPartAService {
     log.info("Request to get FormRPartA by id : {}", id);
 
     String traineeTisId = traineeIdentity.getTraineeId();
-    Optional<FormRPartA> optionalCloudForm = cloudObjectRepository.findByIdAndTraineeTisId(id,
-        traineeTisId);
     Optional<FormRPartA> optionalDbForm = repository.findByIdAndTraineeTisId(UUID.fromString(id),
         traineeTisId);
 
-    FormRPartA latestForm = null;
-
-    if (optionalCloudForm.isPresent() && optionalDbForm.isPresent()) {
-      FormRPartA cloudForm = optionalCloudForm.get();
-      FormRPartA dbForm = optionalDbForm.get();
-      latestForm = cloudForm.getLastModifiedDate().isBefore(dbForm.getLastModifiedDate()) ? dbForm
-          : cloudForm;
-    } else if (optionalCloudForm.isPresent()) {
-      latestForm = optionalCloudForm.get();
-    } else if (optionalDbForm.isPresent()) {
-      latestForm = optionalDbForm.get();
-    }
-
-    return mapper.toDto(latestForm);
+    return mapper.toDto(optionalDbForm.orElse(null));
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
@@ -146,11 +146,8 @@ public class FormRPartBService {
   public List<FormRPartSimpleDto> getFormRPartBs() {
     String traineeTisId = traineeIdentity.getTraineeId();
     log.info("Request to get FormRPartB list by trainee profileId : {}", traineeTisId);
-    List<FormRPartB> storedFormRPartBs = s3ObjectRepository.findByTraineeTisId(traineeTisId);
-    List<FormRPartB> formRPartBList = formRPartBRepository
-        .findByTraineeTisIdAndLifecycleState(traineeTisId, LifecycleState.DRAFT);
-    storedFormRPartBs.addAll(formRPartBList);
-    return formRPartBMapper.toSimpleDtos(storedFormRPartBs);
+    List<FormRPartB> formRPartBList = formRPartBRepository.findByTraineeTisId(traineeTisId);
+    return formRPartBMapper.toSimpleDtos(formRPartBList);
   }
 
   /**
@@ -175,25 +172,10 @@ public class FormRPartBService {
     log.info("Request to get FormRPartB by id : {}", id);
 
     String traineeTisId = traineeIdentity.getTraineeId();
-    Optional<FormRPartB> optionalS3Form = s3ObjectRepository.findByIdAndTraineeTisId(id,
-        traineeTisId);
     Optional<FormRPartB> optionalDbForm = formRPartBRepository.findByIdAndTraineeTisId(
         UUID.fromString(id), traineeTisId);
 
-    FormRPartB latestForm = null;
-
-    if (optionalS3Form.isPresent() && optionalDbForm.isPresent()) {
-      FormRPartB cloudForm = optionalS3Form.get();
-      FormRPartB dbForm = optionalDbForm.get();
-      latestForm = cloudForm.getLastModifiedDate().isBefore(dbForm.getLastModifiedDate()) ? dbForm
-          : cloudForm;
-    } else if (optionalS3Form.isPresent()) {
-      latestForm = optionalS3Form.get();
-    } else if (optionalDbForm.isPresent()) {
-      latestForm = optionalDbForm.get();
-    }
-
-    return formRPartBMapper.toDto(latestForm);
+    return formRPartBMapper.toDto(optionalDbForm.orElse(null));
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartARepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartARepositoryImplTest.java
@@ -7,8 +7,6 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,7 +21,6 @@ import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -48,13 +45,9 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.S3Object;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.DeleteType;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
@@ -64,7 +57,6 @@ import uk.nhs.hee.tis.trainee.forms.service.exception.ApplicationException;
 @ExtendWith(MockitoExtension.class)
 class S3FormRPartARepositoryImplTest {
 
-  private static final String KEY = "object.name";
   private static final UUID DEFAULT_ID = UUID.randomUUID();
   private static final String DEFAULT_ID_STRING = DEFAULT_ID.toString();
   private static final String DEFAULT_TRAINEE_TIS_ID = "1";
@@ -75,17 +67,6 @@ class S3FormRPartARepositoryImplTest {
   private static final String DEFAULT_PROGRAMME_MEMBERSHIP_ID = UUID.randomUUID().toString();
   private static final String DEFAULT_SUBMISSION_DATE_STRING = DEFAULT_SUBMISSION_DATE.format(
       DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-  private static final String DEFAULT_FORM_ID = UUID.randomUUID().toString();
-  private static final Map<String, String> DEFAULT_UNSUBMITTED_METADATA = Map
-      .of("id", DEFAULT_FORM_ID, "formtype", "inform", "lifecyclestate",
-          LifecycleState.UNSUBMITTED.name(), "submissiondate",
-          DEFAULT_SUBMISSION_DATE_STRING, "traineeid",
-          DEFAULT_TRAINEE_TIS_ID, "programmemembershipid", DEFAULT_PROGRAMME_MEMBERSHIP_ID);
-  private static final Map<String, String> DEFAULT_METADATA_MISSING_PM = Map
-      .of("id", DEFAULT_FORM_ID, "formtype", "inform", "lifecyclestate",
-          LifecycleState.UNSUBMITTED.name(), "submissiondate",
-          DEFAULT_SUBMISSION_DATE_STRING, "traineeid",
-          DEFAULT_TRAINEE_TIS_ID);
   private static final String FIXED_FIELDS =
       "id,traineeTisId,lifecycleState,submissionDate,lastModifiedDate";
 
@@ -224,109 +205,6 @@ class S3FormRPartARepositoryImplTest {
 
     Exception actual = assertThrows(RuntimeException.class, () -> repo.save(entity));
     assertThat("Unexpected exception type.", actual instanceof ApplicationException);
-  }
-
-  @Test
-  void shouldNotThrowWhenNoLinkedProgrammeMembership() {
-    when(s3Mock.listObjectsV2(ListObjectsV2Request.builder().bucket(bucketName)
-        .prefix(DEFAULT_TRAINEE_TIS_ID + "/forms/formr-a").build()))
-        .thenReturn(s3ListingMock);
-    String otherKey = KEY + "w/error";
-    List<S3Object> s3Objects = List.of(
-        S3Object.builder().key(KEY).build(),
-        S3Object.builder().key(otherKey).build()
-    );
-    when(s3ListingMock.contents()).thenReturn(s3Objects);
-
-    // invalid UUID metadata
-    Map<String, String> metadata = Map.of(
-        "id", DEFAULT_FORM_ID,
-        "traineeid", DEFAULT_TRAINEE_TIS_ID,
-        "programmemembershipid", "INVALID_UUID",
-        "lifecyclestate", "SUBMITTED",
-        "submissiondate", LocalDateTime.now().toString()
-    );
-
-    HeadObjectResponse metadataResponse = HeadObjectResponse.builder()
-        .metadata(metadata).build();
-    when(s3Mock.headObject(
-        HeadObjectRequest.builder().bucket(bucketName).key(KEY).build())).thenReturn(
-        metadataResponse);
-    when(s3Mock.headObject(HeadObjectRequest.builder().bucket(bucketName).key(otherKey).build()))
-        .thenThrow(AwsServiceException.class);
-
-    assertDoesNotThrow(() -> {
-      repo.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    }, "should not throw when no linkedprogramme membership");
-  }
-
-  @Test
-  void shouldGetFormRPartAsByTraineeTisId() {
-    when(s3Mock.listObjectsV2(ListObjectsV2Request.builder().bucket(bucketName)
-        .prefix(DEFAULT_TRAINEE_TIS_ID + "/forms/formr-a").build()))
-        .thenReturn(s3ListingMock);
-    String otherKey = KEY + "w/error";
-    List<S3Object> s3Objects = List.of(
-        S3Object.builder().key(KEY).build(),
-        S3Object.builder().key(otherKey).build()
-    );
-    when(s3ListingMock.contents()).thenReturn(s3Objects);
-
-    HeadObjectResponse metadataResponse = HeadObjectResponse.builder()
-        .metadata(DEFAULT_UNSUBMITTED_METADATA).build();
-    when(s3Mock.headObject(
-        HeadObjectRequest.builder().bucket(bucketName).key(KEY).build())).thenReturn(
-        metadataResponse);
-    when(s3Mock.headObject(HeadObjectRequest.builder().bucket(bucketName).key(otherKey).build()))
-        .thenThrow(AwsServiceException.class);
-
-    List<FormRPartA> entities = repo.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-
-    assertThat("Unexpected numbers of forms.", entities.size(), is(1));
-
-    FormRPartA entity = entities.get(0);
-    assertThat("Unexpected form ID.", entity.getId(), is(UUID.fromString(DEFAULT_FORM_ID)));
-    assertThat("Unexpected trainee ID.", entity.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected submitted date.", entity.getSubmissionDate(),
-        is(DEFAULT_SUBMISSION_DATE));
-    assertThat("Unexpected lifecycle state.", entity.getLifecycleState(),
-        is(LifecycleState.UNSUBMITTED));
-    assertThat("Unexpected programme membership ID.", entity.getProgrammeMembershipId(),
-        is(UUID.fromString(DEFAULT_PROGRAMME_MEMBERSHIP_ID)));
-  }
-
-  @Test
-  void shouldGetFormrPartAsByTraineeTisIdWhenPmMissing() {
-    when(s3Mock.listObjectsV2(ListObjectsV2Request.builder().bucket(bucketName)
-        .prefix(DEFAULT_TRAINEE_TIS_ID + "/forms/formr-a").build()))
-        .thenReturn(s3ListingMock);
-    String otherKey = KEY + "w/error";
-    List<S3Object> s3Objects = List.of(
-        S3Object.builder().key(KEY).build(),
-        S3Object.builder().key(otherKey).build()
-    );
-    when(s3ListingMock.contents()).thenReturn(s3Objects);
-
-    HeadObjectResponse metadataResponse = HeadObjectResponse.builder()
-        .metadata(DEFAULT_METADATA_MISSING_PM).build();
-    when(s3Mock.headObject(
-        HeadObjectRequest.builder().bucket(bucketName).key(KEY).build())).thenReturn(
-        metadataResponse);
-    when(s3Mock.headObject(HeadObjectRequest.builder().bucket(bucketName).key(otherKey).build()))
-        .thenThrow(AwsServiceException.class);
-
-    List<FormRPartA> entities = repo.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-
-    assertThat("Unexpected numbers of forms.", entities.size(), is(1));
-
-    entity = entities.get(0);
-    assertThat("Unexpected form ID.", entity.getId(), is(UUID.fromString(DEFAULT_FORM_ID)));
-    assertThat("Unexpected trainee ID.", entity.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected submitted date.", entity.getSubmissionDate(),
-        is(DEFAULT_SUBMISSION_DATE));
-    assertThat("Unexpected lifecycle state.", entity.getLifecycleState(),
-        is(LifecycleState.UNSUBMITTED));
-    assertNull(entity.getProgrammeMembershipId(), "Unexpected programme membership ID.");
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/repository/S3FormRPartBRepositoryImplTest.java
@@ -9,8 +9,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -28,7 +26,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -53,13 +50,9 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.S3Object;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.DeleteType;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.Declaration;
@@ -71,7 +64,6 @@ import uk.nhs.hee.tis.trainee.forms.service.exception.ApplicationException;
 @ExtendWith(MockitoExtension.class)
 class S3FormRPartBRepositoryImplTest {
 
-  private static final String KEY = "object.name";
   private static final UUID DEFAULT_ID = UUID.randomUUID();
   private static final String DEFAULT_ID_STRING = DEFAULT_ID.toString();
   private static final String DEFAULT_TRAINEE_TIS_ID = "1";
@@ -105,34 +97,6 @@ class S3FormRPartBRepositoryImplTest {
   private static final LocalDateTime DEFAULT_SUBMISSION_DATE = LocalDateTime.now();
   private static final String DEFAULT_SUBMISSION_DATE_STRING = DEFAULT_SUBMISSION_DATE.format(
       DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-  private static final LocalDate DATE_FORMAT_SUBMISSION_DATE = LocalDate
-      .of(2020, 8, 29);
-  private static final LocalDateTime DATE_FORMAT_SUBMISSION_DATE_PARSED =
-      DATE_FORMAT_SUBMISSION_DATE.atStartOfDay();
-  private static final String DATE_FORMAT_DATE_STRING = DATE_FORMAT_SUBMISSION_DATE.format(
-      DateTimeFormatter.ISO_LOCAL_DATE);
-  private static final String DEFAULT_FORM_ID = UUID.randomUUID().toString();
-  private static final Map<String, String> DEFAULT_UNSUBMITTED_METADATA = Map
-      .of("id", DEFAULT_FORM_ID,
-          "formtype", "inform",
-          "lifecyclestate", LifecycleState.UNSUBMITTED.name(),
-          "submissiondate", DEFAULT_SUBMISSION_DATE_STRING,
-          "traineeid", DEFAULT_TRAINEE_TIS_ID,
-          "programmemembershipid", DEFAULT_PROGRAMME_MEMBERSHIP_ID);
-  private static final Map<String, String> UNSUBMITTED_METADATA_DATE_FORMAT_SUBMISSIONDATE = Map
-      .of("id", DEFAULT_FORM_ID,
-          "formtype", "inform",
-          "lifecyclestate",
-          LifecycleState.UNSUBMITTED.name(),
-          "submissiondate", DATE_FORMAT_DATE_STRING,
-          "traineeid", DEFAULT_TRAINEE_TIS_ID,
-          "programmemembershipid", DEFAULT_PROGRAMME_MEMBERSHIP_ID);
-  private static final Map<String, String> DEFAULT_METADATA_MISSING_PM = Map
-      .of("id", DEFAULT_FORM_ID,
-          "formtype", "inform",
-          "lifecyclestate", LifecycleState.UNSUBMITTED.name(),
-          "submissiondate", DEFAULT_SUBMISSION_DATE_STRING,
-          "traineeid", DEFAULT_TRAINEE_TIS_ID);
   private static final Boolean DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS = true;
   private static final Boolean DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS = true;
   private static final String FIXED_FIELDS =
@@ -290,131 +254,6 @@ class S3FormRPartBRepositoryImplTest {
 
     Exception actual = assertThrows(RuntimeException.class, () -> repo.save(entity));
     assertThat("Unexpected exception type.", actual instanceof ApplicationException);
-  }
-
-  @Test
-  void shouldNotThrowWhenNoLinkedProgrammeMembership() {
-    when(s3Mock.listObjectsV2(ListObjectsV2Request.builder().bucket(bucketName)
-        .prefix(DEFAULT_TRAINEE_TIS_ID + "/forms/formr-b").build()))
-        .thenReturn(s3ListingMock);
-    String otherKey = KEY + "w/error";
-    List<S3Object> s3Objects = List.of(
-        S3Object.builder().key(KEY).build(),
-        S3Object.builder().key(otherKey).build()
-    );
-    when(s3ListingMock.contents()).thenReturn(s3Objects);
-
-    // invalid UUID metadata
-    Map<String, String> metadata = Map.of(
-        "id", DEFAULT_FORM_ID,
-        "traineeid", DEFAULT_TRAINEE_TIS_ID,
-        "programmemembershipid", "INVALID_UUID",
-        "lifecyclestate", "SUBMITTED",
-        "submissiondate", LocalDateTime.now().toString()
-    );
-
-    HeadObjectResponse metadataResponse = HeadObjectResponse.builder()
-        .metadata(metadata).build();
-    when(s3Mock.headObject(
-        HeadObjectRequest.builder().bucket(bucketName).key(KEY).build())).thenReturn(
-        metadataResponse);
-    when(s3Mock.headObject(HeadObjectRequest.builder().bucket(bucketName).key(otherKey).build()))
-        .thenThrow(AwsServiceException.class);
-
-    assertDoesNotThrow(() -> {
-      repo.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    }, "should not throw when no linkedprogramme membership");
-  }
-
-  @Test
-  void shouldGetFormRPartBsByTraineeTisId() {
-    when(s3Mock.listObjectsV2(ListObjectsV2Request.builder().bucket(bucketName)
-        .prefix(DEFAULT_TRAINEE_TIS_ID + "/forms/formr-b").build())).thenReturn(s3ListingMock);
-    String otherKey = KEY + "w/error";
-    List<S3Object> s3Objects = List.of(
-        S3Object.builder().key(KEY).build(),
-        S3Object.builder().key(otherKey).build()
-    );
-    when(s3ListingMock.contents()).thenReturn(s3Objects);
-
-    HeadObjectResponse metadataResponse = HeadObjectResponse.builder()
-        .metadata(DEFAULT_UNSUBMITTED_METADATA).build();
-    when(s3Mock.headObject(
-        HeadObjectRequest.builder().bucket(bucketName).key(KEY).build())).thenReturn(
-        metadataResponse);
-    when(s3Mock.headObject(HeadObjectRequest.builder().bucket(bucketName).key(otherKey).build()))
-        .thenThrow(AwsServiceException.class);
-
-    List<FormRPartB> entities = repo.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-
-    assertThat("Unexpected numbers of forms.", entities.size(), is(1));
-
-    FormRPartB entity = entities.get(0);
-    assertThat("Unexpected form ID.", entity.getId(), is(UUID.fromString(DEFAULT_FORM_ID)));
-    assertThat("Unexpected trainee ID.", entity.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected submitted date.", entity.getSubmissionDate(),
-        is(DEFAULT_SUBMISSION_DATE));
-    assertThat("Unexpected lifecycle state.", entity.getLifecycleState(),
-        is(LifecycleState.UNSUBMITTED));
-    assertThat("Unexpected programme membership ID.", entity.getProgrammeMembershipId(),
-        is(UUID.fromString(DEFAULT_PROGRAMME_MEMBERSHIP_ID)));
-  }
-
-
-  @Test
-  void shouldGetFormrPartBsByTraineeTisIdWhenPmMissing() {
-    when(s3Mock.listObjectsV2(ListObjectsV2Request.builder().bucket(bucketName)
-        .prefix(DEFAULT_TRAINEE_TIS_ID + "/forms/formr-b").build())).thenReturn(s3ListingMock);
-    String otherKey = KEY + "w/error";
-    List<S3Object> s3Objects = List.of(
-        S3Object.builder().key(KEY).build(),
-        S3Object.builder().key(otherKey).build()
-    );
-    when(s3ListingMock.contents()).thenReturn(s3Objects);
-
-    HeadObjectResponse metadataResponse = HeadObjectResponse.builder()
-        .metadata(DEFAULT_METADATA_MISSING_PM).build();
-    when(s3Mock.headObject(
-        HeadObjectRequest.builder().bucket(bucketName).key(KEY).build())).thenReturn(
-        metadataResponse);
-    when(s3Mock.headObject(HeadObjectRequest.builder().bucket(bucketName).key(otherKey).build()))
-        .thenThrow(AwsServiceException.class);
-
-    List<FormRPartB> entities = repo.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-
-    assertThat("Unexpected numbers of forms.", entities.size(), is(1));
-
-    entity = entities.get(0);
-    assertThat("Unexpected form ID.", entity.getId(), is(UUID.fromString(DEFAULT_FORM_ID)));
-    assertThat("Unexpected trainee ID.", entity.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected submitted date.", entity.getSubmissionDate(),
-        is(DEFAULT_SUBMISSION_DATE));
-    assertThat("Unexpected lifecycle state.", entity.getLifecycleState(),
-        is(LifecycleState.UNSUBMITTED));
-    assertNull(entity.getProgrammeMembershipId(), "Unexpected programme membership ID.");
-  }
-
-  @Test
-  void shouldParseSubmissionDateWhenInDateFormat() {
-    when(s3Mock.listObjectsV2(ListObjectsV2Request.builder().bucket(bucketName)
-        .prefix(DEFAULT_TRAINEE_TIS_ID + "/forms/formr-b").build())).thenReturn(s3ListingMock);
-    List<S3Object> s3Objects = List.of(S3Object.builder().key(KEY).build());
-    when(s3ListingMock.contents()).thenReturn(s3Objects);
-
-    HeadObjectResponse metadataResponse = HeadObjectResponse.builder()
-        .metadata(UNSUBMITTED_METADATA_DATE_FORMAT_SUBMISSIONDATE).build();
-    when(s3Mock.headObject(
-        HeadObjectRequest.builder().bucket(bucketName).key(KEY).build())).thenReturn(
-        metadataResponse);
-
-    List<FormRPartB> entities = repo.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-
-    assertThat("Unexpected numbers of forms.", entities.size(), is(1));
-
-    FormRPartB entity = entities.get(0);
-
-    assertThat("Unexpected submitted date.", entity.getSubmissionDate(),
-        is(DATE_FORMAT_SUBMISSION_DATE_PARSED));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -304,11 +305,7 @@ class FormRPartAServiceTest {
   @Test
   void shouldGetFormRPartAs() {
     List<FormRPartA> entities = Collections.singletonList(entity);
-    when(repositoryMock
-        .findByTraineeTisIdAndLifecycleState(DEFAULT_TRAINEE_TIS_ID, LifecycleState.DRAFT))
-        .thenReturn(entities);
-    when(cloudObjectRepository.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(new ArrayList<>());
+    when(repositoryMock.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID)).thenReturn(entities);
 
     List<FormRPartSimpleDto> dtos = service.getFormRPartAs();
 
@@ -320,177 +317,30 @@ class FormRPartAServiceTest {
   }
 
   @Test
-  void shouldCombineAllFormRPartAsByTraineeTisId() {
-    List<FormRPartA> entities = Collections.singletonList(entity);
-    when(repositoryMock
-        .findByTraineeTisIdAndLifecycleState(DEFAULT_TRAINEE_TIS_ID, LifecycleState.DRAFT))
-        .thenReturn(entities);
-    FormRPartA cloudEntity = createEntity();
-    cloudEntity.setId(DEFAULT_ID);
-    cloudEntity.setSubmissionDate(DEFAULT_SUBMISSION_DATE);
-    cloudEntity.setLifecycleState(UNSUBMITTED);
-    List<FormRPartA> cloudStoredEntities = new ArrayList<>();
-    cloudStoredEntities.add(cloudEntity);
-    when(cloudObjectRepository.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(cloudStoredEntities);
-
-    List<FormRPartSimpleDto> dtos = service.getFormRPartAs();
-
-    assertThat("Unexpected numbers of forms.", dtos.size(), is(2));
-
-    FormRPartSimpleDto dto = dtos.stream()
-        .filter(f -> f.getLifecycleState() == LifecycleState.DRAFT)
-        .findAny()
-        .orElseThrow();
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
-    assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    dto = dtos.stream()
-        .filter(f -> f.getLifecycleState() == UNSUBMITTED)
-        .findAny()
-        .orElseThrow();
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
-    assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected submitted date.", dto.getSubmissionDate(), is(DEFAULT_SUBMISSION_DATE));
-    assertThat("Unexpected lifecycle state.", dto.getLifecycleState(),
-        is(UNSUBMITTED));
-  }
-
-  @Test
-  void shouldGetFormRPartAFromCloudStorageByIdWhenOnlyCloudFormExists() {
-    FormRPartA cloudForm = new FormRPartA();
-    cloudForm.setId(DEFAULT_ID);
-    cloudForm.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    cloudForm.setForename("Cloud Only");
-    cloudForm.setLifecycleState(UNSUBMITTED);
-
-    when(cloudObjectRepository.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(cloudForm));
-
+  void shouldReturnNullGettingFormRPartAByIdWhenFormNotExists() {
     when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
         .thenReturn(Optional.empty());
 
     FormRPartADto dto = service.getFormRPartAById(DEFAULT_ID_STRING);
 
+    assertThat("Unexpected form.", dto, nullValue());
+  }
+
+  @Test
+  void shouldGetFormRPartAByIdWhenFormExists() {
+    FormRPartA form = new FormRPartA();
+    form.setId(DEFAULT_ID);
+    form.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
+    form.setLifecycleState(UNSUBMITTED);
+
+    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(Optional.of(form));
+
+    FormRPartADto dto = service.getFormRPartAById(DEFAULT_ID_STRING);
+
     assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected forename.", dto.getForename(), is("Cloud Only"));
     assertThat("Unexpected status.", dto.getLifecycleState(), is(UNSUBMITTED));
-  }
-
-  @Test
-  void shouldGetFormRPartAFromDatabaseByIdWhenOnlyDatabaseFormExists() {
-    when(cloudObjectRepository.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.empty());
-
-    FormRPartA dbForm = new FormRPartA();
-    dbForm.setId(DEFAULT_ID);
-    dbForm.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    dbForm.setForename("Database Only");
-    dbForm.setLifecycleState(SUBMITTED);
-
-    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(dbForm));
-
-    FormRPartADto dto = service.getFormRPartAById(DEFAULT_ID_STRING);
-
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
-    assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected forename.", dto.getForename(), is("Database Only"));
-    assertThat("Unexpected status.", dto.getLifecycleState(), is(SUBMITTED));
-  }
-
-  @Test
-  void shouldGetFormRPartAFromCloudStorageByIdWhenCloudFormIsLatest() {
-    FormRPartA cloudForm = new FormRPartA();
-    cloudForm.setId(DEFAULT_ID);
-    cloudForm.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    cloudForm.setForename("Cloud Latest");
-    cloudForm.setLifecycleState(UNSUBMITTED);
-    cloudForm.setLastModifiedDate(LocalDateTime.MAX);
-
-    when(cloudObjectRepository.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(cloudForm));
-
-    FormRPartA dbForm = new FormRPartA();
-    dbForm.setId(DEFAULT_ID);
-    dbForm.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    dbForm.setForename("Database Oldest");
-    dbForm.setLifecycleState(SUBMITTED);
-    dbForm.setLastModifiedDate(LocalDateTime.MIN);
-
-    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(dbForm));
-
-    FormRPartADto dto = service.getFormRPartAById(DEFAULT_ID_STRING);
-
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
-    assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected forename.", dto.getForename(), is("Cloud Latest"));
-    assertThat("Unexpected status.", dto.getLifecycleState(), is(UNSUBMITTED));
-  }
-
-  @Test
-  void shouldGetFormRPartAFromDatabaseByIdWhenDatabaseFormIsLatest() {
-    FormRPartA cloudForm = new FormRPartA();
-    cloudForm.setId(DEFAULT_ID);
-    cloudForm.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    cloudForm.setForename("Cloud Oldest");
-    cloudForm.setLifecycleState(UNSUBMITTED);
-    cloudForm.setLastModifiedDate(LocalDateTime.MIN);
-
-    when(cloudObjectRepository.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(cloudForm));
-
-    FormRPartA dbForm = new FormRPartA();
-    dbForm.setId(DEFAULT_ID);
-    dbForm.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    dbForm.setForename("Database Latest");
-    dbForm.setLifecycleState(SUBMITTED);
-    dbForm.setLastModifiedDate(LocalDateTime.MAX);
-
-    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(dbForm));
-
-    FormRPartADto dto = service.getFormRPartAById(DEFAULT_ID_STRING);
-
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
-    assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected forename.", dto.getForename(), is("Database Latest"));
-    assertThat("Unexpected status.", dto.getLifecycleState(), is(SUBMITTED));
-  }
-
-  @ParameterizedTest
-  @EnumSource(LifecycleState.class)
-  void shouldGetFormRPartAFromCloudByIdWhenCloudAndDatabaseEqualModifiedTime(
-      LifecycleState cloudState) {
-    LocalDateTime now = LocalDateTime.now();
-
-    FormRPartA cloudForm = new FormRPartA();
-    cloudForm.setId(DEFAULT_ID);
-    cloudForm.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    cloudForm.setForename("Cloud Equal");
-    cloudForm.setLifecycleState(cloudState);
-    cloudForm.setLastModifiedDate(now);
-
-    when(cloudObjectRepository.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(cloudForm));
-
-    FormRPartA dbForm = new FormRPartA();
-    dbForm.setId(DEFAULT_ID);
-    dbForm.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    dbForm.setForename("Database Equal");
-    dbForm.setLifecycleState(SUBMITTED);
-    dbForm.setLastModifiedDate(now);
-
-    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(dbForm));
-
-    FormRPartADto dto = service.getFormRPartAById(DEFAULT_ID_STRING);
-
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
-    assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected forename.", dto.getForename(), is("Cloud Equal"));
-    assertThat("Unexpected status.", dto.getLifecycleState(), is(cloudState));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
 import static org.mockito.ArgumentMatchers.any;
@@ -116,7 +117,6 @@ class FormRPartBServiceTest {
   private static final String DEFAULT_CURRENT_DECLARATION_SUMMARY =
       "DEFAULT_CURRENT_DECLARATION_SUMMARY";
   private static final LocalDateTime DEFAULT_SUBMISSION_DATE = LocalDateTime.now();
-  private static final UUID DEFAULT_FORM_ID = UUID.randomUUID();
 
   private static final Boolean DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS = true;
   private static final Boolean DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS = true;
@@ -488,235 +488,42 @@ class FormRPartBServiceTest {
   @Test
   void shouldGetFormRPartBsByTraineeTisId() {
     List<FormRPartB> entities = Collections.singletonList(entity);
-    when(repositoryMock
-        .findByTraineeTisIdAndLifecycleState(DEFAULT_TRAINEE_TIS_ID, LifecycleState.DRAFT))
-        .thenReturn(entities);
-    when(s3FormRPartBRepository.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(new ArrayList<>());
+    when(repositoryMock.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID)).thenReturn(entities);
 
     List<FormRPartSimpleDto> dtos = service.getFormRPartBs();
 
     assertThat("Unexpected numbers of forms.", dtos.size(), is(entities.size()));
+
     FormRPartSimpleDto dto = dtos.get(0);
     assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
   }
 
   @Test
-  void shouldCombineAllFormRPartBsByTraineeTisId() {
-    List<FormRPartB> entities = Collections.singletonList(entity);
-    when(repositoryMock
-        .findByTraineeTisIdAndLifecycleState(DEFAULT_TRAINEE_TIS_ID, LifecycleState.DRAFT))
-        .thenReturn(entities);
-    FormRPartB cloudEntity = createEntity();
-    cloudEntity.setId(DEFAULT_FORM_ID);
-    cloudEntity.setSubmissionDate(DEFAULT_SUBMISSION_DATE);
-    cloudEntity.setLifecycleState(UNSUBMITTED);
-    List<FormRPartB> cloudStoredEntities = new ArrayList<>();
-    cloudStoredEntities.add(cloudEntity);
-    when(s3FormRPartBRepository.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(cloudStoredEntities);
-
-    List<FormRPartSimpleDto> dtos = service.getFormRPartBs();
-
-    assertThat("Unexpected numbers of forms.", dtos.size(), is(2));
-
-    FormRPartSimpleDto dto = dtos.stream()
-        .filter(f -> f.getLifecycleState() == LifecycleState.DRAFT)
-        .findAny()
-        .orElseThrow();
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
-    assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    dto = dtos.stream()
-        .filter(f -> f.getLifecycleState() == UNSUBMITTED)
-        .findAny()
-        .orElseThrow();
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_FORM_ID.toString()));
-    assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected submitted date.", dto.getSubmissionDate(), is(DEFAULT_SUBMISSION_DATE));
-    assertThat("Unexpected lifecycle state.", dto.getLifecycleState(), is(UNSUBMITTED));
-  }
-
-  @Test
-  void shouldGetFormRPartBFromCloudStorageByIdWhenOnlyCloudFormExists() {
-    entity.setForename("Cloud Only");
-    entity.setLifecycleState(UNSUBMITTED);
-
-    when(s3FormRPartBRepository.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(entity));
-
+  void shouldReturnNullGettingFormRPartBByIdWhenFormNotExists() {
     when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
         .thenReturn(Optional.empty());
 
     FormRPartBDto dto = service.getFormRPartBById(DEFAULT_ID_STRING);
 
+    assertThat("Unexpected form.", dto, nullValue());
+  }
+
+  @Test
+  void shouldGetFormRPartBByIdWhenFormExists() {
+    FormRPartB form = new FormRPartB();
+    form.setId(DEFAULT_ID);
+    form.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
+    form.setLifecycleState(UNSUBMITTED);
+
+    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(Optional.of(form));
+
+    FormRPartBDto dto = service.getFormRPartBById(DEFAULT_ID_STRING);
+
     assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected forename.", dto.getForename(), is("Cloud Only"));
-    assertThat("Unexpected surname.", dto.getSurname(), is(DEFAULT_SURNAME));
-    assertThat("Unexpected work.", dto.getWork(), is(Collections.singletonList(workDto)));
-    assertThat("Unexpected total leave.", dto.getTotalLeave(), is(DEFAULT_TOTAL_LEAVE));
-    assertThat("Unexpected isHonest flag.", dto.getIsHonest(), is(DEFAULT_IS_HONEST));
-    assertThat("Unexpected isHealthy flag.", dto.getIsHealthy(), is(DEFAULT_IS_HEALTHY));
-    assertThat("Unexpected health statement.", dto.getHealthStatement(),
-        is(DEFAULT_HEALTHY_STATEMENT));
-    assertThat("Unexpected havePreviousDeclarations flag.", dto.getHavePreviousDeclarations(),
-        is(DEFAULT_HAVE_PREVIOUS_DECLARATIONS));
-    assertThat("Unexpected previous declarations.", dto.getPreviousDeclarations(),
-        is(Collections.singletonList(previousDeclarationDto)));
-    assertThat("Unexpected previous declaration summary.", dto.getPreviousDeclarationSummary(),
-        is(DEFAULT_PREVIOUS_DECLARATION_SUMMARY));
-    assertThat("Unexpected haveCurrentDeclarations flag.", dto.getHaveCurrentDeclarations(),
-        is(DEFAULT_HAVE_CURRENT_DECLARATIONS));
-    assertThat("Unexpected current declarations.", dto.getCurrentDeclarations(),
-        is(Collections.singletonList(currentDeclarationDto)));
-    assertThat("Unexpected current declaration summary.", dto.getCurrentDeclarationSummary(),
-        is(DEFAULT_CURRENT_DECLARATION_SUMMARY));
-    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.",
-        dto.getHaveCurrentUnresolvedDeclarations(),
-        is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
-    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.",
-        dto.getHavePreviousUnresolvedDeclarations(),
-        is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
     assertThat("Unexpected status.", dto.getLifecycleState(), is(UNSUBMITTED));
-  }
-
-  @Test
-  void shouldGetFormRPartBFromDatabaseByIdWhenOnlyDatabaseFormExists() {
-    when(s3FormRPartBRepository.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.empty());
-
-    entity.setForename("Database Only");
-    entity.setLifecycleState(SUBMITTED);
-
-    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(entity));
-
-    FormRPartBDto dto = service.getFormRPartBById(DEFAULT_ID_STRING);
-
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
-    assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected forename.", dto.getForename(), is("Database Only"));
-    assertThat("Unexpected surname.", dto.getSurname(), is(DEFAULT_SURNAME));
-    assertThat("Unexpected work.", dto.getWork(), is(Collections.singletonList(workDto)));
-    assertThat("Unexpected total leave.", dto.getTotalLeave(), is(DEFAULT_TOTAL_LEAVE));
-    assertThat("Unexpected isHonest flag.", dto.getIsHonest(), is(DEFAULT_IS_HONEST));
-    assertThat("Unexpected isHealthy flag.", dto.getIsHealthy(), is(DEFAULT_IS_HEALTHY));
-    assertThat("Unexpected health statement.", dto.getHealthStatement(),
-        is(DEFAULT_HEALTHY_STATEMENT));
-    assertThat("Unexpected havePreviousDeclarations flag.", dto.getHavePreviousDeclarations(),
-        is(DEFAULT_HAVE_PREVIOUS_DECLARATIONS));
-    assertThat("Unexpected previous declarations.", dto.getPreviousDeclarations(),
-        is(Collections.singletonList(previousDeclarationDto)));
-    assertThat("Unexpected previous declaration summary.", dto.getPreviousDeclarationSummary(),
-        is(DEFAULT_PREVIOUS_DECLARATION_SUMMARY));
-    assertThat("Unexpected haveCurrentDeclarations flag.", dto.getHaveCurrentDeclarations(),
-        is(DEFAULT_HAVE_CURRENT_DECLARATIONS));
-    assertThat("Unexpected current declarations.", dto.getCurrentDeclarations(),
-        is(Collections.singletonList(currentDeclarationDto)));
-    assertThat("Unexpected current declaration summary.", dto.getCurrentDeclarationSummary(),
-        is(DEFAULT_CURRENT_DECLARATION_SUMMARY));
-    assertThat("Unexpected haveCurrentUnresolvedDeclarations flag.",
-        dto.getHaveCurrentUnresolvedDeclarations(),
-        is(DEFAULT_HAVE_CURRENT_UNRESOLVED_DECLARATIONS));
-    assertThat("Unexpected havePreviousUnresolvedDeclarations flag.",
-        dto.getHavePreviousUnresolvedDeclarations(),
-        is(DEFAULT_HAVE_PREVIOUS_UNRESOLVED_DECLARATIONS));
-    assertThat("Unexpected status.", dto.getLifecycleState(), is(SUBMITTED));
-  }
-
-  @Test
-  void shouldGetFormRPartBFromCloudStorageByIdWhenCloudFormIsLatest() {
-    FormRPartB cloudForm = new FormRPartB();
-    cloudForm.setId(DEFAULT_ID);
-    cloudForm.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    cloudForm.setForename("Cloud Latest");
-    cloudForm.setLifecycleState(UNSUBMITTED);
-    cloudForm.setLastModifiedDate(LocalDateTime.MAX);
-
-    when(s3FormRPartBRepository.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(cloudForm));
-
-    FormRPartB dbForm = new FormRPartB();
-    dbForm.setId(DEFAULT_ID);
-    dbForm.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    dbForm.setForename("Database Oldest");
-    dbForm.setLifecycleState(SUBMITTED);
-    dbForm.setLastModifiedDate(LocalDateTime.MIN);
-
-    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(dbForm));
-
-    FormRPartBDto dto = service.getFormRPartBById(DEFAULT_ID_STRING);
-
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
-    assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected forename.", dto.getForename(), is("Cloud Latest"));
-    assertThat("Unexpected status.", dto.getLifecycleState(), is(UNSUBMITTED));
-  }
-
-  @Test
-  void shouldGetFormRPartBFromDatabaseByIdWhenDatabaseFormIsLatest() {
-    FormRPartB cloudForm = new FormRPartB();
-    cloudForm.setId(DEFAULT_ID);
-    cloudForm.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    cloudForm.setForename("Cloud Oldest");
-    cloudForm.setLifecycleState(UNSUBMITTED);
-    cloudForm.setLastModifiedDate(LocalDateTime.MIN);
-
-    when(s3FormRPartBRepository.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(cloudForm));
-
-    FormRPartB dbForm = new FormRPartB();
-    dbForm.setId(DEFAULT_ID);
-    dbForm.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    dbForm.setForename("Database Latest");
-    dbForm.setLifecycleState(SUBMITTED);
-    dbForm.setLastModifiedDate(LocalDateTime.MAX);
-
-    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(dbForm));
-
-    FormRPartBDto dto = service.getFormRPartBById(DEFAULT_ID_STRING);
-
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
-    assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected forename.", dto.getForename(), is("Database Latest"));
-    assertThat("Unexpected status.", dto.getLifecycleState(), is(SUBMITTED));
-  }
-
-  @ParameterizedTest
-  @EnumSource(LifecycleState.class)
-  void shouldGetFormRPartBFromCloudByIdWhenCloudAndDatabaseEqualModifiedTime(
-      LifecycleState cloudState) {
-    LocalDateTime now = LocalDateTime.now();
-
-    FormRPartB cloudForm = new FormRPartB();
-    cloudForm.setId(DEFAULT_ID);
-    cloudForm.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    cloudForm.setForename("Cloud Equal");
-    cloudForm.setLifecycleState(cloudState);
-    cloudForm.setLastModifiedDate(now);
-
-    when(s3FormRPartBRepository.findByIdAndTraineeTisId(DEFAULT_ID_STRING, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(cloudForm));
-
-    FormRPartB dbForm = new FormRPartB();
-    dbForm.setId(DEFAULT_ID);
-    dbForm.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
-    dbForm.setForename("Database Equal");
-    dbForm.setLifecycleState(SUBMITTED);
-    dbForm.setLastModifiedDate(now);
-
-    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
-        .thenReturn(Optional.of(dbForm));
-
-    FormRPartBDto dto = service.getFormRPartBById(DEFAULT_ID_STRING);
-
-    assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
-    assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
-    assertThat("Unexpected forename.", dto.getForename(), is("Cloud Equal"));
-    assertThat("Unexpected status.", dto.getLifecycleState(), is(cloudState));
   }
 
   @Test


### PR DESCRIPTION
When a trainee's forms are retrieved the S3 and DB forms are combined, now that S3 is no longer required for admin access to forms the GET requests should be answered fully from the database.

The current set-up has caused some issues with historical data, where unsubmitted forms were never updated in the database. By cutting S3 out, we can ensure that the trainee has a consistent experience. However, some forms may appear to "rollback" to the unsubmitted state - but this only applies where a form was unsubmitted and never updated afterwards.

NO-TICKET