### PR TITLE
feat: review stage workflow config, model, service, and GET endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.68.1"
+version = "0.69.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
@@ -64,6 +64,7 @@ import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto.LftfStatusInfoDetailDto;
 import uk.nhs.hee.tis.trainee.forms.dto.PersonDto;
+import uk.nhs.hee.tis.trainee.forms.dto.ReviewWorkflowDto;
 import uk.nhs.hee.tis.trainee.forms.service.LtftService;
 import uk.nhs.hee.tis.trainee.forms.service.PdfService;
 
@@ -220,6 +221,17 @@ public class AdminLtftResource {
   ResponseEntity<LtftFormDto> assignAdmin(@PathVariable UUID id, @RequestBody PersonDto admin) {
     Optional<LtftFormDto> form = service.assignAdmin(id, admin);
     return ResponseEntity.of(form);
+  }
+
+  /**
+   * Get the review workflow state for the form with the given ID.
+   *
+   * @param id The ID of the form.
+   * @return The review workflow DTO, or 404 if the form was not found for the admin's local office.
+   */
+  @GetMapping("/{id}/review-workflow")
+  ResponseEntity<ReviewWorkflowDto> getReviewWorkflow(@PathVariable UUID id) {
+    return ResponseEntity.of(service.getReviewWorkflow(id));
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/config/ReviewWorkflowProperties.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/config/ReviewWorkflowProperties.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.config;
+
+import jakarta.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configuration properties for LTFT review workflows, keyed by designated body code (DBC).
+ *
+ * <p>Each entry maps a DBC to an ordered list of {@link StateStage}s, each carrying a label and
+ * an {@code enabled} flag. Only local offices that require review stages need to be configured;
+ * offices using the existing process need no entry.
+ *
+ * <pre>{@code
+ * application:
+ *   review-workflows:
+ *     "1-1RSSQ6R":
+ *       - label: "Programme/Education Team Triage"
+ *         enabled: true
+ *       - label: "Programme Manager Review"
+ *         enabled: true
+ *       - label: "Associate Dean Approval"
+ *         enabled: false
+ * }</pre>
+ */
+@Slf4j
+@Data
+@Component
+@ConfigurationProperties("application")
+public class ReviewWorkflowProperties {
+
+  /**
+   * Map of DBC code to its ordered list of review stages.
+   */
+  private Map<String, List<StateStage>> reviewWorkflows = new HashMap<>();
+
+  /**
+   * Validates the configured review workflows after properties have been bound.
+   *
+   * @throws IllegalStateException if any stage label is blank.
+   */
+  @PostConstruct
+  void validate() {
+    reviewWorkflows.forEach((dbc, stages) -> {
+      for (int i = 0; i < stages.size(); i++) {
+        String label = stages.get(i).label();
+        if (label == null || label.isBlank()) {
+          throw new IllegalStateException(
+              "Review workflow for DBC '%s' contains a blank stage label at index %d."
+                  .formatted(dbc, i));
+        }
+      }
+    });
+
+    log.info("Loaded review workflows for {} DBC(s): {}", reviewWorkflows.size(),
+        reviewWorkflows.keySet());
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/config/StateStage.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/config/StateStage.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.config;
+
+/**
+ * A single stage within a lifecycle state.
+ *
+ * @param label   The display label for this stage.
+ * @param enabled Whether this stage is currently active.
+ */
+public record StateStage(String label, boolean enabled) {
+
+}
+

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
@@ -36,6 +36,7 @@ import uk.nhs.hee.tis.trainee.forms.dto.validation.Create;
 import uk.nhs.hee.tis.trainee.forms.dto.validation.Update;
 import uk.nhs.hee.tis.trainee.forms.dto.views.Admin;
 import uk.nhs.hee.tis.trainee.forms.dto.views.ReadOnly;
+import uk.nhs.hee.tis.trainee.forms.model.ReviewStageStatus;
 import uk.nhs.hee.tis.trainee.forms.model.content.CctChangeType;
 
 /**
@@ -194,6 +195,7 @@ public record LtftFormDto(
      * @param modifiedBy    The Person who made this status change.
      * @param timestamp     The timestamp of the status change.
      * @param revision      The revision number associated with this status change.
+     * @param reviewStage   The review stage associated with this status change, if any.
      */
     @Builder
     public record StatusInfoDto(
@@ -204,7 +206,8 @@ public record LtftFormDto(
         RedactedPersonDto assignedAdmin,
         RedactedPersonDto modifiedBy,
         Instant timestamp,
-        Integer revision
+        Integer revision,
+        ReviewStageStatus reviewStage
     ) {
 
     }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/ReviewWorkflowDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/ReviewWorkflowDto.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.dto;
+
+import jakarta.annotation.Nullable;
+import java.util.List;
+
+/**
+ * The review workflow state for a given LTFT form.
+ *
+ * @param stages       The ordered list of visible review-stage labels for the form's DBC.  Only
+ *                     enabled stages are included, except that the form's current stage is always
+ *                     included even if it has since been disabled.
+ * @param currentStage Zero-based index into {@code stages} of the form's current review stage, or
+ *                     {@code null} if the form is not currently SUBMITTED (or has no review
+ *                     workflow).
+ */
+public record ReviewWorkflowDto(List<String> stages, @Nullable Integer currentStage) {
+
+}
+

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractAuditedForm.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractAuditedForm.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.forms.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.annotation.Nullable;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -119,6 +120,21 @@ public abstract class AbstractAuditedForm<T extends FormContent> extends Abstrac
    */
   public void setLifecycleState(LifecycleState lifecycleState, StatusDetail detail,
       Person modifiedBy, int revision) {
+    setLifecycleState(lifecycleState, detail, modifiedBy, revision, null);
+  }
+
+  /**
+   * Set the current lifecycle state of the form, appending to the status history. This does not
+   * consider whether a state transition is valid or not, it simply sets the state.
+   *
+   * @param lifecycleState The new lifecycle state.
+   * @param detail         Any status detail.
+   * @param modifiedBy     The Person who made this status change.
+   * @param revision       The revision number associated with this status change.
+   * @param reviewStage    The review stage to associate with this status change, or null.
+   */
+  public void setLifecycleState(LifecycleState lifecycleState, StatusDetail detail,
+      Person modifiedBy, int revision, @Nullable ReviewStageStatus reviewStage) {
     StatusInfo statusInfo = StatusInfo.builder()
         .state(lifecycleState)
         .detail(detail)
@@ -127,9 +143,48 @@ public abstract class AbstractAuditedForm<T extends FormContent> extends Abstrac
         .modifiedBy(modifiedBy)
         .timestamp(Instant.now())
         .revision(revision)
+        .reviewStage(reviewStage)
         .build();
 
     updateStatusInfo(statusInfo, true);
+  }
+
+  /**
+   * Set the current review stage of the form without changing any other state, appending to the
+   * status history. The existing detail and modifiedBy are copied from the current status.
+   *
+   * @param reviewStage The new review stage.
+   */
+  public void setReviewStage(@Nullable ReviewStageStatus reviewStage) {
+    StatusDetail currentDetail =
+        status == null || status.current == null ? null : status.current.detail;
+    Person currentModifiedBy =
+        status == null || status.current == null ? null : status.current.modifiedBy;
+    setReviewStage(reviewStage, currentDetail, currentModifiedBy);
+  }
+
+  /**
+   * Set the current review stage of the form without changing any other state, appending to the
+   * status history. The provided detail and modifiedBy are recorded in the new history entry.
+   *
+   * @param reviewStage The new review stage.
+   * @param detail      The status detail to record, or {@code null} to clear.
+   * @param modifiedBy  The person making this change, or {@code null} if unknown.
+   */
+  public void setReviewStage(@Nullable ReviewStageStatus reviewStage,
+      @Nullable StatusDetail detail, @Nullable Person modifiedBy) {
+    StatusInfo statusInfo = StatusInfo.builder()
+        .state(getLifecycleState())
+        .detail(detail)
+        .assignedAdmin(
+            status == null || status.current == null ? null : status.current.assignedAdmin)
+        .modifiedBy(modifiedBy)
+        .timestamp(Instant.now())
+        .revision(status == null || status.current == null ? null : status.current.revision)
+        .reviewStage(reviewStage)
+        .build();
+
+    updateStatusInfo(statusInfo, false);
   }
 
   /**
@@ -187,6 +242,7 @@ public abstract class AbstractAuditedForm<T extends FormContent> extends Abstrac
      * @param modifiedBy    The Person who made this status change.
      * @param timestamp     The timestamp of the status change.
      * @param revision      The revision number associated with this status change.
+     * @param reviewStage   The review stage associated with this status change, if any.
      */
     @Builder
     public record StatusInfo(
@@ -197,7 +253,8 @@ public abstract class AbstractAuditedForm<T extends FormContent> extends Abstrac
         Person assignedAdmin,
         Person modifiedBy,
         Instant timestamp,
-        Integer revision
+        Integer revision,
+        ReviewStageStatus reviewStage
     ) {
 
     }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/ReviewStageStatus.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/ReviewStageStatus.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.model;
+
+/**
+ * The active review stage of an LTFT form, recorded in the form's status history.
+ *
+ * @param index The zero-based position of this stage within the configured workflow.
+ * @param label The display label for this stage.
+ */
+public record ReviewStageStatus(int index, String label) {
+
+}
+

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -69,6 +69,7 @@ import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto.LftfStatusInfoDetailDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.PersonDto;
+import uk.nhs.hee.tis.trainee.forms.dto.ReviewWorkflowDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.EmailValidityType;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.dto.identity.AdminIdentity;
@@ -80,7 +81,6 @@ import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 import uk.nhs.hee.tis.trainee.forms.model.Person;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
 import uk.nhs.hee.tis.trainee.forms.repository.LtftFormRepository;
-
 /**
  * A service for managing LTFT forms.
  */
@@ -103,13 +103,13 @@ public class LtftService {
   private final Validator validator;
 
   private final EventBroadcastService eventBroadcastService;
+  private final LtftSubmissionHistoryService ltftSubmissionHistoryService;
+  private final ReviewStageService reviewStageService;
 
   @Getter
   private final String ltftAssignmentUpdateTopic;
   private final String ltftStatusUpdateTopic;
   private final String ltftContentUpdateTopic;
-
-  private final LtftSubmissionHistoryService ltftSubmissionHistoryService;
 
   /**
    * Instantiate the LTFT form service.
@@ -126,6 +126,7 @@ public class LtftService {
    * @param ltftStatusUpdateTopic        The SNS topic for LTFT status updates.
    * @param ltftContentUpdateTopic       The SNS topic for LTFT content updates.
    * @param ltftSubmissionHistoryService The service for LTFT submission history.
+   * @param reviewStageService           The service for managing review stage transitions.
    */
   public LtftService(AdminIdentity adminIdentity, TraineeIdentity traineeIdentity,
       LtftFormRepository ltftFormRepository, MongoTemplate mongoTemplate, ObjectMapper objectMapper,
@@ -133,7 +134,8 @@ public class LtftService {
       @Value("${application.aws.sns.ltft-assignment-updated}") String ltftAssignmentUpdateTopic,
       @Value("${application.aws.sns.ltft-status-updated}") String ltftStatusUpdateTopic,
       @Value("${application.aws.sns.ltft-content-updated}") String ltftContentUpdateTopic,
-      LtftSubmissionHistoryService ltftSubmissionHistoryService) {
+      LtftSubmissionHistoryService ltftSubmissionHistoryService,
+      ReviewStageService reviewStageService) {
     this.adminIdentity = adminIdentity;
     this.traineeIdentity = traineeIdentity;
     this.ltftFormRepository = ltftFormRepository;
@@ -146,6 +148,31 @@ public class LtftService {
     this.ltftContentUpdateTopic = ltftContentUpdateTopic;
     this.ltftSubmissionHistoryService = ltftSubmissionHistoryService;
     this.eventBroadcastService = eventBroadcastService;
+    this.reviewStageService = reviewStageService;
+  }
+
+  /**
+   * Get the review workflow state for an LTFT form associated with the calling admin's local
+   * office.
+   *
+   * @param formId The ID of the form.
+   * @return The workflow DTO, or empty if no form was found for the admin's DBCs.
+   */
+  public Optional<ReviewWorkflowDto> getReviewWorkflow(UUID formId) {
+    log.info("Getting review workflow for LTFT form {} as admin [{}]", formId,
+        adminIdentity.getEmail());
+    Set<String> dbcs = adminIdentity.getGroups();
+    Optional<LtftForm> optForm =
+        ltftFormRepository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(formId,
+            dbcs);
+
+    if (optForm.isEmpty()) {
+      log.warn("Could not get review workflow for form {} since no form exists for DBCs [{}]",
+          formId, dbcs);
+      return Optional.empty();
+    }
+
+    return Optional.of(reviewStageService.getWorkflowDto(optForm.get()));
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
@@ -1,0 +1,332 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.service;
+
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMITTED;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.UNSUBMITTED;
+
+import jakarta.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.forms.config.ReviewWorkflowProperties;
+import uk.nhs.hee.tis.trainee.forms.config.StateStage;
+import uk.nhs.hee.tis.trainee.forms.dto.ReviewWorkflowDto;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
+import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
+import uk.nhs.hee.tis.trainee.forms.model.ReviewStageStatus;
+
+/**
+ * A service for managing review stage transitions on LTFT forms.
+ *
+ * <p>Rules enforced:
+ * <ul>
+ *   <li>On entering SUBMITTED: set the review stage to the first <em>enabled</em> configured stage
+ *       for the form's DBC, or null if no enabled stages are configured.</li>
+ *   <li>On leaving SUBMITTED for any reason: clear the review stage to null.</li>
+ *   <li>On re-entering SUBMITTED after UNSUBMITTED: restart from the first enabled stage.</li>
+ *   <li>Any review stage may UNSUBMIT a form.</li>
+ *   <li>A disabled review stage may be advanced or exited as if it were enabled.</li>
+ *   <li>Advancing always moves to the next <em>enabled</em> stage, skipping disabled ones.</li>
+ *   <li>Only the <em>effective</em> final stage (the stage after which no further enabled stages
+ *       exist) may approve, reject, or otherwise terminate a form.</li>
+ *   <li>If no enabled stages are configured for a DBC, that DBC is treated as having no review
+ *       workflow at all.</li>
+ * </ul>
+ */
+@Slf4j
+@Service
+public class ReviewStageService {
+
+  /**
+   * The label for the implicit terminal review stage that is appended after all configured stages.
+   * This stage allows admins to record a reason for completing the final review before
+   * transitioning the form to APPROVED, REJECTED, or WITHDRAWN.
+   */
+  static final String TERMINAL_STAGE_LABEL = "Review complete";
+
+  private final ReviewWorkflowProperties reviewWorkflowProperties;
+
+  ReviewStageService(ReviewWorkflowProperties reviewWorkflowProperties) {
+    this.reviewWorkflowProperties = reviewWorkflowProperties;
+  }
+
+  /**
+   * Build the {@link ReviewWorkflowDto} for the given form.
+   *
+   * <p>The {@code stages} list contains only enabled stages, with one exception: if the form is
+   * currently SUBMITTED and its active review stage is disabled (e.g. the stage was disabled after
+   * the form entered it), that stage is also included at its correct position. When at least one
+   * configured stage is enabled, an implicit terminal "Review complete" stage is appended.
+   *
+   * <p>The {@code currentStage} field is the zero-based index of the form's current review stage
+   * within the returned {@code stages} list, or {@code null} if the form is not SUBMITTED or has
+   * no active review stage.
+   *
+   * @param form The form to inspect.
+   * @return The workflow DTO describing the visible stages and the form's current position.
+   */
+  public ReviewWorkflowDto getWorkflowDto(LtftForm form) {
+    String dbc = getDesignatedBodyCode(form);
+    List<StateStage> allStages = getConfiguredStages(dbc);
+
+    ReviewStageStatus currentReviewStage = getCurrentReviewStage(form);
+    boolean isSubmitted = form.getStatus() != null
+        && form.getStatus().current() != null
+        && form.getStatus().current().state() == SUBMITTED;
+    Integer currentAbsoluteIndex = (isSubmitted && currentReviewStage != null)
+        ? currentReviewStage.index() : null;
+
+    List<String> visibleLabels = new ArrayList<>();
+    Integer currentVisiblePosition = null;
+
+    for (int i = 0; i < allStages.size(); i++) {
+      StateStage stage = allStages.get(i);
+      boolean isCurrent = currentAbsoluteIndex != null && currentAbsoluteIndex == i;
+      if (stage.enabled() || isCurrent) {
+        if (isCurrent) {
+          currentVisiblePosition = visibleLabels.size();
+        }
+        visibleLabels.add(stage.label());
+      }
+    }
+
+    // Append the implicit terminal stage if any configured stages are enabled.
+    boolean anyEnabled = allStages.stream().anyMatch(StateStage::enabled);
+    if (anyEnabled) {
+      if (currentAbsoluteIndex != null && currentAbsoluteIndex == allStages.size()) {
+        currentVisiblePosition = visibleLabels.size();
+      }
+      visibleLabels.add(TERMINAL_STAGE_LABEL);
+    }
+
+    return new ReviewWorkflowDto(visibleLabels, currentVisiblePosition);
+  }
+
+  /**
+   * Resolve the review stage to apply when transitioning the form to a new lifecycle state.
+   *
+   * <p>When entering SUBMITTED the first <em>enabled</em> stage for the form's DBC is returned. If
+   * no enabled stages are configured (or no workflow exists) {@code null} is returned, indicating
+   * the form should behave as if no review workflow is in place.
+   *
+   * @param form        The form being transitioned.
+   * @param targetState The lifecycle state being transitioned to.
+   * @return The review stage to record, or {@code null} if the stage should be cleared.
+   */
+  @Nullable
+  public ReviewStageStatus resolveReviewStageForTransition(LtftForm form,
+      LifecycleState targetState) {
+    if (targetState != SUBMITTED) {
+      // Leaving SUBMITTED for any reason (APPROVED, REJECTED, UNSUBMITTED, WITHDRAWN) clears stage.
+      return null;
+    }
+
+    // Entering (or re-entering) SUBMITTED always starts from the first enabled stage.
+    String dbc = getDesignatedBodyCode(form);
+    List<StateStage> stages = getConfiguredStages(dbc);
+
+    if (stages.isEmpty()) {
+      log.debug("No review workflow configured for DBC '{}', setting review stage to null.", dbc);
+      return null;
+    }
+
+    Optional<ReviewStageStatus> firstEnabled = nextEnabledStageAfter(stages, -1);
+    if (firstEnabled.isPresent()) {
+      log.debug("Resolving first enabled review stage for DBC '{}': index={}, label='{}'.",
+          dbc, firstEnabled.get().index(), firstEnabled.get().label());
+    } else {
+      log.debug("No enabled review stages configured for DBC '{}'; setting review stage to null.",
+          dbc);
+    }
+    return firstEnabled.orElse(null);
+  }
+
+  /**
+   * Resolve the next {@link ReviewStageStatus} when an admin advances the review of a form.
+   *
+   * <p>Disabled stages are skipped: the next <em>enabled</em> stage after the current index is
+   * returned. If no enabled stage exists after the current index (i.e. the form is at the
+   * effective final configured stage), the implicit terminal "Review complete" stage is returned,
+   * allowing the admin to record a reason before transitioning to a terminal lifecycle state.
+   *
+   * <p>If the form is already at the terminal stage, {@link Optional#empty()} is returned to
+   * indicate that no further advancement is possible. Transitioning to APPROVED must be performed
+   * separately via the normal status-update path.
+   *
+   * @param form The form whose review is being advanced.
+   * @return The next review stage (including the implicit terminal stage), or empty if the form
+   *     is already at the terminal stage.
+   */
+  public Optional<ReviewStageStatus> resolveAdvance(LtftForm form) {
+    String dbc = getDesignatedBodyCode(form);
+    List<StateStage> stages = getConfiguredStages(dbc);
+
+    boolean anyEnabled = stages.stream().anyMatch(StateStage::enabled);
+    if (!anyEnabled) {
+      log.debug("All review stages disabled for DBC '{}'; no stages to advance through.", dbc);
+      return Optional.empty();
+    }
+
+    ReviewStageStatus current = getCurrentReviewStage(form);
+    if (current == null) {
+      log.warn("Form {} has a review workflow but no current review stage; cannot advance.",
+          form.getId());
+      return Optional.empty();
+    }
+
+    int currentIndex = current.index();
+
+    // Already at the terminal stage — no further advancement is possible.
+    // Note, not stages.size() - 1, as the terminal stage is not part of the configured stages list.
+    if (currentIndex == stages.size()) {
+      log.debug("Form {} is already at the terminal review stage; no advancement possible.",
+          form.getId());
+      return Optional.empty();
+    }
+
+    Optional<ReviewStageStatus> next = nextEnabledStageAfter(stages, currentIndex);
+    if (next.isPresent()) {
+      log.debug("Advancing form {} from review stage index {} to {} ('{}').",
+          form.getId(), currentIndex, next.get().index(), next.get().label());
+      return next;
+    }
+
+    // At the effective final configured stage — advance to the implicit terminal stage.
+    log.debug("Advancing form {} from final configured stage (index {}) to terminal stage.",
+        form.getId(), currentIndex);
+    return Optional.of(new ReviewStageStatus(stages.size(), TERMINAL_STAGE_LABEL));
+  }
+
+
+  /**
+   * Determine whether the form's current review stage permits a transition to the given
+   * lifecycle state.
+   *
+   * <p>UNSUBMITTED is always permitted from any review stage. All other lifecycle states
+   * (APPROVED, REJECTED, WITHDRAWN) require the form to be at the implicit terminal stage,
+   * i.e. past all configured stages.
+   *
+   * <p>If no workflow is configured for the form's DBC, or all configured stages are disabled,
+   * the transition is always permitted.
+   *
+   * @param form        The form to check.
+   * @param targetState The lifecycle state the form is being transitioned to.
+   * @return {@code true} if the transition is permitted, {@code false} otherwise.
+   */
+  public boolean canTransitionToLifecycleState(LtftForm form, LifecycleState targetState) {
+    if (targetState == UNSUBMITTED) {
+      return true;
+    }
+
+    String dbc = getDesignatedBodyCode(form);
+    List<StateStage> stages = getConfiguredStages(dbc);
+
+    if (stages.isEmpty()) {
+      return true;
+    }
+
+    // If all stages are disabled treat as no workflow — allow any transition.
+    boolean anyEnabled = stages.stream().anyMatch(StateStage::enabled);
+    if (!anyEnabled) {
+      log.debug("All review stages disabled for DBC '{}'; treating as no workflow.", dbc);
+      return true;
+    }
+
+    ReviewStageStatus currentReviewStage = getCurrentReviewStage(form);
+    if (currentReviewStage == null) {
+      log.debug("Form {} has no review stage; treating as pre-workflow form — allowing transition "
+          + "to {}.", form.getId(), targetState);
+      return true;
+    }
+
+    // Terminal transitions (APPROVED, REJECTED, WITHDRAWN) are only permitted from the implicit
+    // terminal stage, i.e. after all configured review stages have been completed.
+    boolean atTerminalStage = currentReviewStage.index() >= stages.size();
+    if (!atTerminalStage) {
+      log.warn("Form {} is at review stage index {} but attempted to transition to {}; "
+              + "the form must be advanced to the terminal stage first.",
+          form.getId(), currentReviewStage.index(), targetState);
+    }
+    return atTerminalStage;
+  }
+
+  /**
+   * Return the configured review-workflow stages for the given DBC code, or an empty list if no
+   * workflow is configured.
+   *
+   * @param dbc The designated body code to look up.
+   * @return The list of configured stages, never {@code null}.
+   */
+  private List<StateStage> getConfiguredStages(@Nullable String dbc) {
+    if (dbc == null) {
+      return List.of();
+    }
+    List<StateStage> stages = reviewWorkflowProperties.getReviewWorkflows().get(dbc);
+    return stages != null ? stages : List.of();
+  }
+
+  /**
+   * Return the current {@link ReviewStageStatus} for the given form, or {@code null} if the form
+   * has no current status.
+   *
+   * @param form The form to inspect.
+   * @return The current review stage, or {@code null}.
+   */
+  @Nullable
+  private ReviewStageStatus getCurrentReviewStage(LtftForm form) {
+    if (form.getStatus() == null || form.getStatus().current() == null) {
+      return null;
+    }
+    return form.getStatus().current().reviewStage();
+  }
+
+  /**
+   * Find the next enabled stage in {@code stages} whose index is strictly greater than
+   * {@code fromIndex}.
+   *
+   * <p>Pass {@code -1} as {@code fromIndex} to find the very first enabled stage.
+   *
+   * @param stages    The ordered list of configured stages.
+   * @param fromIndex The index to start searching <em>after</em> (exclusive).
+   * @return The first enabled stage found, or empty if none exists.
+   */
+  private Optional<ReviewStageStatus> nextEnabledStageAfter(List<StateStage> stages,
+      int fromIndex) {
+    for (int i = fromIndex + 1; i < stages.size(); i++) {
+      if (stages.get(i).enabled()) {
+        return Optional.of(new ReviewStageStatus(i, stages.get(i).label()));
+      }
+    }
+    return Optional.empty();
+  }
+
+  @Nullable
+  private String getDesignatedBodyCode(LtftForm form) {
+    if (form.getContent() == null || form.getContent().programmeMembership() == null) {
+      return null;
+    }
+    return form.getContent().programmeMembership().designatedBodyCode();
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,27 @@ application:
       coj-received: ${COJ_RECEIVED_QUEUE:}
       notification-event: ${NOTIFICATION_EVENT_QUEUE:}
       profile-move: ${PROFILE_MOVE_QUEUE:}
+  review-workflows:
+    "1-1RSSQ6R": # DBC code as the map key (Thames Valley)
+      - label: "Programme/Education Team Triage"
+        enabled: true
+      - label: "Programme Manager Review"
+        enabled: true
+      - label: "Associate Dean Approval"
+        enabled: true
+    "1-1RUZUSF": # DBC code as the map key (Wessex)
+      - label: "Programme/Education Team Triage"
+        enabled: false
+      - label: "Education Team Review"
+        enabled: true
+      - label: "APD Approval"
+        enabled: true
+    "1-1RUZV1D": # DBC code as the map key (KSS, if they had a one-step review)
+      - label: "Completeness checks"
+        enabled: true
+    "1-1RSSPZ7": # East Midlands (if they had, but no longer have, a one-step review)
+      - label: "Programme/Education Team Triage"
+        enabled: false
   schedules:
     publish-all-formr-partas: "-"
     publish-all-formr-partbs: "-"

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
@@ -66,6 +66,7 @@ import uk.nhs.hee.tis.trainee.forms.dto.LtftAdminSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto;
 import uk.nhs.hee.tis.trainee.forms.dto.LtftFormDto.StatusDto.LftfStatusInfoDetailDto;
 import uk.nhs.hee.tis.trainee.forms.dto.PersonDto;
+import uk.nhs.hee.tis.trainee.forms.dto.ReviewWorkflowDto;
 import uk.nhs.hee.tis.trainee.forms.service.LtftService;
 import uk.nhs.hee.tis.trainee.forms.service.PdfService;
 
@@ -496,5 +497,38 @@ class AdminLtftResourceTest {
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
     assertThat("Unexpected response body.", response.getBody(), sameInstance(dto));
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenReviewWorkflowFormNotFound() {
+    UUID id = UUID.randomUUID();
+    when(service.getReviewWorkflow(id)).thenReturn(Optional.empty());
+
+    ResponseEntity<ReviewWorkflowDto> response = controller.getReviewWorkflow(id);
+
+    assertThat("Unexpected response code.", response.getStatusCode(), is(NOT_FOUND));
+    assertThat("Unexpected response body.", response.getBody(), nullValue());
+  }
+
+  @Test
+  void shouldReturnReviewWorkflowWhenFormFound() {
+    UUID id = UUID.randomUUID();
+    ReviewWorkflowDto dto = new ReviewWorkflowDto(List.of("Triage", "Dean Approval"), 0);
+    when(service.getReviewWorkflow(id)).thenReturn(Optional.of(dto));
+
+    ResponseEntity<ReviewWorkflowDto> response = controller.getReviewWorkflow(id);
+
+    assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
+    assertThat("Unexpected response body.", response.getBody(), sameInstance(dto));
+  }
+
+  @Test
+  void shouldPassIdToServiceWhenGettingReviewWorkflow() {
+    UUID id = UUID.randomUUID();
+    when(service.getReviewWorkflow(id)).thenReturn(Optional.empty());
+
+    controller.getReviewWorkflow(id);
+
+    verify(service).getReviewWorkflow(id);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/config/ReviewWorkflowPropertiesTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/config/ReviewWorkflowPropertiesTest.java
@@ -1,0 +1,203 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.config;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ReviewWorkflowPropertiesTest {
+
+  private static final String DBC_1 = "1-1RSSQ6R";
+  private static final String DBC_2 = "1-1RUZUSF";
+
+  private ReviewWorkflowProperties properties;
+
+  @BeforeEach
+  void setUp() {
+    properties = new ReviewWorkflowProperties();
+  }
+
+  private static StateStage stage(String label, boolean enabled) {
+    return new StateStage(label, enabled);
+  }
+
+  @Test
+  void shouldDefaultToEmptyMapWhenNoWorkflowsConfigured() {
+    assertThat("Unexpected review workflows.", properties.getReviewWorkflows().isEmpty(), is(true));
+  }
+
+  @Test
+  void shouldNotThrowWhenNoWorkflowsConfigured() {
+    assertDoesNotThrow(() -> properties.validate());
+  }
+
+  @Test
+  void shouldPopulateReviewWorkflowsForSingleDbc() {
+    List<StateStage> stages = List.of(
+        stage("Stage One", true),
+        stage("Stage Two", false),
+        stage("Stage Three", true)
+    );
+    properties.setReviewWorkflows(Map.of(DBC_1, stages));
+
+    assertThat("Unexpected DBC.", properties.getReviewWorkflows(), hasKey(DBC_1));
+    List<StateStage> result = properties.getReviewWorkflows().get(DBC_1);
+    assertThat("Unexpected stage count.", result.size(), is(3));
+    assertThat("Unexpected label.", result.get(0).label(), is("Stage One"));
+    assertThat("Unexpected enabled.", result.get(0).enabled(), is(true));
+    assertThat("Unexpected label.", result.get(1).label(), is("Stage Two"));
+    assertThat("Unexpected enabled.", result.get(1).enabled(), is(false));
+    assertThat("Unexpected label.", result.get(2).label(), is("Stage Three"));
+    assertThat("Unexpected enabled.", result.get(2).enabled(), is(true));
+  }
+
+  @Test
+  void shouldPopulateReviewWorkflowsForMultipleDbcs() {
+    Map<String, List<StateStage>> workflows = Map.of(
+        DBC_1, List.of(stage("Triage", true), stage("Manager Review", true),
+            stage("Dean Approval", false)),
+        DBC_2, List.of(stage("Completeness checks", true))
+    );
+    properties.setReviewWorkflows(workflows);
+
+    assertThat("Unexpected DBC 1.", properties.getReviewWorkflows(), hasKey(DBC_1));
+    assertThat("Unexpected DBC 2.", properties.getReviewWorkflows(), hasKey(DBC_2));
+    assertThat("Unexpected stage count for DBC 1.",
+        properties.getReviewWorkflows().get(DBC_1).size(), is(3));
+    assertThat("Unexpected stage count for DBC 2.",
+        properties.getReviewWorkflows().get(DBC_2).size(), is(1));
+  }
+
+  @Test
+  void shouldPreserveEnabledFlagPerStage() {
+    List<StateStage> stages = List.of(
+        stage("Active Stage", true),
+        stage("Inactive Stage", false)
+    );
+    properties.setReviewWorkflows(Map.of(DBC_1, stages));
+
+    List<StateStage> result = properties.getReviewWorkflows().get(DBC_1);
+    assertThat("Unexpected enabled for stage 0.", result.get(0).enabled(), is(true));
+    assertThat("Unexpected enabled for stage 1.", result.get(1).enabled(), is(false));
+  }
+
+  @Test
+  void shouldAllowSingleStageWorkflow() {
+    properties.setReviewWorkflows(Map.of(DBC_1, List.of(stage("Only Stage", true))));
+
+    assertDoesNotThrow(() -> properties.validate());
+  }
+
+  @Test
+  void shouldAllowDuplicateStageLabelsBetweenDbcs() {
+    Map<String, List<StateStage>> workflows = Map.of(
+        DBC_1, List.of(stage("Triage", true), stage("Manager Review", false)),
+        DBC_2, List.of(stage("Triage", true), stage("APD Approval", true))
+    );
+    properties.setReviewWorkflows(workflows);
+
+    assertDoesNotThrow(() -> properties.validate());
+  }
+
+  @Test
+  void shouldAllowDuplicateStageLabelsWithinSameDbc() {
+    properties.setReviewWorkflows(
+        Map.of(DBC_1, List.of(stage("Review", true), stage("Review", false),
+            stage("Final Review", true))));
+
+    assertDoesNotThrow(() -> properties.validate());
+  }
+
+  @Test
+  void shouldNotThrowWhenAllStageLabelsAreValid() {
+    Map<String, List<StateStage>> workflows = Map.of(
+        DBC_1, List.of(stage("Programme/Education Team Triage", true),
+            stage("Programme Manager Review", true), stage("Associate Dean Approval", false)),
+        DBC_2, List.of(stage("Education Team Review", true), stage("APD Approval", false))
+    );
+    properties.setReviewWorkflows(workflows);
+
+    assertDoesNotThrow(() -> properties.validate());
+  }
+
+  @Test
+  void shouldNotThrowWhenAllStagesAreDisabled() {
+    properties.setReviewWorkflows(
+        Map.of(DBC_1, List.of(stage("Stage One", false), stage("Stage Two", false))));
+
+    assertDoesNotThrow(() -> properties.validate());
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {" ", "\t", "\n", ""})
+  void shouldThrowWhenStageLabelIsBlankOrEmpty(String blankLabel) {
+    StateStage bad = stage(blankLabel, true);
+    properties.setReviewWorkflows(Map.of(DBC_1, List.of(stage("Valid Stage", true), bad)));
+
+    assertThrows(IllegalStateException.class, () -> properties.validate());
+  }
+
+  @Test
+  void shouldThrowWhenFirstStageLabelIsBlank() {
+    List<StateStage> stages = new ArrayList<>();
+    stages.add(stage("", false));
+    stages.add(stage("Stage Two", true));
+    properties.setReviewWorkflows(Map.of(DBC_1, stages));
+
+    assertThrows(IllegalStateException.class, () -> properties.validate());
+  }
+
+  @Test
+  void shouldThrowWhenBlankLabelAppearsInSecondDbc() {
+    Map<String, List<StateStage>> workflows = new HashMap<>();
+    workflows.put(DBC_1, List.of(stage("Valid Stage One", true), stage("Valid Stage Two", false)));
+    List<StateStage> invalidStages = new ArrayList<>();
+    invalidStages.add(stage("Valid Stage", true));
+    invalidStages.add(stage(" ", false));
+    workflows.put(DBC_2, invalidStages);
+    properties.setReviewWorkflows(workflows);
+
+    assertThrows(IllegalStateException.class, () -> properties.validate());
+  }
+
+  @Test
+  void shouldThrowWhenDisabledStageLabelIsBlank() {
+    StateStage bad = stage("", false);
+    properties.setReviewWorkflows(Map.of(DBC_1, List.of(stage("Valid Stage", true), bad)));
+
+    assertThrows(IllegalStateException.class, () -> properties.validate());
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/model/AbstractAuditedFormTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/model/AbstractAuditedFormTest.java
@@ -429,6 +429,219 @@ class AbstractAuditedFormTest {
 
   }
 
+  @Test
+  void shouldSetReviewStageWhenCallingSetLifecycleStateWithReviewStage() {
+    ReviewStageStatus reviewStage = new ReviewStageStatus(0, "Triage");
+    form.setLifecycleState(SUBMITTED, null, null, 0, reviewStage);
+
+    assertThat("Unexpected review stage.", form.getStatus().current().reviewStage(),
+        is(reviewStage));
+  }
+
+  @Test
+  void shouldSetNullReviewStageWhenCallingSetLifecycleStateWithNullReviewStage() {
+    form.setLifecycleState(SUBMITTED, null, null, 0, null);
+
+    assertThat("Unexpected review stage.", form.getStatus().current().reviewStage(), nullValue());
+  }
+
+  @Test
+  void shouldSetNullReviewStageWhenCallingSetLifecycleStateWithoutReviewStage() {
+    form.setLifecycleState(SUBMITTED, null, null, 0);
+
+    assertThat("Unexpected review stage.", form.getStatus().current().reviewStage(), nullValue());
+  }
+
+  @Test
+  void shouldAddReviewStageToHistoryWhenSettingLifecycleState() {
+    ReviewStageStatus stage0 = new ReviewStageStatus(0, "Triage");
+    ReviewStageStatus stage1 = new ReviewStageStatus(1, "Manager Review");
+
+    form.setLifecycleState(SUBMITTED, null, null, 0, stage0);
+    form.setLifecycleState(SUBMITTED, null, null, 0, stage1);
+
+    assertThat("Unexpected history review stage 0.",
+        form.getStatus().history().get(0).reviewStage(), is(stage0));
+    assertThat("Unexpected history review stage 1.",
+        form.getStatus().history().get(1).reviewStage(), is(stage1));
+  }
+
+  @Test
+  void shouldSetReviewStage() {
+    form.setLifecycleState(SUBMITTED);
+    ReviewStageStatus reviewStage = new ReviewStageStatus(0, "Triage");
+
+    form.setReviewStage(reviewStage);
+
+    assertThat("Unexpected review stage.", form.getStatus().current().reviewStage(),
+        is(reviewStage));
+  }
+
+  @Test
+  void shouldSetNullReviewStage() {
+    form.setLifecycleState(SUBMITTED, null, null, 0, new ReviewStageStatus(0, "Triage"));
+
+    form.setReviewStage(null);
+
+    assertThat("Unexpected review stage.", form.getStatus().current().reviewStage(), nullValue());
+  }
+
+  @Test
+  void shouldUpdateReviewStage() {
+    form.setLifecycleState(SUBMITTED, null, null, 0, new ReviewStageStatus(0, "Triage"));
+    ReviewStageStatus nextStage = new ReviewStageStatus(1, "Manager Review");
+
+    form.setReviewStage(nextStage);
+
+    assertThat("Unexpected review stage.", form.getStatus().current().reviewStage(), is(nextStage));
+  }
+
+  @Test
+  void shouldRetainLifecycleStateWhenSettingReviewStage() {
+    form.setLifecycleState(SUBMITTED);
+
+    form.setReviewStage(new ReviewStageStatus(0, "Triage"));
+
+    assertThat("Unexpected lifecycle state.", form.getLifecycleState(), is(SUBMITTED));
+  }
+
+  @Test
+  void shouldRetainDetailWhenSettingReviewStage() {
+    StatusDetail detail = StatusDetail.builder().reason("a reason").message("a message").build();
+    form.setLifecycleState(SUBMITTED, detail, null, 0);
+
+    form.setReviewStage(new ReviewStageStatus(0, "Triage"));
+
+    assertThat("Unexpected detail.", form.getStatus().current().detail(), is(detail));
+  }
+
+  @Test
+  void shouldRetainRevisionWhenSettingReviewStage() {
+    form.setLifecycleState(SUBMITTED, null, null, 3);
+
+    form.setReviewStage(new ReviewStageStatus(0, "Triage"));
+
+    assertThat("Unexpected revision.", form.getStatus().current().revision(), is(3));
+  }
+
+  @Test
+  void shouldRetainAssignedAdminWhenSettingReviewStage() {
+    Person admin = Person.builder()
+        .name("Ad Min")
+        .email("ad.min@example.com")
+        .role("ADMIN")
+        .build();
+    form.setStatus(Status.builder()
+        .current(StatusInfo.builder().state(SUBMITTED).assignedAdmin(admin).build())
+        .history(List.of())
+        .build());
+
+    form.setReviewStage(new ReviewStageStatus(0, "Triage"));
+
+    assertThat("Unexpected assigned admin.", form.getStatus().current().assignedAdmin(),
+        is(admin));
+  }
+
+  @Test
+  void shouldAddReviewStageChangeToHistory() {
+    form.setLifecycleState(SUBMITTED);
+    ReviewStageStatus stage0 = new ReviewStageStatus(0, "Triage");
+    ReviewStageStatus stage1 = new ReviewStageStatus(1, "Manager Review");
+
+    form.setReviewStage(stage0);
+    form.setReviewStage(stage1);
+
+    List<StatusInfo> history = form.getStatus().history();
+    assertThat("Unexpected history count.", history, hasSize(3));
+    assertThat("Unexpected review stage in history entry 1.", history.get(1).reviewStage(),
+        is(stage0));
+    assertThat("Unexpected review stage in history entry 2.", history.get(2).reviewStage(),
+        is(stage1));
+  }
+
+  @Test
+  void shouldNotAffectSubmittedTimestampWhenSettingReviewStage() {
+    Instant submittedTime = Instant.parse("2026-01-01T10:00:00Z");
+    form.setStatus(Status.builder()
+        .current(StatusInfo.builder().state(SUBMITTED).build())
+        .submitted(submittedTime)
+        .history(List.of())
+        .build());
+
+    form.setReviewStage(new ReviewStageStatus(0, "Triage"));
+
+    assertThat("Unexpected submitted timestamp.", form.getStatus().submitted(), is(submittedTime));
+  }
+
+  @Test
+  void shouldSetReviewStageWhenStatusIsNull() {
+    form.setStatus(null);
+    ReviewStageStatus reviewStage = new ReviewStageStatus(0, "Triage");
+
+    form.setReviewStage(reviewStage);
+
+    assertThat("Unexpected review stage.", form.getStatus().current().reviewStage(),
+        is(reviewStage));
+  }
+
+  @Test
+  void shouldSetReviewStageWhenCurrentStatusIsMissing() {
+    form.setStatus(Status.builder().build());
+    ReviewStageStatus reviewStage = new ReviewStageStatus(0, "Triage");
+
+    form.setReviewStage(reviewStage);
+
+    assertThat("Unexpected review stage.", form.getStatus().current().reviewStage(),
+        is(reviewStage));
+  }
+
+  @Test
+  void shouldSetProvidedDetailWhenCallingSetReviewStageWithDetailAndModifiedBy() {
+    form.setLifecycleState(SUBMITTED);
+    StatusDetail newDetail = StatusDetail.builder().reason("Triage done").message("notes").build();
+    Person modifiedBy = Person.builder().name("Ad Min").email("ad@test.com").role("ADMIN").build();
+
+    form.setReviewStage(new ReviewStageStatus(1, "Manager Review"), newDetail, modifiedBy);
+
+    assertThat("Unexpected detail.", form.getStatus().current().detail(), is(newDetail));
+  }
+
+  @Test
+  void shouldSetNullDetailWhenCallingSetReviewStageWithNullDetail() {
+    StatusDetail existingDetail = StatusDetail.builder().reason("existing").build();
+    form.setLifecycleState(SUBMITTED, existingDetail, null, 0);
+
+    form.setReviewStage(new ReviewStageStatus(1, "Manager Review"), null, null);
+
+    assertThat("Unexpected detail after null.", form.getStatus().current().detail(), nullValue());
+  }
+
+  @Test
+  void shouldSetProvidedModifiedByWhenCallingSetReviewStageWithModifiedBy() {
+    form.setLifecycleState(SUBMITTED);
+    Person modifiedBy = Person.builder().name("Ad Min").email("ad@test.com").role("ADMIN").build();
+
+    form.setReviewStage(new ReviewStageStatus(1, "Manager Review"), null, modifiedBy);
+
+    assertThat("Unexpected modifiedBy.", form.getStatus().current().modifiedBy(), is(modifiedBy));
+  }
+
+  @Test
+  void shouldNotAffectSubmittedTimestampWhenCallingSetReviewStageWithDetailAndModifiedBy() {
+    Instant submittedTime = Instant.parse("2026-01-01T10:00:00Z");
+    form.setStatus(Status.builder()
+        .current(StatusInfo.builder().state(SUBMITTED).build())
+        .submitted(submittedTime)
+        .history(List.of())
+        .build());
+    Person modifiedBy = Person.builder().name("Ad Min").email("ad@test.com").role("ADMIN").build();
+
+    form.setReviewStage(new ReviewStageStatus(1, "Manager Review"),
+        StatusDetail.builder().reason("done").build(), modifiedBy);
+
+    assertThat("Unexpected submitted timestamp.", form.getStatus().submitted(), is(submittedTime));
+  }
+
   /**
    * A stub for testing the behaviour of the AbstractForm event listener.
    */

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -118,6 +118,7 @@ import uk.nhs.hee.tis.trainee.forms.dto.LtftSummaryDto;
 import uk.nhs.hee.tis.trainee.forms.dto.PersonDto;
 import uk.nhs.hee.tis.trainee.forms.dto.PersonalDetailsDto;
 import uk.nhs.hee.tis.trainee.forms.dto.RedactedPersonDto;
+import uk.nhs.hee.tis.trainee.forms.dto.ReviewWorkflowDto;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.EmailValidityType;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.dto.identity.AdminIdentity;
@@ -169,6 +170,7 @@ class LtftServiceTest {
   private Validator validator;
   private EventBroadcastService eventBroadcastService;
   private LtftSubmissionHistoryService ltftSubmissionHistoryService;
+  private ReviewStageService reviewStageService;
 
   @BeforeEach
   void setUp() {
@@ -194,6 +196,7 @@ class LtftServiceTest {
     mongoTemplate = mock(MongoTemplate.class);
     eventBroadcastService = mock(EventBroadcastService.class);
     ltftSubmissionHistoryService = mock(LtftSubmissionHistoryService.class);
+    reviewStageService = mock(ReviewStageService.class);
 
     jsonMapper = (JsonMapper) new JsonMapper().registerModule(new JavaTimeModule());
     temporalMapper = mock(TemporalMapper.class);
@@ -202,7 +205,8 @@ class LtftServiceTest {
     validator = mock(Validator.class);
     service = new LtftService(adminIdentity, traineeIdentity, repository, mongoTemplate, jsonMapper,
         mapper, validator, eventBroadcastService, LTFT_ASSIGNMENT_UPDATE_TOPIC,
-        LTFT_STATUS_UPDATE_TOPIC, LTFT_STATUS_CONTENT_TOPIC, ltftSubmissionHistoryService);
+        LTFT_STATUS_UPDATE_TOPIC, LTFT_STATUS_CONTENT_TOPIC, ltftSubmissionHistoryService,
+        reviewStageService);
   }
 
   @Test
@@ -2300,7 +2304,8 @@ class LtftServiceTest {
 
     service = new LtftService(adminIdentity, traineeIdentity, repository, mongoTemplate, jsonMapper,
         mapper, validator, eventBroadcastService, LTFT_ASSIGNMENT_UPDATE_TOPIC,
-        LTFT_STATUS_UPDATE_TOPIC, LTFT_STATUS_CONTENT_TOPIC, ltftSubmissionHistoryService);
+        LTFT_STATUS_UPDATE_TOPIC, LTFT_STATUS_CONTENT_TOPIC, ltftSubmissionHistoryService,
+        reviewStageService);
 
     LtftFormDto dtoToSave = LtftFormDto.builder()
         .traineeTisId(TRAINEE_ID)
@@ -2337,7 +2342,8 @@ class LtftServiceTest {
 
     service = new LtftService(adminIdentity, traineeIdentity, repository, mongoTemplate, jsonMapper,
         mapper, validator, eventBroadcastService, LTFT_ASSIGNMENT_UPDATE_TOPIC,
-        LTFT_STATUS_UPDATE_TOPIC, LTFT_STATUS_CONTENT_TOPIC, ltftSubmissionHistoryService);
+        LTFT_STATUS_UPDATE_TOPIC, LTFT_STATUS_CONTENT_TOPIC, ltftSubmissionHistoryService,
+        reviewStageService);
 
     LtftFormDto dtoToSave = LtftFormDto.builder()
         .traineeTisId(TRAINEE_ID)
@@ -2373,7 +2379,8 @@ class LtftServiceTest {
 
     service = new LtftService(adminIdentity, traineeIdentity, repository, mongoTemplate, jsonMapper,
         mapper, validator, eventBroadcastService, LTFT_ASSIGNMENT_UPDATE_TOPIC,
-        LTFT_STATUS_UPDATE_TOPIC, LTFT_STATUS_CONTENT_TOPIC, ltftSubmissionHistoryService);
+        LTFT_STATUS_UPDATE_TOPIC, LTFT_STATUS_CONTENT_TOPIC, ltftSubmissionHistoryService,
+        reviewStageService);
 
     LtftFormDto dtoToSave = LtftFormDto.builder()
         .traineeTisId(TRAINEE_ID)
@@ -3884,5 +3891,38 @@ class LtftServiceTest {
         Arguments.of(UNSUBMITTED, SUBMITTED),
         Arguments.of(UNSUBMITTED, WITHDRAWN)
     );
+  }  @Test
+  void shouldLookUpFormByIdWhenGettingReviewWorkflow() {
+    when(repository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.empty());
+    service.getReviewWorkflow(ID);
+    verify(repository).findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        eq(ID), any());
+  }
+  @Test
+  void shouldLookUpFormByAdminDbcsWhenGettingReviewWorkflow() {
+    when(repository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.empty());
+    service.getReviewWorkflow(ID);
+    verify(repository).findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        any(), eq(Set.of(ADMIN_GROUP)));
+  }
+  @Test
+  void shouldReturnEmptyWhenFormNotFoundForReviewWorkflow() {
+    when(repository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.empty());
+    Optional<ReviewWorkflowDto> result = service.getReviewWorkflow(ID);
+    assertThat("Unexpected result presence.", result.isPresent(), is(false));
+  }
+  @Test
+  void shouldReturnWorkflowDtoFromServiceWhenFormFound() {
+    LtftForm form = new LtftForm();
+    ReviewWorkflowDto expectedDto = new ReviewWorkflowDto(List.of("Triage", "Dean Approval"), 0);
+    when(repository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(
+        ID, Set.of(ADMIN_GROUP))).thenReturn(Optional.of(form));
+    when(reviewStageService.getWorkflowDto(form)).thenReturn(expectedDto);
+    Optional<ReviewWorkflowDto> result = service.getReviewWorkflow(ID);
+    assertThat("Unexpected result presence.", result.isPresent(), is(true));
+    assertThat("Unexpected workflow dto.", result.get(), is(expectedDto));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageServiceTest.java
@@ -1,0 +1,887 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.forms.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.APPROVED;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMITTED;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.UNSUBMITTED;
+import static uk.nhs.hee.tis.trainee.forms.service.ReviewStageService.TERMINAL_STAGE_LABEL;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+import uk.nhs.hee.tis.trainee.forms.config.ReviewWorkflowProperties;
+import uk.nhs.hee.tis.trainee.forms.config.StateStage;
+import uk.nhs.hee.tis.trainee.forms.dto.ReviewWorkflowDto;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status.StatusInfo;
+import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
+import uk.nhs.hee.tis.trainee.forms.model.ReviewStageStatus;
+import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
+import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent.ProgrammeMembership;
+
+class ReviewStageServiceTest {
+
+  private static final String DBC = "1-1RSSQ6R";
+
+  private ReviewStageService service;
+  private ReviewWorkflowProperties workflowProperties;
+
+  @BeforeEach
+  void setUp() {
+    workflowProperties = new ReviewWorkflowProperties();
+    service = new ReviewStageService(workflowProperties);
+  }
+
+  // -- helpers --
+
+  private static StateStage stage(String label) {
+    return new StateStage(label, true);
+  }
+
+  private static StateStage disabledStage(String label) {
+    return new StateStage(label, false);
+  }
+
+  private LtftForm formWithDbc(String dbc) {
+    LtftForm form = new LtftForm();
+    form.setContent(LtftContent.builder()
+        .programmeMembership(ProgrammeMembership.builder()
+            .designatedBodyCode(dbc)
+            .build())
+        .build());
+    return form;
+  }
+
+  private LtftForm formAtReviewStage(String dbc, int index, String label) {
+    LtftForm form = formWithDbc(dbc);
+    form.setStatus(Status.builder()
+        .current(StatusInfo.builder()
+            .state(SUBMITTED)
+            .reviewStage(new ReviewStageStatus(index, label))
+            .build())
+        .build());
+    return form;
+  }
+
+  private LtftForm formWithNoProgrammeMembership() {
+    LtftForm form = new LtftForm();
+    form.setContent(LtftContent.builder().build()); // content present but no programmeMembership
+    return form;
+  }
+
+  // -- resolveReviewStageForTransition --
+
+  @Test
+  void shouldReturnNullReviewStageWhenNoWorkflowConfiguredAndEnteringSubmitted() {
+    LtftForm form = formWithDbc(DBC);
+
+    ReviewStageStatus result = service.resolveReviewStageForTransition(form, SUBMITTED);
+
+    assertThat("Unexpected review stage.", result, nullValue());
+  }
+
+  @Test
+  void shouldReturnFirstStageWhenWorkflowConfiguredAndEnteringSubmitted() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"), stage("Dean Approval"))));
+
+    LtftForm form = formWithDbc(DBC);
+    ReviewStageStatus result = service.resolveReviewStageForTransition(form, SUBMITTED);
+
+    assertThat("Unexpected stage index.", result.index(), is(0));
+    assertThat("Unexpected stage label.", result.label(), is("Triage"));
+  }
+
+  @Test
+  void shouldAlwaysReturnFirstStageOnResubmitAfterUnsubmit() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"))));
+
+    // Form was previously at stage 1 before being unsubmitted; re-submit goes back to 0.
+    LtftForm form = formAtReviewStage(DBC, 1, "Manager Review");
+    ReviewStageStatus result = service.resolveReviewStageForTransition(form, SUBMITTED);
+
+    assertThat("Unexpected stage index on re-submit.", result.index(), is(0));
+    assertThat("Unexpected stage label on re-submit.", result.label(), is("Triage"));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = Mode.EXCLUDE, names = {"SUBMITTED"})
+  void shouldReturnNullReviewStageWhenLeavingSubmitted(LifecycleState targetState) {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"))));
+
+    LtftForm form = formAtReviewStage(DBC, 0, "Triage");
+    ReviewStageStatus result = service.resolveReviewStageForTransition(form, targetState);
+
+    assertThat("Unexpected review stage when leaving SUBMITTED.", result, nullValue());
+  }
+
+  @Test
+  void shouldReturnNullWhenDbcHasNoContent() {
+    LtftForm form = new LtftForm(); // no content set
+
+    ReviewStageStatus result = service.resolveReviewStageForTransition(form, SUBMITTED);
+
+    assertThat("Unexpected review stage for form with no content.", result, nullValue());
+  }
+
+  @Test
+  void shouldSkipDisabledFirstStageAndReturnFirstEnabledStageOnSubmit() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        disabledStage("Triage"), stage("Manager Review"), stage("Dean Approval"))));
+
+    LtftForm form = formWithDbc(DBC);
+    ReviewStageStatus result = service.resolveReviewStageForTransition(form, SUBMITTED);
+
+    assertThat("Unexpected stage index.", result.index(), is(1));
+    assertThat("Unexpected stage label.", result.label(), is("Manager Review"));
+  }
+
+  @Test
+  void shouldReturnNullWhenAllStagesDisabledOnSubmit() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        disabledStage("Triage"), disabledStage("Manager Review"))));
+
+    LtftForm form = formWithDbc(DBC);
+    ReviewStageStatus result = service.resolveReviewStageForTransition(form, SUBMITTED);
+
+    assertThat("Unexpected review stage when all stages disabled.", result, nullValue());
+  }
+
+  @Test
+  void shouldReturnNullWhenNoStageEnabledAndResubmitting() {
+    // All disabled → null, even if re-submitting from a previous stage.
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        disabledStage("Triage"), disabledStage("Manager Review"))));
+
+    LtftForm form = formAtReviewStage(DBC, 1, "Manager Review");
+    ReviewStageStatus result = service.resolveReviewStageForTransition(form, SUBMITTED);
+
+    assertThat("Unexpected review stage when all stages disabled on re-submit.", result,
+        nullValue());
+  }
+
+  @Test
+  void shouldReturnNullWhenFormHasContentButNoProgrammeMembership() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(stage("Triage"))));
+
+    LtftForm form = formWithNoProgrammeMembership();
+    ReviewStageStatus result = service.resolveReviewStageForTransition(form, SUBMITTED);
+
+    assertThat("Unexpected review stage when no programme membership.", result, nullValue());
+  }
+
+  @Test
+  void shouldReturnEmptyWhenNoWorkflowConfigured() {
+    LtftForm form = formAtReviewStage(DBC, 0, "Triage");
+
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    assertTrue(result.isEmpty(), "Expected empty optional when no workflow configured.");
+  }
+
+  @Test
+  void shouldReturnNextStageWhenNotAtFinalStage() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 0, "Triage");
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    assertTrue(result.isPresent(), "Expected next stage to be present.");
+    assertThat("Unexpected next stage index.", result.get().index(), is(1));
+    assertThat("Unexpected next stage label.", result.get().label(), is("Manager Review"));
+  }
+
+  @Test
+  void shouldReturnTerminalStageWhenAtFinalConfiguredStage() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 2, "Dean Approval");
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    assertTrue(result.isPresent(), "Expected terminal stage to be present at final stage.");
+    assertThat("Unexpected terminal stage index.", result.get().index(), is(3));
+    assertThat("Unexpected terminal stage label.", result.get().label(), is(TERMINAL_STAGE_LABEL));
+  }
+
+  @Test
+  void shouldReturnTerminalStageWhenAtFinalStageOfSingleStageWorkflow() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(stage("Only Stage"))));
+
+    LtftForm form = formAtReviewStage(DBC, 0, "Only Stage");
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    assertTrue(result.isPresent(),
+        "Expected terminal stage for single-stage workflow at stage 0.");
+    assertThat("Unexpected terminal stage index.", result.get().index(), is(1));
+    assertThat("Unexpected terminal stage label.", result.get().label(), is(TERMINAL_STAGE_LABEL));
+  }
+
+  @Test
+  void shouldReturnEmptyWhenAlreadyAtTerminalStage() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"), stage("Dean Approval"))));
+
+    // Terminal stage index = stages.size() = 3.
+    LtftForm form = formAtReviewStage(DBC, 3, TERMINAL_STAGE_LABEL);
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    assertTrue(result.isEmpty(),
+        "Expected empty optional when already at the terminal stage.");
+  }
+
+  @Test
+  void shouldReturnEmptyWhenAllStagesDisabledForAdvance() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        disabledStage("Triage"), disabledStage("Manager Review"))));
+
+    LtftForm form = formAtReviewStage(DBC, 0, "Triage");
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    assertTrue(result.isEmpty(),
+        "Expected empty optional when all stages are disabled.");
+  }
+
+  @Test
+  void shouldAdvanceThroughAllStagesInOrderIncludingTerminal() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Stage A"), stage("Stage B"), stage("Stage C"))));
+
+    LtftForm form = formAtReviewStage(DBC, 0, "Stage A");
+
+    Optional<ReviewStageStatus> step1 = service.resolveAdvance(form);
+    assertTrue(step1.isPresent(), "Expected step 1 to be present.");
+    assertThat("Unexpected step 1 index.", step1.get().index(), is(1));
+    assertThat("Unexpected step 1 label.", step1.get().label(), is("Stage B"));
+
+    LtftForm formAt1 = formAtReviewStage(DBC, 1, "Stage B");
+    Optional<ReviewStageStatus> step2 = service.resolveAdvance(formAt1);
+    assertTrue(step2.isPresent(), "Expected step 2 to be present.");
+    assertThat("Unexpected step 2 index.", step2.get().index(), is(2));
+    assertThat("Unexpected step 2 label.", step2.get().label(), is("Stage C"));
+
+    LtftForm formAt2 = formAtReviewStage(DBC, 2, "Stage C");
+    Optional<ReviewStageStatus> step3 = service.resolveAdvance(formAt2);
+    assertTrue(step3.isPresent(), "Expected step 3 (terminal) to be present.");
+    assertThat("Unexpected step 3 index.", step3.get().index(), is(3));
+    assertThat("Unexpected step 3 label.", step3.get().label(), is(TERMINAL_STAGE_LABEL));
+
+    LtftForm formAt3 = formAtReviewStage(DBC, 3, TERMINAL_STAGE_LABEL);
+    Optional<ReviewStageStatus> step4 = service.resolveAdvance(formAt3);
+    assertTrue(step4.isEmpty(),
+        "Expected step 4 to be empty (already at terminal stage, no further advance).");
+  }
+
+  @Test
+  void shouldSkipDisabledStageWhenAdvancing() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), disabledStage("Middle"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 0, "Triage");
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    assertTrue(result.isPresent(), "Expected next stage to be present after skipping disabled.");
+    assertThat("Unexpected next stage index.", result.get().index(), is(2));
+    assertThat("Unexpected next stage label.", result.get().label(), is("Dean Approval"));
+  }
+
+  @Test
+  void shouldReturnTerminalStageWhenAllRemainingStagesAreDisabled() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), disabledStage("End"))));
+
+    LtftForm form = formAtReviewStage(DBC, 0, "Triage");
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    assertTrue(result.isPresent(),
+        "Expected terminal stage when no enabled stages follow the current stage.");
+    assertThat("Unexpected terminal stage index.", result.get().index(), is(2));
+    assertThat("Unexpected terminal stage label.", result.get().label(), is(TERMINAL_STAGE_LABEL));
+  }
+
+  @Test
+  void shouldAdvanceFromDisabledStageToNextEnabledStage() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), disabledStage("Middle"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 1, "Middle");
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    assertTrue(result.isPresent(), "Expected next stage when advancing from a disabled stage.");
+    assertThat("Unexpected next stage index.", result.get().index(), is(2));
+    assertThat("Unexpected next stage label.", result.get().label(), is("Dean Approval"));
+  }
+
+  @Test
+  void shouldReturnTerminalStageWhenAtDisabledFinalStage() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), disabledStage("End"))));
+
+    LtftForm form = formAtReviewStage(DBC, 1, "End");
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    assertTrue(result.isPresent(),
+        "Expected terminal stage at disabled final stage.");
+    assertThat("Unexpected terminal stage index.", result.get().index(), is(2));
+    assertThat("Unexpected terminal stage label.", result.get().label(), is(TERMINAL_STAGE_LABEL));
+  }
+
+  @Test
+  void shouldReturnTerminalStageAfterSkippingMultipleConsecutiveDisabledFinalStages() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Stage A"), disabledStage("Stage B"), disabledStage("Stage C"), stage("Stage D"))));
+
+    LtftForm form = formAtReviewStage(DBC, 0, "Stage A");
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    assertTrue(result.isPresent(), "Expected next stage after skipping multiple disabled stages.");
+    assertThat("Unexpected next stage index.", result.get().index(), is(3));
+    assertThat("Unexpected next stage label.", result.get().label(), is("Stage D"));
+  }
+
+  @Test
+  void shouldReturnEmptyWhenNoCurrentReviewStageAndWorkflowConfigured() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"))));
+
+    // Form has no status at all — getCurrentReviewStage returns null → cannot advance
+    LtftForm form = formWithDbc(DBC);
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    assertTrue(result.isEmpty(),
+        "Expected empty optional when there is no current review stage to advance from.");
+  }
+
+  @Test
+  void shouldReturnEmptyWhenStatusPresentButCurrentIsNull() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"))));
+
+    // Status is non-null but current() is null — hits the second condition in getCurrentReviewStage
+    LtftForm form = formWithDbc(DBC);
+    form.setStatus(Status.builder().build()); // current() is null
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    assertTrue(result.isEmpty(),
+        "Expected empty optional when status is present but current status is null.");
+  }
+
+  @Test
+  void shouldReturnEmptyWhenFormHasNoProgrammeMembershipForAdvance() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(stage("Triage"))));
+
+    LtftForm form = formWithNoProgrammeMembership();
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    assertTrue(result.isEmpty(),
+        "Expected empty optional when form has no programme membership.");
+  }
+
+  @Test
+  void shouldAllowUnsubmitFromAnyStageWhenNoWorkflowConfigured() {
+    LtftForm form = formWithDbc(DBC);
+
+    assertTrue(service.canTransitionToLifecycleState(form, UNSUBMITTED),
+        "Expected UNSUBMIT to be allowed with no workflow.");
+  }
+
+  @Test
+  void shouldAllowUnsubmitFromFirstStage() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 0, "Triage");
+
+    assertTrue(service.canTransitionToLifecycleState(form, UNSUBMITTED),
+        "Expected UNSUBMIT to be allowed from first stage.");
+  }
+
+  @Test
+  void shouldAllowUnsubmitFromMiddleStage() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 1, "Manager Review");
+
+    assertTrue(service.canTransitionToLifecycleState(form, UNSUBMITTED),
+        "Expected UNSUBMIT to be allowed from middle stage.");
+  }
+
+  @Test
+  void shouldAllowUnsubmitFromFinalStage() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 2, "Dean Approval");
+
+    assertTrue(service.canTransitionToLifecycleState(form, UNSUBMITTED),
+        "Expected UNSUBMIT to be allowed from final stage.");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, names = {"APPROVED", "REJECTED", "WITHDRAWN"})
+  void shouldDenyTerminalTransitionFromNonFinalStageWhenWorkflowConfigured(
+      LifecycleState targetState) {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 0, "Triage");
+
+    assertFalse(service.canTransitionToLifecycleState(form, targetState),
+        "Expected terminal transition to be denied from non-final stage.");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, names = {"APPROVED", "REJECTED", "WITHDRAWN"})
+  void shouldDenyTerminalTransitionFromFinalConfiguredStageWhenWorkflowConfigured(
+      LifecycleState targetState) {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"), stage("Dean Approval"))));
+
+    // At the final configured stage (index 2), not yet at the terminal stage.
+    LtftForm form = formAtReviewStage(DBC, 2, "Dean Approval");
+
+    assertFalse(service.canTransitionToLifecycleState(form, targetState),
+        "Expected terminal transition to be denied from final configured stage "
+            + "(must advance to terminal stage first).");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, names = {"APPROVED", "REJECTED", "WITHDRAWN"})
+  void shouldAllowTerminalTransitionFromTerminalStageWhenWorkflowConfigured(
+      LifecycleState targetState) {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"), stage("Dean Approval"))));
+
+    // At the implicit terminal stage (index = stages.size() = 3).
+    LtftForm form = formAtReviewStage(DBC, 3, TERMINAL_STAGE_LABEL);
+
+    assertTrue(service.canTransitionToLifecycleState(form, targetState),
+        "Expected terminal transition to be allowed from the terminal stage.");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, names = {"APPROVED", "REJECTED", "WITHDRAWN"})
+  void shouldAllowTerminalTransitionWhenNoWorkflowConfiguredForDbc(LifecycleState targetState) {
+    // No workflow entry for DBC — existing behaviour applies.
+    LtftForm form = formWithDbc(DBC);
+
+    assertTrue(service.canTransitionToLifecycleState(form, targetState),
+        "Expected terminal transition to be allowed when no workflow is configured.");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, names = {"APPROVED", "REJECTED", "WITHDRAWN"})
+  void shouldAllowTerminalTransitionWhenWorkflowExistsButNoCurrentReviewStage(
+      LifecycleState targetState) {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(stage("Triage"))));
+
+    // Form has content + DBC but no reviewStage in current status — pre-workflow form.
+    LtftForm form = formWithDbc(DBC);
+    form.setStatus(Status.builder()
+        .current(StatusInfo.builder().state(SUBMITTED).build()) // reviewStage is null
+        .build());
+
+    assertTrue(service.canTransitionToLifecycleState(form, targetState),
+        "Expected terminal transition to be allowed for pre-workflow form with null reviewStage.");
+  }
+
+  @Test
+  void shouldDenySingleStageWorkflowApprovalAtStageZero() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(stage("Only Stage"))));
+
+    LtftForm form = formAtReviewStage(DBC, 0, "Only Stage");
+
+    assertFalse(service.canTransitionToLifecycleState(form, APPROVED),
+        "Expected APPROVE to be denied from the only configured stage "
+            + "(must advance to terminal stage first).");
+  }
+
+  @Test
+  void shouldAllowSingleStageWorkflowApprovalAtTerminalStage() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(stage("Only Stage"))));
+
+    // At terminal stage (index = stages.size() = 1).
+    LtftForm form = formAtReviewStage(DBC, 1, TERMINAL_STAGE_LABEL);
+
+    assertTrue(service.canTransitionToLifecycleState(form, APPROVED),
+        "Expected APPROVE to be allowed from the terminal stage of a single-stage workflow.");
+  }
+
+  @Test
+  void shouldHandleDifferentDbcsIndependently() {
+    String dbc2 = "1-1RUZUSF";
+    Map<String, List<StateStage>> workflows = new HashMap<>();
+    workflows.put(DBC, List.of(stage("Triage"), stage("Dean Approval")));
+    workflows.put(dbc2, List.of(stage("Completeness checks")));
+    workflowProperties.setReviewWorkflows(workflows);
+
+    // DBC at terminal stage — allow approve
+    LtftForm formDbc1 = formAtReviewStage(DBC, 2, TERMINAL_STAGE_LABEL);
+    assertTrue(service.canTransitionToLifecycleState(formDbc1, APPROVED),
+        "Expected APPROVE for DBC1 at terminal stage.");
+
+    // DBC2 at terminal stage — allow approve
+    LtftForm formDbc2 = formAtReviewStage(dbc2, 1, TERMINAL_STAGE_LABEL);
+    assertTrue(service.canTransitionToLifecycleState(formDbc2, APPROVED),
+        "Expected APPROVE for DBC2 at terminal stage.");
+
+    // DBC at first stage — deny approve
+    LtftForm formDbc1Stage0 = formAtReviewStage(DBC, 0, "Triage");
+    assertFalse(service.canTransitionToLifecycleState(formDbc1Stage0, APPROVED),
+        "Expected APPROVE to be denied for DBC1 at non-final stage.");
+
+    // DBC at final configured stage — deny approve (must reach terminal first)
+    LtftForm formDbc1FinalConfigured = formAtReviewStage(DBC, 1, "Dean Approval");
+    assertFalse(service.canTransitionToLifecycleState(formDbc1FinalConfigured, APPROVED),
+        "Expected APPROVE to be denied for DBC1 at final configured stage.");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, names = {"APPROVED", "REJECTED", "WITHDRAWN"})
+  void shouldAllowTerminalTransitionWhenAllStagesDisabled(LifecycleState targetState) {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        disabledStage("Triage"), disabledStage("Manager Review"))));
+
+    LtftForm form = formWithDbc(DBC);
+
+    assertTrue(service.canTransitionToLifecycleState(form, targetState),
+        "Expected terminal transition to be allowed when all stages disabled.");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, names = {"APPROVED", "REJECTED", "WITHDRAWN"})
+  void shouldDenyTerminalTransitionFromEnabledStageWhenAllSubsequentStagesDisabled(
+      LifecycleState targetState) {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), disabledStage("Manager Review"))));
+
+    // At the last enabled stage, but not yet at the terminal stage.
+    LtftForm form = formAtReviewStage(DBC, 0, "Triage");
+
+    assertFalse(service.canTransitionToLifecycleState(form, targetState),
+        "Expected terminal transition denied from enabled stage "
+            + "(must advance to terminal stage first).");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, names = {"APPROVED", "REJECTED", "WITHDRAWN"})
+  void shouldDenyTerminalTransitionFromEnabledStageWhenEnabledStagesFollowIt(
+      LifecycleState targetState) {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), disabledStage("Middle"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 0, "Triage");
+
+    assertFalse(service.canTransitionToLifecycleState(form, targetState),
+        "Expected terminal transition denied when an enabled stage follows the current stage.");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, names = {"APPROVED", "REJECTED", "WITHDRAWN"})
+  void shouldDenyTerminalTransitionFromDisabledStageWhenNoEnabledStagesFollowIt(
+      LifecycleState targetState) {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), disabledStage("Manager Review"))));
+
+    // At a disabled final stage, but not yet at the terminal stage.
+    LtftForm form = formAtReviewStage(DBC, 1, "Manager Review");
+
+    assertFalse(service.canTransitionToLifecycleState(form, targetState),
+        "Expected terminal transition denied from disabled stage "
+            + "(must advance to terminal stage first).");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, names = {"APPROVED", "REJECTED", "WITHDRAWN"})
+  void shouldDenyTerminalTransitionFromDisabledStageWhenEnabledStagesFollowIt(
+      LifecycleState targetState) {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), disabledStage("Middle"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 1, "Middle");
+
+    assertFalse(service.canTransitionToLifecycleState(form, targetState),
+        "Expected terminal transition denied from disabled stage when enabled stages follow it.");
+  }
+
+  @Test
+  void shouldAllowUnsubmitFromDisabledStage() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), disabledStage("Manager Review"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 1, "Manager Review");
+
+    assertTrue(service.canTransitionToLifecycleState(form, UNSUBMITTED),
+        "Expected UNSUBMIT to be allowed from a disabled stage.");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, names = {"APPROVED", "REJECTED", "WITHDRAWN"})
+  void shouldAllowTerminalTransitionWhenFormHasNoProgrammeMembership(
+      LifecycleState targetState) {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(stage("Triage"))));
+
+    // No programme membership → dbc is null → no configured stages → allow
+    LtftForm form = formWithNoProgrammeMembership();
+
+    assertTrue(service.canTransitionToLifecycleState(form, targetState),
+        "Expected terminal transition allowed when form has no programme membership.");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, names = {"APPROVED", "REJECTED", "WITHDRAWN"})
+  void shouldAllowTerminalTransitionWhenStatusPresentButCurrentIsNullAndWorkflowConfigured(
+      LifecycleState targetState) {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(stage("Triage"))));
+
+    // Status is non-null but current() is null — getCurrentReviewStage returns null.
+    // Treated as a pre-workflow form; transition is allowed.
+    LtftForm form = formWithDbc(DBC);
+    form.setStatus(Status.builder().build()); // current() is null
+
+    assertTrue(service.canTransitionToLifecycleState(form, targetState),
+        "Expected terminal transition allowed when status.current() is null — pre-workflow form.");
+  }
+
+  // -- getWorkflowDto --
+
+  @Test
+  void shouldReturnEmptyStagesWhenNoWorkflowConfigured() {
+    LtftForm form = formWithDbc(DBC);
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Unexpected stages.", dto.stages(), empty());
+    assertThat("Unexpected current stage.", dto.currentStage(), nullValue());
+  }
+
+  @Test
+  void shouldReturnOnlyEnabledStageLabelsWhenFormNotSubmitted() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), disabledStage("Middle"), stage("Dean Approval"))));
+
+    LtftForm form = formWithDbc(DBC); // not SUBMITTED
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Unexpected stages.", dto.stages(),
+        contains("Triage", "Dean Approval", TERMINAL_STAGE_LABEL));
+    assertThat("Unexpected current stage.", dto.currentStage(), nullValue());
+  }
+
+  @Test
+  void shouldReturnNullCurrentStageWhenFormNotSubmitted() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"), stage("Dean Approval"))));
+
+    LtftForm form = formWithDbc(DBC); // no status set
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Unexpected stages.", dto.stages(),
+        contains("Triage", "Manager Review", "Dean Approval", TERMINAL_STAGE_LABEL));
+
+    assertThat("Unexpected current stage when not submitted.", dto.currentStage(), nullValue());
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, mode = Mode.EXCLUDE, names = "SUBMITTED")
+  void shouldReturnNullCurrentStageForNonSubmittedStates(LifecycleState state) {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(stage("Triage"))));
+
+    LtftForm form = formWithDbc(DBC);
+    form.setStatus(Status.builder()
+        .current(StatusInfo.builder().state(state)
+            .reviewStage(new ReviewStageStatus(0, "Triage")).build())
+        .build());
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Unexpected stages.", dto.stages(),
+        contains("Triage", TERMINAL_STAGE_LABEL));
+
+    assertThat("Unexpected current stage for state " + state + ".", dto.currentStage(),
+        nullValue());
+  }
+
+  @Test
+  void shouldReturnCurrentStagePositionInVisibleListWhenFormSubmitted() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 1, "Manager Review");
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Unexpected stages.", dto.stages(),
+        contains("Triage", "Manager Review", "Dean Approval", TERMINAL_STAGE_LABEL));
+    assertThat("Unexpected current stage.", dto.currentStage(), is(1));
+  }
+
+  @Test
+  void shouldReturnCurrentStageRemappedPositionWhenDisabledStagesExistBefore() {
+    // Disabled stage at index 1 shifts Dean Approval from abs-index 2 to visible-index 1.
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), disabledStage("Middle"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 2, "Dean Approval");
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Unexpected stages.", dto.stages(),
+        contains("Triage", "Dean Approval", TERMINAL_STAGE_LABEL));
+    assertThat("Unexpected current stage.", dto.currentStage(), is(1));
+  }
+
+  @Test
+  void shouldExcludeDisabledStageWhenFormIsNotCurrentlyInIt() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), disabledStage("Middle"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 0, "Triage");
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Unexpected stages.", dto.stages(),
+        contains("Triage", "Dean Approval", TERMINAL_STAGE_LABEL));
+    assertThat("Unexpected current stage.", dto.currentStage(), is(0));
+  }
+
+  @Test
+  void shouldIncludeCurrentDisabledStageInListAtCorrectPosition() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), disabledStage("Middle"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 1, "Middle");
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Unexpected stages.", dto.stages(),
+        contains("Triage", "Middle", "Dean Approval", TERMINAL_STAGE_LABEL));
+    assertThat("Unexpected current stage.", dto.currentStage(), is(1));
+  }
+
+  @Test
+  void shouldReturnNullCurrentStageWhenSubmittedWithNoReviewStage() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(stage("Triage"))));
+
+    LtftForm form = formWithDbc(DBC);
+    form.setStatus(Status.builder()
+        .current(StatusInfo.builder().state(SUBMITTED).build()) // no reviewStage
+        .build());
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Unexpected stages.", dto.stages(),
+        contains("Triage", TERMINAL_STAGE_LABEL));
+    assertThat("Unexpected current stage when no review stage set.", dto.currentStage(),
+        nullValue());
+  }
+
+  @Test
+  void shouldReturnEmptyStagesAndNullCurrentStageWhenAllStagesDisabled() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        disabledStage("Triage"), disabledStage("Middle"))));
+
+    LtftForm form = formWithDbc(DBC);
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Unexpected stages when all disabled.", dto.stages(), empty());
+    assertThat("Unexpected current stage when all disabled.", dto.currentStage(), nullValue());
+  }
+
+  @Test
+  void shouldReturnEmptyStagesWhenFormHasContentButNoProgrammeMembership() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(stage("Triage"))));
+
+    LtftForm form = formWithNoProgrammeMembership();
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Unexpected stages when no programme membership.", dto.stages(), empty());
+    assertThat("Unexpected current stage when no programme membership.", dto.currentStage(),
+        nullValue());
+  }
+
+  @Test
+  void shouldReturnNullCurrentStageWhenStatusPresentButCurrentIsNull() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"))));
+
+    // Status is non-null but current() is null — isSubmitted evaluates to false
+    LtftForm form = formWithDbc(DBC);
+    form.setStatus(Status.builder().build()); // current() is null
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Unexpected stages.", dto.stages(),
+        contains("Triage", "Manager Review", TERMINAL_STAGE_LABEL));
+    assertThat("Unexpected current stage when status.current() is null.", dto.currentStage(),
+        nullValue());
+  }
+
+  @Test
+  void shouldReturnTerminalStagePositionWhenFormIsAtTerminalStage() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"), stage("Dean Approval"))));
+
+    // Form at terminal stage (index = stages.size() = 3).
+    LtftForm form = formAtReviewStage(DBC, 3, TERMINAL_STAGE_LABEL);
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Unexpected stages.", dto.stages(),
+        contains("Triage", "Manager Review", "Dean Approval", TERMINAL_STAGE_LABEL));
+    assertThat("Unexpected current stage at terminal.", dto.currentStage(), is(3));
+  }
+
+  @Test
+  void shouldAllowUnsubmitFromTerminalStage() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"), stage("Dean Approval"))));
+
+    LtftForm form = formAtReviewStage(DBC, 3, TERMINAL_STAGE_LABEL);
+
+    assertTrue(service.canTransitionToLifecycleState(form, UNSUBMITTED),
+        "Expected UNSUBMIT to be allowed from terminal stage.");
+  }
+}


### PR DESCRIPTION
- Add ReviewWorkflowProperties and StateStage for per-DBC stage configuration
- Add ReviewStageStatus model to carry review stage through StatusInfo history
- Extend AbstractAuditedForm with setReviewStage() and reviewStage in StatusInfo
- Add ReviewStageService with full stage navigation rules (first-enabled on submit, skip disabled, terminal stage, clear on leave SUBMITTED)
- Add ReviewWorkflowDto
- Wire ReviewStageService into LtftService constructor
- Add GET /api/admin/ltft/{id}/review-workflow endpoint to AdminLtftResource
- Unit tests for all of the above