### PR TITLE
feat: refresh jobs take 'since' parameter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.66.0"
+version = "0.67.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/JobResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/JobResourceIntegrationTest.java
@@ -1,0 +1,347 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.DELETED;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.DRAFT;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMITTED;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.UNSUBMITTED;
+
+import io.awspring.cloud.sns.core.SnsTemplate;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import uk.nhs.hee.tis.trainee.forms.DockerImageNames;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status.StatusInfo;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
+import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
+import uk.nhs.hee.tis.trainee.forms.repository.S3FormRPartARepositoryImpl;
+import uk.nhs.hee.tis.trainee.forms.service.PdfService;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@AutoConfigureMockMvc
+class JobResourceIntegrationTest {
+
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate template;
+
+  @MockitoBean
+  private SnsTemplate snsTemplate;
+
+  @MockitoBean
+  private SnsClient snsClient;
+
+  @MockitoBean
+  private S3FormRPartARepositoryImpl s3FormRPartARepository;
+
+  @MockitoBean
+  private PdfService pdfService;
+
+  @AfterEach
+  void tearDown() {
+    template.findAllAndRemove(new Query(), FormRPartA.class);
+    template.findAllAndRemove(new Query(), FormRPartB.class);
+    template.findAllAndRemove(new Query(), LtftForm.class);
+  }
+
+  // Form-R Part A refresh
+
+  @Test
+  void shouldReturnZeroWhenNoFormRPartAsExistForRefresh() throws Exception {
+    MvcResult result = mockMvc.perform(post("/api/job/formr-parta/publish-refresh"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andReturn();
+
+    assertThat("Unexpected publish count.", result.getResponse().getContentAsString(), is("0"));
+    verifyNoInteractions(snsClient);
+  }
+
+  @Test
+  void shouldPublishAllEligibleFormRPartAsWhenNoSinceDateProvided() throws Exception {
+    insertFormRPartA(UUID.randomUUID(), SUBMITTED, LocalDateTime.now().minusDays(10));
+    insertFormRPartA(UUID.randomUUID(), UNSUBMITTED, LocalDateTime.now().minusDays(5));
+    insertFormRPartA(UUID.randomUUID(), DELETED, LocalDateTime.now().minusDays(3));
+    // DRAFT should not be published
+    insertFormRPartA(UUID.randomUUID(), DRAFT, LocalDateTime.now());
+
+    MvcResult result = mockMvc.perform(post("/api/job/formr-parta/publish-refresh"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    assertThat("Unexpected publish count.", result.getResponse().getContentAsString(), is("3"));
+    verify(snsClient, times(3)).publish(any(PublishRequest.class));
+  }
+
+  @Test
+  void shouldPublishOnlyFormRPartAsModifiedOnOrAfterSinceDate() throws Exception {
+    LocalDate since = LocalDate.now().minusDays(7);
+
+    // Modified after cutoff — should be published
+    insertFormRPartA(UUID.randomUUID(), SUBMITTED, LocalDateTime.now().minusDays(3));
+    // Modified on the cutoff boundary — should be published
+    insertFormRPartA(UUID.randomUUID(), UNSUBMITTED, since.atStartOfDay());
+    // Modified before cutoff — should NOT be published
+    insertFormRPartA(UUID.randomUUID(), SUBMITTED, LocalDateTime.now().minusDays(14));
+    // DRAFT should never be published regardless of date
+    insertFormRPartA(UUID.randomUUID(), DRAFT, LocalDateTime.now());
+
+    MvcResult result = mockMvc.perform(post("/api/job/formr-parta/publish-refresh")
+            .param("since", since.toString()))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    assertThat("Unexpected publish count.", result.getResponse().getContentAsString(), is("2"));
+    verify(snsClient, times(2)).publish(any(PublishRequest.class));
+  }
+
+  @Test
+  void shouldPublishFormRPartAAndIncludeFormTypeMessageAttribute() throws Exception {
+    insertFormRPartA(UUID.randomUUID(), SUBMITTED, LocalDateTime.now());
+
+    mockMvc.perform(post("/api/job/formr-parta/publish-refresh"))
+        .andExpect(status().isOk());
+
+    ArgumentCaptor<PublishRequest> captor = ArgumentCaptor.forClass(PublishRequest.class);
+    verify(snsClient).publish(captor.capture());
+
+    PublishRequest request = captor.getValue();
+    assertThat("Unexpected formType message attribute.",
+        request.messageAttributes().get("formType").stringValue(), is("formr-a"));
+  }
+
+  // Form-R Part B refresh
+
+  @Test
+  void shouldReturnZeroWhenNoFormRPartBsExistForRefresh() throws Exception {
+    MvcResult result = mockMvc.perform(post("/api/job/formr-partb/publish-refresh"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andReturn();
+
+    assertThat("Unexpected publish count.", result.getResponse().getContentAsString(), is("0"));
+    verifyNoInteractions(snsClient);
+  }
+
+  @Test
+  void shouldPublishAllEligibleFormRPartBsWhenNoSinceDateProvided() throws Exception {
+    insertFormRPartB(UUID.randomUUID(), SUBMITTED, LocalDateTime.now().minusDays(10));
+    insertFormRPartB(UUID.randomUUID(), UNSUBMITTED, LocalDateTime.now().minusDays(5));
+    insertFormRPartB(UUID.randomUUID(), DELETED, LocalDateTime.now().minusDays(3));
+    // DRAFT should not be published
+    insertFormRPartB(UUID.randomUUID(), DRAFT, LocalDateTime.now());
+
+    MvcResult result = mockMvc.perform(post("/api/job/formr-partb/publish-refresh"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    assertThat("Unexpected publish count.", result.getResponse().getContentAsString(), is("3"));
+    verify(snsClient, times(3)).publish(any(PublishRequest.class));
+  }
+
+  @Test
+  void shouldPublishOnlyFormRPartBsModifiedOnOrAfterSinceDate() throws Exception {
+    LocalDate since = LocalDate.now().minusDays(7);
+
+    // Modified after cutoff — should be published
+    insertFormRPartB(UUID.randomUUID(), SUBMITTED, LocalDateTime.now().minusDays(3));
+    // Modified on the cutoff boundary — should be published
+    insertFormRPartB(UUID.randomUUID(), UNSUBMITTED, since.atStartOfDay());
+    // Modified before cutoff — should NOT be published
+    insertFormRPartB(UUID.randomUUID(), SUBMITTED, LocalDateTime.now().minusDays(14));
+    // DRAFT should never be published regardless of date
+    insertFormRPartB(UUID.randomUUID(), DRAFT, LocalDateTime.now());
+
+    MvcResult result = mockMvc.perform(post("/api/job/formr-partb/publish-refresh")
+            .param("since", since.toString()))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    assertThat("Unexpected publish count.", result.getResponse().getContentAsString(), is("2"));
+    verify(snsClient, times(2)).publish(any(PublishRequest.class));
+  }
+
+  @Test
+  void shouldPublishFormRPartBAndIncludeFormTypeMessageAttribute() throws Exception {
+    insertFormRPartB(UUID.randomUUID(), SUBMITTED, LocalDateTime.now());
+
+    mockMvc.perform(post("/api/job/formr-partb/publish-refresh"))
+        .andExpect(status().isOk());
+
+    ArgumentCaptor<PublishRequest> captor = ArgumentCaptor.forClass(PublishRequest.class);
+    verify(snsClient).publish(captor.capture());
+
+    PublishRequest request = captor.getValue();
+    assertThat("Unexpected formType message attribute.",
+        request.messageAttributes().get("formType").stringValue(), is("formr-b"));
+  }
+
+  // LTFT refresh
+
+  @Test
+  void shouldReturnZeroWhenNoLtftsExistForRefresh() throws Exception {
+    MvcResult result = mockMvc.perform(post("/api/job/ltft/publish-refresh"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andReturn();
+
+    assertThat("Unexpected publish count.", result.getResponse().getContentAsString(), is("0"));
+    verifyNoInteractions(snsClient);
+  }
+
+  @Test
+  void shouldPublishAllEligibleLtftsWhenNoSinceDateProvided() throws Exception {
+    insertLtftForm(UUID.randomUUID(), SUBMITTED, Instant.now().minusSeconds(864000));
+    insertLtftForm(UUID.randomUUID(), UNSUBMITTED, Instant.now().minusSeconds(432000));
+    insertLtftForm(UUID.randomUUID(), DELETED, Instant.now().minusSeconds(259200));
+    // DRAFT should not be published
+    insertLtftForm(UUID.randomUUID(), DRAFT, Instant.now());
+
+    MvcResult result = mockMvc.perform(post("/api/job/ltft/publish-refresh"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    assertThat("Unexpected publish count.", result.getResponse().getContentAsString(), is("3"));
+    verify(snsClient, times(3)).publish(any(PublishRequest.class));
+  }
+
+  @Test
+  void shouldPublishOnlyLtftsModifiedOnOrAfterSinceDate() throws Exception {
+    LocalDate since = LocalDate.now().minusDays(7);
+    Instant cutoff = since.atStartOfDay(java.time.ZoneOffset.UTC).toInstant();
+
+    // Modified after cutoff — should be published
+    insertLtftForm(UUID.randomUUID(), SUBMITTED, Instant.now().minusSeconds(259200));
+    // Modified on the cutoff boundary — should be published
+    insertLtftForm(UUID.randomUUID(), UNSUBMITTED, cutoff);
+    // Modified before cutoff — should NOT be published
+    insertLtftForm(UUID.randomUUID(), SUBMITTED, Instant.now().minusSeconds(1728000));
+    // DRAFT should never be published regardless of date
+    insertLtftForm(UUID.randomUUID(), DRAFT, Instant.now());
+
+    MvcResult result = mockMvc.perform(post("/api/job/ltft/publish-refresh")
+            .param("since", since.toString()))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    assertThat("Unexpected publish count.", result.getResponse().getContentAsString(), is("2"));
+    verify(snsClient, times(2)).publish(any(PublishRequest.class));
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private void insertFormRPartA(UUID id, LifecycleState state, LocalDateTime lastModifiedDate) {
+    FormRPartA form = new FormRPartA();
+    form.setId(id);
+    form.setTraineeTisId(TRAINEE_ID);
+    form.setLifecycleState(state);
+    form.setLastModifiedDate(lastModifiedDate);
+    if (state == SUBMITTED || state == UNSUBMITTED || state == DELETED) {
+      form.setSubmissionDate(lastModifiedDate != null ? lastModifiedDate : LocalDateTime.now());
+    }
+    template.insert(form);
+  }
+
+  private void insertFormRPartB(UUID id, LifecycleState state, LocalDateTime lastModifiedDate) {
+    FormRPartB form = new FormRPartB();
+    form.setId(id);
+    form.setTraineeTisId(TRAINEE_ID);
+    form.setLifecycleState(state);
+    form.setLastModifiedDate(lastModifiedDate);
+    if (state == SUBMITTED || state == UNSUBMITTED || state == DELETED) {
+      form.setSubmissionDate(lastModifiedDate != null ? lastModifiedDate : LocalDateTime.now());
+    }
+    template.insert(form);
+  }
+
+  private void insertLtftForm(UUID id, LifecycleState state, Instant lastModified) {
+    LtftForm form = new LtftForm();
+    form.setId(id);
+    form.setTraineeTisId(TRAINEE_ID);
+
+    StatusInfo statusInfo = StatusInfo.builder()
+        .state(state)
+        .timestamp(lastModified)
+        .build();
+    Status status = Status.builder()
+        .current(statusInfo)
+        .history(java.util.List.of(statusInfo))
+        .build();
+    form.setStatus(status);
+
+    // Directly set the lastModified audit field via MongoTemplate
+    // by inserting and then updating the document
+    template.insert(form);
+    template.updateFirst(
+        org.springframework.data.mongodb.core.query.Query.query(
+            org.springframework.data.mongodb.core.query.Criteria.where("_id").is(id)),
+        new org.springframework.data.mongodb.core.query.Update().set("lastModified", lastModified),
+        LtftForm.class);
+  }
+}
+

--- a/src/integrationTest/resources/application-test.yml
+++ b/src/integrationTest/resources/application-test.yml
@@ -4,12 +4,16 @@ application:
   aws:
     sns:
       formr-file-event: dummy
+      formr-refresh: dummy-formr-refresh
       formr-updated: dummy
+      ltft-refresh: dummy-ltft-refresh
     sqs:
       coj-received: dummy
       notification-event: dummy
       profile-move: dummy
   schedules:
+    publish-all-formr-partas: "-"
+    publish-all-formr-partbs: "-"
     publish-all-ltfts: "-"
 
 mongock:

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/JobResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/JobResource.java
@@ -23,10 +23,13 @@
 package uk.nhs.hee.tis.trainee.forms.api;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
+import java.time.LocalDate;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.tis.trainee.forms.job.PublishFormrPartaRefresh;
 import uk.nhs.hee.tis.trainee.forms.job.PublishFormrPartbRefresh;
@@ -63,36 +66,50 @@ public class JobResource {
   /**
    * Publish all exportable Form-R Part A records as a refresh.
    *
+   * @param since An optional cutoff start date; only forms last modified on or after this date will
+   *              be published. If absent, all forms are published.
    * @return The number of exported Form-R Part A records.
    */
   @PostMapping("/formr-parta/publish-refresh")
-  public ResponseEntity<Integer> publishFormrPartaRefresh() {
-    log.info("Received request to publish Form-R Part A refresh.");
-    int publishCount = publishFormrPartaRefreshJob.execute();
+  public ResponseEntity<Integer> publishFormrPartaRefresh(
+      @RequestParam Optional<LocalDate> since) {
+    since.ifPresentOrElse(
+        date -> log.info("Received request to publish Form-R Part A refresh since {}.", date),
+        () -> log.info("Received request to publish Form-R Part A refresh."));
+    int publishCount = publishFormrPartaRefreshJob.execute(since);
     return ResponseEntity.ok(publishCount);
   }
 
   /**
    * Publish all exportable Form-R Part B records as a refresh.
    *
+   * @param since An optional cutoff start date; only forms last modified on or after this date will
+   *              be published. If absent, all forms are published.
    * @return The number of exported Form-R Part B records.
    */
   @PostMapping("/formr-partb/publish-refresh")
-  public ResponseEntity<Integer> publishFormrPartbRefresh() {
-    log.info("Received request to publish Form-R Part B refresh.");
-    int publishCount = publishFormrPartbRefreshJob.execute();
+  public ResponseEntity<Integer> publishFormrPartbRefresh(
+      @RequestParam Optional<LocalDate> since) {
+    since.ifPresentOrElse(
+        date -> log.info("Received request to publish Form-R Part B refresh since {}.", date),
+        () -> log.info("Received request to publish Form-R Part B refresh."));
+    int publishCount = publishFormrPartbRefreshJob.execute(since);
     return ResponseEntity.ok(publishCount);
   }
 
   /**
    * Publish all exportable LTFT records as a refresh.
    *
+   * @param since An optional cutoff start date; only forms last modified on or after this date will
+   *              be published. If absent, all forms are published.
    * @return The number of exported LTFT records.
    */
   @PostMapping("/ltft/publish-refresh")
-  public ResponseEntity<Integer> publishLtftRefresh() {
-    log.info("Received request to publish LTFT refresh.");
-    int publishCount = publishLtftRefreshJob.execute();
+  public ResponseEntity<Integer> publishLtftRefresh(@RequestParam Optional<LocalDate> since) {
+    since.ifPresentOrElse(
+        date -> log.info("Received request to publish LTFT refresh since {}.", date),
+        () -> log.info("Received request to publish LTFT refresh."));
+    int publishCount = publishLtftRefreshJob.execute(since);
     return ResponseEntity.ok(publishCount);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/job/AbstractPublishRefresh.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/job/AbstractPublishRefresh.java
@@ -22,6 +22,8 @@
 
 package uk.nhs.hee.tis.trainee.forms.job;
 
+import java.time.LocalDate;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
@@ -54,9 +56,11 @@ public abstract class AbstractPublishRefresh<T> {
   /**
    * Get the forms to be refreshed, should also apply any relevant filtering.
    *
+   * @param cutoffDate An optional cutoff start date; only forms last modified on or after this date
+   *                   will be included. If empty, all forms are included.
    * @return The filtered list of forms to be refreshed.
    */
-  protected abstract Stream<T> streamForms();
+  protected abstract Stream<T> streamForms(Optional<LocalDate> cutoffDate);
 
   /**
    * Refresh the given form by publishing to an event topic.
@@ -66,18 +70,20 @@ public abstract class AbstractPublishRefresh<T> {
   protected abstract void publishForm(T form);
 
   /**
-   * Execute the job to publish all exportable forms a refresh.
+   * Execute the job to publish all exportable forms as a refresh.
    *
+   * @param cutoffDate An optional cutoff start date; only forms last modified on or after this date
+   *                   will be refreshed. If empty, all forms are refreshed.
    * @return The number of published forms.
    */
-  protected Integer execute() {
+  protected Integer execute(Optional<LocalDate> cutoffDate) {
     String formType = getFormTypeName();
     log.info("Starting {} downstream refresh.", formType);
 
     AtomicInteger total = new AtomicInteger();
     AtomicInteger published = new AtomicInteger();
 
-    streamForms()
+    streamForms(cutoffDate)
         .forEach(
             form -> {
               total.getAndIncrement();
@@ -95,5 +101,14 @@ public abstract class AbstractPublishRefresh<T> {
 
     log.info("Finished {} downstream refresh, published count: {}/{}.", formType, published, total);
     return published.get();
+  }
+
+  /**
+   * Execute the job to publish all exportable forms as a refresh with no date cutoff.
+   *
+   * @return The number of published forms.
+   */
+  protected Integer execute() {
+    return execute(Optional.empty());
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/job/PublishFormrPartaRefresh.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/job/PublishFormrPartaRefresh.java
@@ -115,6 +115,7 @@ public class PublishFormrPartaRefresh extends AbstractPublishRefresh<FormRPartA>
    *                   will be refreshed. If empty, all forms are refreshed.
    * @return The number of published forms.
    */
+  @SchedulerLock(name = "PublishFormrPartaRefresh.execute")
   @Override
   public Integer execute(Optional<LocalDate> cutoffDate) {
     return super.execute(cutoffDate);

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/job/PublishFormrPartaRefresh.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/job/PublishFormrPartaRefresh.java
@@ -27,6 +27,8 @@ import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMIT
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.UNSUBMITTED;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
+import java.time.LocalDate;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -35,6 +37,7 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.mapper.FormRPartAMapper;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
 import uk.nhs.hee.tis.trainee.forms.repository.FormRPartARepository;
@@ -80,13 +83,14 @@ public class PublishFormrPartaRefresh extends AbstractPublishRefresh<FormRPartA>
   }
 
   @Override
-  public Stream<FormRPartA> streamForms() {
+  public Stream<FormRPartA> streamForms(Optional<LocalDate> cutoffDate) {
+    Set<LifecycleState> states = Set.of(DELETED, SUBMITTED, UNSUBMITTED);
     // Listing allowed (non-DRAFT) states avoids any accidental inclusions of future states.
-    return repository.streamByLifecycleStateIn(Set.of(
-        DELETED,
-        SUBMITTED,
-        UNSUBMITTED
-    ));
+    if (cutoffDate.isPresent()) {
+      return repository.streamByLifecycleStateInAndLastModifiedDateGreaterThanEqual(
+          states, cutoffDate.get().atStartOfDay());
+    }
+    return repository.streamByLifecycleStateIn(states);
   }
 
   @Override
@@ -102,5 +106,17 @@ public class PublishFormrPartaRefresh extends AbstractPublishRefresh<FormRPartA>
   @Override
   public Integer execute() {
     return super.execute();
+  }
+
+  /**
+   * Execute the job to publish exportable Form-R Part A applications as a refresh.
+   *
+   * @param cutoffDate An optional cutoff start date; only forms last modified on or after this date
+   *                   will be refreshed. If empty, all forms are refreshed.
+   * @return The number of published forms.
+   */
+  @Override
+  public Integer execute(Optional<LocalDate> cutoffDate) {
+    return super.execute(cutoffDate);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/job/PublishFormrPartbRefresh.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/job/PublishFormrPartbRefresh.java
@@ -115,6 +115,7 @@ public class PublishFormrPartbRefresh extends AbstractPublishRefresh<FormRPartB>
    *                   will be refreshed. If empty, all forms are refreshed.
    * @return The number of published forms.
    */
+  @SchedulerLock(name = "PublishFormrPartbRefresh.execute")
   @Override
   public Integer execute(Optional<LocalDate> cutoffDate) {
     return super.execute(cutoffDate);

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/job/PublishFormrPartbRefresh.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/job/PublishFormrPartbRefresh.java
@@ -27,6 +27,8 @@ import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMIT
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.UNSUBMITTED;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
+import java.time.LocalDate;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -35,6 +37,7 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.mapper.FormRPartBMapper;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
 import uk.nhs.hee.tis.trainee.forms.repository.FormRPartBRepository;
@@ -80,13 +83,14 @@ public class PublishFormrPartbRefresh extends AbstractPublishRefresh<FormRPartB>
   }
 
   @Override
-  public Stream<FormRPartB> streamForms() {
+  public Stream<FormRPartB> streamForms(Optional<LocalDate> cutoffDate) {
+    Set<LifecycleState> states = Set.of(DELETED, SUBMITTED, UNSUBMITTED);
     // Listing allowed (non-DRAFT) states avoids any accidental inclusions of future states.
-    return repository.streamByLifecycleStateIn(Set.of(
-        DELETED,
-        SUBMITTED,
-        UNSUBMITTED
-    ));
+    if (cutoffDate.isPresent()) {
+      return repository.streamByLifecycleStateInAndLastModifiedDateGreaterThanEqual(
+          states, cutoffDate.get().atStartOfDay());
+    }
+    return repository.streamByLifecycleStateIn(states);
   }
 
   @Override
@@ -102,5 +106,17 @@ public class PublishFormrPartbRefresh extends AbstractPublishRefresh<FormRPartB>
   @Override
   public Integer execute() {
     return super.execute();
+  }
+
+  /**
+   * Execute the job to publish exportable Form-R Part B applications as a refresh.
+   *
+   * @param cutoffDate An optional cutoff start date; only forms last modified on or after this date
+   *                   will be refreshed. If empty, all forms are refreshed.
+   * @return The number of published forms.
+   */
+  @Override
+  public Integer execute(Optional<LocalDate> cutoffDate) {
+    return super.execute(cutoffDate);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/job/PublishLtftRefresh.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/job/PublishLtftRefresh.java
@@ -29,6 +29,10 @@ import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.UNSUBM
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.WITHDRAWN;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -37,6 +41,7 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 import uk.nhs.hee.tis.trainee.forms.repository.LtftFormRepository;
 import uk.nhs.hee.tis.trainee.forms.service.LtftService;
@@ -79,16 +84,16 @@ public class PublishLtftRefresh extends AbstractPublishRefresh<LtftForm> {
   }
 
   @Override
-  public Stream<LtftForm> streamForms() {
+  public Stream<LtftForm> streamForms(Optional<LocalDate> cutoffDate) {
+    Set<LifecycleState> states = Set.of(APPROVED, DELETED, REJECTED, SUBMITTED, UNSUBMITTED,
+        WITHDRAWN);
     // Listing allowed (non-DRAFT) states avoids any accidental inclusions of future states.
-    return repository.streamByStatus_Current_StateIn(Set.of(
-        APPROVED,
-        DELETED,
-        REJECTED,
-        SUBMITTED,
-        UNSUBMITTED,
-        WITHDRAWN
-    ));
+    if (cutoffDate.isPresent()) {
+      Instant cutoff = cutoffDate.get().atStartOfDay(ZoneOffset.UTC).toInstant();
+      return repository.streamByStatus_Current_StateInAndLastModifiedGreaterThanEqual(
+          states, cutoff);
+    }
+    return repository.streamByStatus_Current_StateIn(states);
   }
 
   @Override
@@ -104,5 +109,17 @@ public class PublishLtftRefresh extends AbstractPublishRefresh<LtftForm> {
   @Override
   public Integer execute() {
     return super.execute();
+  }
+
+  /**
+   * Execute the job to publish exportable LTFT applications as a refresh.
+   *
+   * @param cutoffDate An optional cutoff start date; only forms last modified on or after this date
+   *                   will be refreshed. If empty, all forms are refreshed.
+   * @return The number of published forms.
+   */
+  @Override
+  public Integer execute(Optional<LocalDate> cutoffDate) {
+    return super.execute(cutoffDate);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/job/PublishLtftRefresh.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/job/PublishLtftRefresh.java
@@ -118,6 +118,7 @@ public class PublishLtftRefresh extends AbstractPublishRefresh<LtftForm> {
    *                   will be refreshed. If empty, all forms are refreshed.
    * @return The number of published forms.
    */
+  @SchedulerLock(name = "PublishLtftRefresh.execute")
   @Override
   public Integer execute(Optional<LocalDate> cutoffDate) {
     return super.execute(cutoffDate);

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartARepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartARepository.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.forms.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -58,4 +59,14 @@ public interface FormRPartARepository extends MongoRepository<FormRPartA, UUID> 
    * @return The found forms, empty if none found.
    */
   Stream<FormRPartA> streamByLifecycleStateIn(Set<LifecycleState> states);
+
+  /**
+   * Stream all Form-R Part As with the given states and last modified on or after the cutoff.
+   *
+   * @param states             The states to filter by.
+   * @param lastModifiedCutoff The cutoff date/time; only forms modified on or after are included.
+   * @return The found forms, empty if none found.
+   */
+  Stream<FormRPartA> streamByLifecycleStateInAndLastModifiedDateGreaterThanEqual(
+      Set<LifecycleState> states, LocalDateTime lastModifiedCutoff);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartBRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartBRepository.java
@@ -20,6 +20,7 @@
 
 package uk.nhs.hee.tis.trainee.forms.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -57,4 +58,14 @@ public interface FormRPartBRepository extends MongoRepository<FormRPartB, UUID> 
    * @return The found forms, empty if none found.
    */
   Stream<FormRPartB> streamByLifecycleStateIn(Set<LifecycleState> states);
+
+  /**
+   * Stream all Form-R Part Bs with the given states and last modified on or after the cutoff.
+   *
+   * @param states             The states to filter by.
+   * @param lastModifiedCutoff The cutoff date/time; only forms modified on or after are included.
+   * @return The found forms, empty if none found.
+   */
+  Stream<FormRPartB> streamByLifecycleStateInAndLastModifiedDateGreaterThanEqual(
+      Set<LifecycleState> states, LocalDateTime lastModifiedCutoff);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.forms.repository;
 
 import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -70,6 +71,16 @@ public interface LtftFormRepository extends MongoRepository<LtftForm, UUID> {
    * @return The found forms, empty if none found.
    */
   Stream<LtftForm> streamByStatus_Current_StateIn(Set<LifecycleState> states);
+
+  /**
+   * Stream all LTFT forms with the given states and last modified on or after the cutoff.
+   *
+   * @param states             The states to filter by.
+   * @param lastModifiedCutoff The cutoff instant; only forms modified on or after are included.
+   * @return The found forms, empty if none found.
+   */
+  Stream<LtftForm> streamByStatus_Current_StateInAndLastModifiedGreaterThanEqual(
+      Set<LifecycleState> states, Instant lastModifiedCutoff);
 
   /**
    * Find the LTFT form with the given ID and one of the given DBCs.

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/JobResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/JobResourceTest.java
@@ -28,6 +28,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.OK;
 
+import java.time.LocalDate;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
@@ -53,32 +55,65 @@ class JobResourceTest {
   }
 
   @Test
-  void shouldPublishFormrPartaRefresh() {
-    when(publishFormrPartaRefreshJob.execute()).thenReturn(3);
+  void shouldPublishFormrPartaRefreshWithNoDate() {
+    when(publishFormrPartaRefreshJob.execute(Optional.empty())).thenReturn(3);
 
-    ResponseEntity<Integer> response = controller.publishFormrPartaRefresh();
+    ResponseEntity<Integer> response = controller.publishFormrPartaRefresh(Optional.empty());
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
     assertThat("Unexpected response body.", response.getBody(), is(3));
   }
 
   @Test
-  void shouldPublishFormrPartbRefresh() {
-    when(publishFormrPartbRefreshJob.execute()).thenReturn(4);
+  void shouldPublishFormrPartaRefreshWithDate() {
+    LocalDate since = LocalDate.of(2025, 1, 1);
+    when(publishFormrPartaRefreshJob.execute(Optional.of(since))).thenReturn(2);
 
-    ResponseEntity<Integer> response = controller.publishFormrPartbRefresh();
+    ResponseEntity<Integer> response = controller.publishFormrPartaRefresh(Optional.of(since));
+
+    assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
+    assertThat("Unexpected response body.", response.getBody(), is(2));
+  }
+
+  @Test
+  void shouldPublishFormrPartbRefreshWithNoDate() {
+    when(publishFormrPartbRefreshJob.execute(Optional.empty())).thenReturn(4);
+
+    ResponseEntity<Integer> response = controller.publishFormrPartbRefresh(Optional.empty());
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
     assertThat("Unexpected response body.", response.getBody(), is(4));
   }
 
   @Test
-  void shouldPublishLtftRefresh() {
-    when(publishLtftRefreshJob.execute()).thenReturn(5);
+  void shouldPublishFormrPartbRefreshWithDate() {
+    LocalDate since = LocalDate.of(2025, 1, 1);
+    when(publishFormrPartbRefreshJob.execute(Optional.of(since))).thenReturn(2);
 
-    ResponseEntity<Integer> response = controller.publishLtftRefresh();
+    ResponseEntity<Integer> response = controller.publishFormrPartbRefresh(Optional.of(since));
+
+    assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
+    assertThat("Unexpected response body.", response.getBody(), is(2));
+  }
+
+  @Test
+  void shouldPublishLtftRefreshWithNoDate() {
+    when(publishLtftRefreshJob.execute(Optional.empty())).thenReturn(5);
+
+    ResponseEntity<Integer> response = controller.publishLtftRefresh(Optional.empty());
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
     assertThat("Unexpected response body.", response.getBody(), is(5));
+  }
+
+  @Test
+  void shouldPublishLtftRefreshWithDate() {
+    LocalDate since = LocalDate.of(2025, 1, 1);
+    when(publishLtftRefreshJob.execute(Optional.of(since))).thenReturn(3);
+
+    ResponseEntity<Integer> response = controller.publishLtftRefresh(Optional.of(since));
+
+    assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
+    assertThat("Unexpected response body.", response.getBody(), is(3));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/job/PublishFormrPartaRefreshTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/job/PublishFormrPartaRefreshTest.java
@@ -36,6 +36,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Objects;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -74,7 +77,17 @@ class PublishFormrPartaRefreshTest {
   void shouldNotPublishWhenNoFormrPartasFound() {
     when(repository.streamByLifecycleStateIn(any())).thenReturn(Stream.of());
 
-    job.execute();
+    job.execute(Optional.empty());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void shouldNotPublishWhenNoFormrPartasFoundWithCutoffDate() {
+    when(repository.streamByLifecycleStateInAndLastModifiedDateGreaterThanEqual(any(),
+        any())).thenReturn(Stream.of());
+
+    job.execute(Optional.of(LocalDate.of(2025, 1, 1)));
 
     verifyNoInteractions(service);
   }
@@ -83,22 +96,43 @@ class PublishFormrPartaRefreshTest {
   @EnumSource(value = LifecycleState.class, mode = Mode.EXCLUDE, names = {"APPROVED", "DRAFT",
       "REJECTED", "WITHDRAWN"})
   void shouldNotPublishDraftFormrPartas(LifecycleState state) {
-    UUID id1 = UUID.randomUUID();
-    FormRPartA form1 = new FormRPartA();
-    form1.setId(id1);
-
-    UUID id2 = UUID.randomUUID();
-    FormRPartA form2 = new FormRPartA();
-    form2.setId(id2);
-
     ArgumentCaptor<Set<LifecycleState>> statesCaptor = ArgumentCaptor.captor();
     when(repository.streamByLifecycleStateIn(statesCaptor.capture())).thenReturn(Stream.of());
 
-    job.execute();
+    job.execute(Optional.empty());
 
     Set<LifecycleState> states = statesCaptor.getValue();
     assertThat("Unexpected state query count.", states, hasSize(3));
     assertThat("Unexpected state in query.", states, hasItem(state));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = Mode.EXCLUDE, names = {"APPROVED", "DRAFT",
+      "REJECTED", "WITHDRAWN"})
+  void shouldNotPublishDraftFormrPartasWithCutoffDate(LifecycleState state) {
+    LocalDate since = LocalDate.of(2025, 1, 1);
+    ArgumentCaptor<Set<LifecycleState>> statesCaptor = ArgumentCaptor.captor();
+    when(repository.streamByLifecycleStateInAndLastModifiedDateGreaterThanEqual(
+        statesCaptor.capture(), any())).thenReturn(Stream.of());
+
+    job.execute(Optional.of(since));
+
+    Set<LifecycleState> states = statesCaptor.getValue();
+    assertThat("Unexpected state query count.", states, hasSize(3));
+    assertThat("Unexpected state in query.", states, hasItem(state));
+  }
+
+  @Test
+  void shouldUseCutoffDateWhenProvided() {
+    LocalDate since = LocalDate.of(2025, 6, 15);
+    ArgumentCaptor<LocalDateTime> cutoffCaptor = ArgumentCaptor.captor();
+    when(repository.streamByLifecycleStateInAndLastModifiedDateGreaterThanEqual(any(),
+        cutoffCaptor.capture())).thenReturn(Stream.of());
+
+    job.execute(Optional.of(since));
+
+    assertThat("Unexpected cutoff date.", cutoffCaptor.getValue(),
+        is(since.atStartOfDay()));
   }
 
   @Test
@@ -113,12 +147,27 @@ class PublishFormrPartaRefreshTest {
 
     when(repository.streamByLifecycleStateIn(any())).thenReturn(Stream.of(form1, form2));
 
-    int publishCount = job.execute();
+    int publishCount = job.execute(Optional.empty());
 
     assertThat("Unexpected published Form-R count.", publishCount, is(2));
 
     verify(service).publishUpdateNotification(argThat(hasId(id1)), eq(PUBLISH_TOPIC));
     verify(service).publishUpdateNotification(argThat(hasId(id2)), eq(PUBLISH_TOPIC));
+  }
+
+  @Test
+  void shouldPublishAllFoundFormrPartasWithCutoffDate() {
+    UUID id1 = UUID.randomUUID();
+    FormRPartA form1 = new FormRPartA();
+    form1.setId(id1);
+
+    when(repository.streamByLifecycleStateInAndLastModifiedDateGreaterThanEqual(any(),
+        any())).thenReturn(Stream.of(form1));
+
+    int publishCount = job.execute(Optional.of(LocalDate.of(2025, 1, 1)));
+
+    assertThat("Unexpected published Form-R count.", publishCount, is(1));
+    verify(service).publishUpdateNotification(argThat(hasId(id1)), eq(PUBLISH_TOPIC));
   }
 
   @Test
@@ -135,7 +184,7 @@ class PublishFormrPartaRefreshTest {
     doThrow(RuntimeException.class).when(service)
         .publishUpdateNotification(argThat(hasId(id1)), eq(PUBLISH_TOPIC));
 
-    int publishCount = job.execute();
+    int publishCount = job.execute(Optional.empty());
 
     assertThat("Unexpected published Form-R count.", publishCount, is(1));
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/job/PublishFormrPartbRefreshTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/job/PublishFormrPartbRefreshTest.java
@@ -36,6 +36,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Objects;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -81,7 +84,17 @@ class PublishFormrPartbRefreshTest {
   void shouldNotPublishWhenNoFormrPartbsFound() {
     when(repository.streamByLifecycleStateIn(any())).thenReturn(Stream.of());
 
-    job.execute();
+    job.execute(Optional.empty());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void shouldNotPublishWhenNoFormrPartbsFoundWithCutoffDate() {
+    when(repository.streamByLifecycleStateInAndLastModifiedDateGreaterThanEqual(any(),
+        any())).thenReturn(Stream.of());
+
+    job.execute(Optional.of(LocalDate.of(2025, 1, 1)));
 
     verifyNoInteractions(service);
   }
@@ -90,22 +103,42 @@ class PublishFormrPartbRefreshTest {
   @EnumSource(value = LifecycleState.class, mode = Mode.EXCLUDE, names = {"APPROVED", "DRAFT",
       "REJECTED", "WITHDRAWN"})
   void shouldNotPublishDraftFormrPartbs(LifecycleState state) {
-    UUID id1 = UUID.randomUUID();
-    FormRPartB form1 = new FormRPartB();
-    form1.setId(id1);
-
-    UUID id2 = UUID.randomUUID();
-    FormRPartB form2 = new FormRPartB();
-    form2.setId(id2);
-
     ArgumentCaptor<Set<LifecycleState>> statesCaptor = ArgumentCaptor.captor();
     when(repository.streamByLifecycleStateIn(statesCaptor.capture())).thenReturn(Stream.of());
 
-    job.execute();
+    job.execute(Optional.empty());
 
     Set<LifecycleState> states = statesCaptor.getValue();
     assertThat("Unexpected state query count.", states, hasSize(3));
     assertThat("Unexpected state in query.", states, hasItem(state));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = Mode.EXCLUDE, names = {"APPROVED", "DRAFT",
+      "REJECTED", "WITHDRAWN"})
+  void shouldNotPublishDraftFormrPartbsWithCutoffDate(LifecycleState state) {
+    LocalDate since = LocalDate.of(2025, 1, 1);
+    ArgumentCaptor<Set<LifecycleState>> statesCaptor = ArgumentCaptor.captor();
+    when(repository.streamByLifecycleStateInAndLastModifiedDateGreaterThanEqual(
+        statesCaptor.capture(), any())).thenReturn(Stream.of());
+
+    job.execute(Optional.of(since));
+
+    Set<LifecycleState> states = statesCaptor.getValue();
+    assertThat("Unexpected state query count.", states, hasSize(3));
+    assertThat("Unexpected state in query.", states, hasItem(state));
+  }
+
+  @Test
+  void shouldUseCutoffDateWhenProvided() {
+    LocalDate since = LocalDate.of(2025, 6, 15);
+    ArgumentCaptor<LocalDateTime> cutoffCaptor = ArgumentCaptor.captor();
+    when(repository.streamByLifecycleStateInAndLastModifiedDateGreaterThanEqual(any(),
+        cutoffCaptor.capture())).thenReturn(Stream.of());
+
+    job.execute(Optional.of(since));
+
+    assertThat("Unexpected cutoff date.", cutoffCaptor.getValue(), is(since.atStartOfDay()));
   }
 
   @Test
@@ -120,12 +153,27 @@ class PublishFormrPartbRefreshTest {
 
     when(repository.streamByLifecycleStateIn(any())).thenReturn(Stream.of(form1, form2));
 
-    int publishCount = job.execute();
+    int publishCount = job.execute(Optional.empty());
 
     assertThat("Unexpected published Form-R count.", publishCount, is(2));
 
     verify(service).publishUpdateNotification(argThat(hasId(id1)), eq(PUBLISH_TOPIC));
     verify(service).publishUpdateNotification(argThat(hasId(id2)), eq(PUBLISH_TOPIC));
+  }
+
+  @Test
+  void shouldPublishAllFoundFormrPartbsWithCutoffDate() {
+    UUID id1 = UUID.randomUUID();
+    FormRPartB form1 = new FormRPartB();
+    form1.setId(id1);
+
+    when(repository.streamByLifecycleStateInAndLastModifiedDateGreaterThanEqual(any(),
+        any())).thenReturn(Stream.of(form1));
+
+    int publishCount = job.execute(Optional.of(LocalDate.of(2025, 1, 1)));
+
+    assertThat("Unexpected published Form-R count.", publishCount, is(1));
+    verify(service).publishUpdateNotification(argThat(hasId(id1)), eq(PUBLISH_TOPIC));
   }
 
   @Test
@@ -142,7 +190,7 @@ class PublishFormrPartbRefreshTest {
     doThrow(RuntimeException.class).when(service)
         .publishUpdateNotification(argThat(hasId(id1)), eq(PUBLISH_TOPIC));
 
-    int publishCount = job.execute();
+    int publishCount = job.execute(Optional.empty());
 
     assertThat("Unexpected published Form-R count.", publishCount, is(1));
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/job/PublishLtftRefreshTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/job/PublishLtftRefreshTest.java
@@ -32,6 +32,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -66,7 +70,17 @@ class PublishLtftRefreshTest {
   void shouldNotPublishWhenNoLtftsFound() {
     when(repository.streamByStatus_Current_StateIn(any())).thenReturn(Stream.of());
 
-    job.execute();
+    job.execute(Optional.empty());
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void shouldNotPublishWhenNoLtftsFoundWithCutoffDate() {
+    when(repository.streamByStatus_Current_StateInAndLastModifiedGreaterThanEqual(any(),
+        any())).thenReturn(Stream.of());
+
+    job.execute(Optional.of(LocalDate.of(2025, 1, 1)));
 
     verifyNoInteractions(service);
   }
@@ -74,22 +88,42 @@ class PublishLtftRefreshTest {
   @ParameterizedTest
   @EnumSource(value = LifecycleState.class, mode = Mode.EXCLUDE, names = "DRAFT")
   void shouldNotPublishDraftLtfts(LifecycleState state) {
-    UUID id1 = UUID.randomUUID();
-    LtftForm form1 = new LtftForm();
-    form1.setId(id1);
-
-    UUID id2 = UUID.randomUUID();
-    LtftForm form2 = new LtftForm();
-    form2.setId(id2);
-
     ArgumentCaptor<Set<LifecycleState>> statesCaptor = ArgumentCaptor.captor();
     when(repository.streamByStatus_Current_StateIn(statesCaptor.capture())).thenReturn(Stream.of());
 
-    job.execute();
+    job.execute(Optional.empty());
 
     Set<LifecycleState> states = statesCaptor.getValue();
     assertThat("Unexpected state query count.", states, hasSize(6));
     assertThat("Unexpected state in query.", states, hasItem(state));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = Mode.EXCLUDE, names = "DRAFT")
+  void shouldNotPublishDraftLtftsWithCutoffDate(LifecycleState state) {
+    LocalDate since = LocalDate.of(2025, 1, 1);
+    ArgumentCaptor<Set<LifecycleState>> statesCaptor = ArgumentCaptor.captor();
+    when(repository.streamByStatus_Current_StateInAndLastModifiedGreaterThanEqual(
+        statesCaptor.capture(), any())).thenReturn(Stream.of());
+
+    job.execute(Optional.of(since));
+
+    Set<LifecycleState> states = statesCaptor.getValue();
+    assertThat("Unexpected state query count.", states, hasSize(6));
+    assertThat("Unexpected state in query.", states, hasItem(state));
+  }
+
+  @Test
+  void shouldUseCutoffDateWhenProvided() {
+    LocalDate since = LocalDate.of(2025, 6, 15);
+    Instant expectedCutoff = since.atStartOfDay(ZoneOffset.UTC).toInstant();
+    ArgumentCaptor<Instant> cutoffCaptor = ArgumentCaptor.captor();
+    when(repository.streamByStatus_Current_StateInAndLastModifiedGreaterThanEqual(any(),
+        cutoffCaptor.capture())).thenReturn(Stream.of());
+
+    job.execute(Optional.of(since));
+
+    assertThat("Unexpected cutoff instant.", cutoffCaptor.getValue(), is(expectedCutoff));
   }
 
   @Test
@@ -104,12 +138,27 @@ class PublishLtftRefreshTest {
 
     when(repository.streamByStatus_Current_StateIn(any())).thenReturn(Stream.of(form1, form2));
 
-    int publishCount = job.execute();
+    int publishCount = job.execute(Optional.empty());
 
     assertThat("Unexpected published LTFT count.", publishCount, is(2));
 
     verify(service).publishUpdateNotification(form1, null, PUBLISH_TOPIC);
     verify(service).publishUpdateNotification(form2, null, PUBLISH_TOPIC);
+  }
+
+  @Test
+  void shouldPublishAllFoundLtftsWithCutoffDate() {
+    UUID id1 = UUID.randomUUID();
+    LtftForm form1 = new LtftForm();
+    form1.setId(id1);
+
+    when(repository.streamByStatus_Current_StateInAndLastModifiedGreaterThanEqual(any(),
+        any())).thenReturn(Stream.of(form1));
+
+    int publishCount = job.execute(Optional.of(LocalDate.of(2025, 1, 1)));
+
+    assertThat("Unexpected published LTFT count.", publishCount, is(1));
+    verify(service).publishUpdateNotification(form1, null, PUBLISH_TOPIC);
   }
 
   @Test
@@ -126,7 +175,7 @@ class PublishLtftRefreshTest {
     doThrow(RuntimeException.class).when(service)
         .publishUpdateNotification(form1, null, PUBLISH_TOPIC);
 
-    int publishCount = job.execute();
+    int publishCount = job.execute(Optional.empty());
 
     assertThat("Unexpected published LTFT count.", publishCount, is(1));
 


### PR DESCRIPTION
Optional: existing behaviour is retained if parameter missing.

Related: https://github.com/Health-Education-England/tis-trainee-api/pull/81

TIS21-8635