### PR TITLE
fix(formr): migrate in-work and latest first

### DIFF
--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAuditedIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAuditedIntegrationTest.java
@@ -25,12 +25,16 @@ package uk.nhs.hee.tis.trainee.forms.migration;
 import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.spy;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.DELETED;
 import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.DRAFT;
@@ -46,13 +50,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TimeZone;
 import java.util.UUID;
 import org.bson.Document;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -107,6 +115,8 @@ class ConvertFormrToAuditedIntegrationTest {
 
   private static final String METADATA_LIFECYCLE_STATE = "lifecyclestate";
 
+  private static TimeZone originalTimeZone;
+
   @Container
   @ServiceConnection
   private static final MongoDBContainer mongoContainer = new MongoDBContainer(
@@ -131,6 +141,9 @@ class ConvertFormrToAuditedIntegrationTest {
 
   @BeforeAll
   static void setUpBeforeAll() throws IOException, InterruptedException {
+    originalTimeZone = TimeZone.getDefault();
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+
     // Create S3 bucket.
     String[] createBucketCmd = {
         "awslocal", "s3api", "create-bucket",
@@ -149,6 +162,11 @@ class ConvertFormrToAuditedIntegrationTest {
     };
     bucketResult = localstack.execInContainer(versionBucketCmd);
     assertThat("S3 bucket versioning failed.", bucketResult.getExitCode(), is(0));
+  }
+
+  @AfterAll
+  static void tearDownAfterAll() {
+    TimeZone.setDefault(originalTimeZone);
   }
 
   @Autowired
@@ -190,6 +208,98 @@ class ConvertFormrToAuditedIntegrationTest {
 
   @ParameterizedTest
   @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
+  void shouldMigrateFormsInPriorityOrder(Class<? extends AbstractFormR<?>> formClass)
+      throws JsonProcessingException {
+    String traineeId = UUID.randomUUID().toString();
+    String collectionName = mongoTemplate.getCollectionName(formClass);
+    LocalDateTime now = LocalDateTime.now();
+
+    UUID draftId1 = UUID.randomUUID();
+    Map<String, Object> draftFields1 = createFormFields(formClass, draftId1, traineeId, DRAFT, null,
+        now.plusDays(10), "draft");
+    mongoTemplate.save(new Document(draftFields1), collectionName);
+
+    UUID draftId2 = UUID.randomUUID();
+    Map<String, Object> draftFields2 = createFormFields(formClass, draftId2, traineeId, DRAFT, null,
+        now.minusDays(10), "draft");
+    mongoTemplate.save(new Document(draftFields2), collectionName);
+
+    UUID submittedId1 = UUID.randomUUID();
+    Map<String, Object> submittedFields1 = createFormFields(formClass, submittedId1, traineeId,
+        SUBMITTED, now.minusDays(10), now, "submitted");
+    mongoTemplate.save(new Document(submittedFields1), collectionName);
+    uploadForm(submittedFields1, formClass);
+
+    UUID submittedId2 = UUID.randomUUID();
+    Map<String, Object> submittedFields2 = createFormFields(formClass, submittedId2, traineeId,
+        SUBMITTED, now.plusDays(10), now, "submitted");
+    mongoTemplate.save(new Document(submittedFields2), collectionName);
+    uploadForm(submittedFields2, formClass);
+
+    UUID unsubmittedId1 = UUID.randomUUID();
+    Map<String, Object> unsubmittedFields1 = createFormFields(formClass, unsubmittedId1, traineeId,
+        SUBMITTED, now.plusDays(10), now, "unsubmitted");
+    uploadForm(unsubmittedFields1, formClass);
+    unsubmittedFields1 = createFormFields(formClass, unsubmittedId1, traineeId, UNSUBMITTED,
+        now.plusDays(10), now, "unsubmitted");
+    mongoTemplate.save(new Document(unsubmittedFields1), collectionName);
+    uploadForm(unsubmittedFields1, formClass);
+
+    UUID unsubmittedId2 = UUID.randomUUID();
+    Map<String, Object> unsubmittedFields2 = createFormFields(formClass, unsubmittedId2, traineeId,
+        SUBMITTED, now.minusDays(10), now, "unsubmitted");
+    uploadForm(unsubmittedFields2, formClass);
+    unsubmittedFields2 = createFormFields(formClass, unsubmittedId2, traineeId, UNSUBMITTED,
+        now.minusDays(10), now, "unsubmitted");
+    mongoTemplate.save(new Document(unsubmittedFields2), collectionName);
+    uploadForm(unsubmittedFields2, formClass);
+
+    UUID deletedId1 = UUID.randomUUID();
+    Map<String, Object> deletedFields1 = createFormFields(formClass, deletedId1, traineeId, DELETED,
+        now.plusDays(10), now, "deleted");
+    mongoTemplate.save(new Document(deletedFields1), collectionName);
+    uploadForm(deletedFields1, formClass);
+
+    UUID deletedId2 = UUID.randomUUID();
+    Map<String, Object> deletedFields2 = createFormFields(formClass, deletedId2, traineeId, DELETED,
+        now.minusDays(10), now, "deleted");
+    mongoTemplate.save(new Document(deletedFields2), collectionName);
+    uploadForm(deletedFields2, formClass);
+
+    mongoTemplate = spy(mongoTemplate);
+    migration = new ConvertFormrToAudited(mongoTemplate, s3Client, env);
+    migration.migrateCollections();
+
+    InOrder inOrder = inOrder(mongoTemplate);
+
+    inOrder.verify(mongoTemplate)
+        .save(Mockito.<Document>argThat(document -> document.get(FIELD_FORM_ID).equals(draftId1)),
+            eq(collectionName));
+    inOrder.verify(mongoTemplate)
+        .save(Mockito.<Document>argThat(document -> document.get(FIELD_FORM_ID).equals(draftId2)),
+            eq(collectionName));
+    inOrder.verify(mongoTemplate).save(
+        Mockito.<Document>argThat(document -> document.get(FIELD_FORM_ID).equals(unsubmittedId1)),
+        eq(collectionName));
+    inOrder.verify(mongoTemplate).save(
+        Mockito.<Document>argThat(document -> document.get(FIELD_FORM_ID).equals(unsubmittedId2)),
+        eq(collectionName));
+    inOrder.verify(mongoTemplate).save(
+        Mockito.<Document>argThat(document -> document.get(FIELD_FORM_ID).equals(submittedId2)),
+        eq(collectionName));
+    inOrder.verify(mongoTemplate).save(
+        Mockito.<Document>argThat(document -> document.get(FIELD_FORM_ID).equals(submittedId1)),
+        eq(collectionName));
+    inOrder.verify(mongoTemplate)
+        .save(Mockito.<Document>argThat(document -> document.get(FIELD_FORM_ID).equals(deletedId1)),
+            eq(collectionName));
+    inOrder.verify(mongoTemplate)
+        .save(Mockito.<Document>argThat(document -> document.get(FIELD_FORM_ID).equals(deletedId2)),
+            eq(collectionName));
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
   void shouldMigrateFormMetadata(Class<? extends AbstractFormR<?>> formClass)
       throws JsonProcessingException {
     UUID formId = UUID.randomUUID();
@@ -225,6 +335,78 @@ class ConvertFormrToAuditedIntegrationTest {
         is(submissionDate.toInstant(UTC).truncatedTo(MILLIS)));
     assertThat("Unexpected last modified.", migratedForm.getLastModified(),
         is(submissionDate.toInstant(UTC).truncatedTo(MILLIS)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
+  void shouldGenerateConsistentFormRefs(Class<? extends AbstractFormR<?>> formClass)
+      throws JsonProcessingException {
+    String traineeId = UUID.randomUUID().toString();
+    String collectionName = mongoTemplate.getCollectionName(formClass);
+    LocalDateTime now = LocalDateTime.now();
+
+    UUID draftId = UUID.randomUUID();
+    Map<String, Object> draftFields = createFormFields(formClass, draftId, traineeId, DRAFT, null,
+        now, "noref");
+    mongoTemplate.save(new Document(draftFields), collectionName);
+
+    UUID firstId = UUID.randomUUID();
+    Map<String, Object> firstFields = createFormFields(formClass, firstId, traineeId, DELETED,
+        now.minusDays(1), now.minusDays(1), "001");
+    mongoTemplate.save(new Document(firstFields), collectionName);
+    uploadForm(firstFields, formClass);
+
+    UUID secondId = UUID.randomUUID();
+    Map<String, Object> secondFields = createFormFields(formClass, secondId, traineeId, SUBMITTED,
+        now, now, "002");
+    mongoTemplate.save(new Document(secondFields), collectionName);
+    uploadForm(secondFields, formClass);
+
+    UUID thirdId = new UUID(0L, 0L);
+    Map<String, Object> thirdFields = createFormFields(formClass, thirdId, traineeId, SUBMITTED,
+        now.plusDays(1), now, "003");
+    mongoTemplate.save(new Document(thirdFields), collectionName);
+    uploadForm(thirdFields, formClass);
+
+    UUID fourthId = new UUID(0L, 1L);
+    Map<String, Object> fourthFields = createFormFields(formClass, fourthId, traineeId, SUBMITTED,
+        now.plusDays(1), now, "004");
+    mongoTemplate.save(new Document(fourthFields), collectionName);
+    uploadForm(fourthFields, formClass);
+
+    UUID fifthId = UUID.randomUUID();
+    Map<String, Object> fifthFields = createFormFields(formClass, fifthId, traineeId, SUBMITTED,
+        now.plusDays(2), now.plusDays(2), "005");
+    uploadForm(fifthFields, formClass);
+    fifthFields = createFormFields(formClass, fifthId, traineeId, UNSUBMITTED, now.plusDays(2),
+        now.plusDays(2), "005");
+    mongoTemplate.save(new Document(fifthFields), collectionName);
+    uploadForm(fifthFields, formClass);
+
+    migration.migrateCollections();
+
+    Map<UUID, String> expectedSuffix = Map.of(
+        firstId, "001",
+        secondId, "002",
+        thirdId, "003",
+        fourthId, "004",
+        fifthId, "005"
+    );
+
+    Optional<? extends AbstractFormR<?>> foundForm = getMigratedForm(draftId, formClass);
+    assertThat("Expected form not found.", foundForm.isPresent(), is(true));
+
+    AbstractFormR<?> migratedForm = foundForm.get();
+    assertThat("Unexpected form ref.", migratedForm.getFormRef(), nullValue());
+
+    for (var entry : expectedSuffix.entrySet()) {
+      foundForm = getMigratedForm(entry.getKey(), formClass);
+      assertThat("Expected form not found.", foundForm.isPresent(), is(true));
+
+      migratedForm = foundForm.get();
+      assertThat("Unexpected form ref suffix.", migratedForm.getFormRef(),
+          endsWith(entry.getValue()));
+    }
   }
 
   @ParameterizedTest

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAudited.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAudited.java
@@ -36,6 +36,7 @@ import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
 import io.mongock.api.annotations.RollbackExecution;
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -55,6 +56,10 @@ import org.bson.Document;
 import org.springframework.core.env.Environment;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.ComparisonOperators;
+import org.springframework.data.mongodb.core.aggregation.ConditionalOperators;
+import org.springframework.data.mongodb.core.aggregation.ConditionalOperators.Switch;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -104,12 +109,15 @@ public class ConvertFormrToAudited {
   private static final String FIELD_LAST_MODIFIED = "lastModified";
 
   private static final String METADATA_LIFECYCLE_STATE = "lifecyclestate";
+  private static final String QUERY_FIELD_LIFECYCLE_PRIORITY = "migrationPriority";
+  private static final String FIELD_STATUS_SUBMITTED = "status.submitted";
 
   private final MongoTemplate mongoTemplate;
   private final S3Client s3Client;
 
   private final String bucket;
 
+  private Instant startTime;
   private int lastLoggedPercent;
 
   /**
@@ -126,36 +134,44 @@ public class ConvertFormrToAudited {
    */
   @Execution
   public void migrateCollections() {
-    migrateFormr(FormRPartA.class, FormrPartaSubmissionHistory.class, "%s/forms/formr-a/%s.json");
-    migrateFormr(FormRPartB.class, FormrPartbSubmissionHistory.class, "%s/forms/formr-b/%s.json");
+    // Migrate in-work states first to unblock any active forms.
+    List<LifecycleState> priorityStates = List.of(DRAFT, UNSUBMITTED);
+    migrateFormr(FormRPartA.class, priorityStates, FormrPartaSubmissionHistory.class,
+        "%s/forms/formr-a/%s.json");
+    migrateFormr(FormRPartB.class, priorityStates, FormrPartbSubmissionHistory.class,
+        "%s/forms/formr-b/%s.json");
+
+    // Migrate the remaining historic forms.
+    List<LifecycleState> remainingStates = List.of(SUBMITTED, DELETED);
+    migrateFormr(FormRPartA.class, remainingStates, FormrPartaSubmissionHistory.class,
+        "%s/forms/formr-a/%s.json");
+    migrateFormr(FormRPartB.class, remainingStates, FormrPartbSubmissionHistory.class,
+        "%s/forms/formr-b/%s.json");
   }
 
   /**
    * Migrate Form-R collection to the audited form structure.
    *
    * @param formClass              The class of the form to migrate.
+   * @param targetStates           The lifecycle states to include in the migration.
    * @param submissionHistoryClass The class of the form's submission history.
    * @param bucketKeyTemplate      The key template to use with this form.
    */
-  private void migrateFormr(Class<?> formClass, Class<?> submissionHistoryClass,
-      String bucketKeyTemplate) {
+  private void migrateFormr(Class<?> formClass, List<LifecycleState> targetStates,
+      Class<?> submissionHistoryClass, String bucketKeyTemplate) {
     String collectionName = mongoTemplate.getCollectionName(formClass);
-
-    // Content will only be present on the new Form-R Part A and Part B documents, so we can use its
-    // presence to identify documents that need to be migrated.
-    Query query = Query.query(Criteria.where(FIELD_CONTENT).exists(false))
-        .with(Sort.by(Sort.Direction.ASC, FIELD_LAST_MODIFIED_DATE));
-    List<Document> forms = mongoTemplate.find(query, Document.class, collectionName);
-    log.info("Found {} forms of type {}", forms.size(), collectionName);
+    List<Document> forms = findForms(collectionName, targetStates);
+    log.info("Found {} forms of type {} in states {}", forms.size(), collectionName,
+        targetStates);
 
     int successCount = 0;
     int failureCount = 0;
     lastLoggedPercent = 0;
+    startTime = Instant.now();
 
     for (Document form : forms) {
-      String traineeId = form.getString(FIELD_TRAINEE_ID);
       LifecycleState lifecycleState = LifecycleState.valueOf(form.getString(FIELD_LIFECYCLE_STATE));
-      String formRef = lifecycleState != DRAFT ? getFormRef(traineeId, formClass) : null;
+      String formRef = lifecycleState != DRAFT ? getFormRef(form, formClass) : null;
 
       // Delete any built submission history so it can be retried without duplication.
       if (formRef != null) {
@@ -168,6 +184,7 @@ public class ConvertFormrToAudited {
         Instant lastModified = getInstantFromLocalDateTime(form.get(FIELD_LAST_MODIFIED_DATE));
         history = List.of(buildStatusInfo(DRAFT.toString(), form, lastModified, 0));
       } else {
+        String traineeId = form.getString(FIELD_TRAINEE_ID);
         UUID formId = UUID.fromString(form.get(FIELD_ID).toString());
         String formKey = bucketKeyTemplate.formatted(traineeId, formId);
         try {
@@ -191,6 +208,58 @@ public class ConvertFormrToAudited {
   }
 
   /**
+   * Find forms to migrate, sorted so that forms which are most likely to be accessed are processed
+   * first. i.e. DRAFT -> UNSUBMITTED -> SUBMITTED -> DELETED, with most recently submitted or
+   * modified forms first.
+   *
+   * @param collectionName The name of the collection to query.
+   * @param targetStates   The lifecycle states to include in the query.
+   * @return The found forms, sorted by migration priority.
+   */
+  private List<Document> findForms(String collectionName, List<LifecycleState> targetStates) {
+    Aggregation aggregation = Aggregation.newAggregation(
+        // Content will only be present on the new Form-R Part A and Part B documents, so we can use its
+        // presence to identify documents that need to be migrated.
+        Aggregation.match(
+            Criteria.where(FIELD_CONTENT).exists(false)
+                .and(FIELD_LIFECYCLE_STATE).in(targetStates)
+        ),
+        Aggregation.addFields()
+            // Lifecycle state priority ensures trainees have access to the most useful forms first.
+            .addField(QUERY_FIELD_LIFECYCLE_PRIORITY)
+            .withValue(
+                ConditionalOperators.switchCases(
+                    Switch.CaseOperator.when(
+                            ComparisonOperators.valueOf(FIELD_LIFECYCLE_STATE)
+                                .equalToValue(DRAFT))
+                        .then(1),
+                    Switch.CaseOperator.when(
+                            ComparisonOperators.valueOf(FIELD_LIFECYCLE_STATE)
+                                .equalToValue(UNSUBMITTED))
+                        .then(2),
+                    Switch.CaseOperator.when(
+                            ComparisonOperators.valueOf(FIELD_LIFECYCLE_STATE)
+                                .equalToValue(SUBMITTED))
+                        .then(3)
+                ).defaultTo(4)
+            )
+            .build(),
+        Aggregation.sort(
+            // Sorted to process in-work forms first, followed by the most recently actioned.
+            Sort.by(
+                Sort.Order.asc(QUERY_FIELD_LIFECYCLE_PRIORITY),
+                Sort.Order.desc(FIELD_SUBMISSION_DATE),
+                Sort.Order.desc(FIELD_LAST_MODIFIED_DATE)
+            )
+        ),
+        Aggregation.project()
+            .andExclude(QUERY_FIELD_LIFECYCLE_PRIORITY)
+    );
+
+    return mongoTemplate.aggregate(aggregation, collectionName, Document.class).getMappedResults();
+  }
+
+  /**
    * Log the progress every 10 percent.
    *
    * @param successCount The number of successfully migrated forms.
@@ -202,8 +271,29 @@ public class ConvertFormrToAudited {
     int percent = processed * 100 / total;
 
     if (percent > lastLoggedPercent) {
-      log.info("Progress: {}% ({}/{}) (success={} failure={})", percent, processed, total,
-          successCount, failureCount);
+      Instant now = Instant.now();
+      long elapsedSeconds = Duration.between(startTime, now).toSeconds();
+
+      Duration remaining = null;
+      if (elapsedSeconds > 0 && processed > 0 && processed < total) {
+        double processedPerSec = (double) processed / elapsedSeconds;
+        long secRemaining = (long) Math.ceil((total - processed) / processedPerSec);
+        remaining = Duration.ofSeconds(secRemaining);
+      }
+
+      if (remaining != null) {
+        String remainingStr = String.format("%02d:%02d:%02d", remaining.toHours(),
+            remaining.toMinutesPart(), remaining.toSecondsPart());
+
+        log.info(
+            "Progress: {}% ({}/{}) (success={} failure={}) (est. remaining={})",
+            percent, processed, total, successCount, failureCount, remainingStr);
+      } else {
+        log.info(
+            "Progress: {}% ({}/{}) (success={} failure={}) (est. remaining=calculating)",
+            percent, processed, total, successCount, failureCount);
+      }
+
       lastLoggedPercent = percent;
     }
   }
@@ -431,21 +521,44 @@ public class ConvertFormrToAudited {
    * Get the next for reference for the trainee, based on how many forms already have a generated
    * form reference.
    *
-   * @param traineeId The trainee ID.
+   * @param form      The form to get the form reference for.
    * @param formClass The class of the form.
    * @return The generated form reference.
    */
-  private String getFormRef(String traineeId, Class<?> formClass) {
-    String formCollectionName = mongoTemplate.getCollectionName(formClass);
-    long existingRefCount = mongoTemplate.count(
-        Query.query(Criteria
-            .where(FIELD_TRAINEE_ID).is(traineeId)
-            .and(FIELD_FORM_REF).exists(true)
-        ), formCollectionName);
-    return "formr_part%s_%s_%03d".formatted(
-        formClass == FormRPartA.class ? "a" : "b",
-        traineeId,
-        existingRefCount + 1);
+  private String getFormRef(Document form, Class<?> formClass) {
+    String collectionName = mongoTemplate.getCollectionName(formClass);
+    String traineeId = form.getString(FIELD_TRAINEE_ID);
+
+    Query query = Query.query(Criteria.where(FIELD_TRAINEE_ID).is(traineeId));
+    query.fields()
+        .include(FIELD_ID, FIELD_SUBMISSION_DATE, FIELD_STATUS_SUBMITTED);
+    List<String> documentIds = mongoTemplate.find(query, Document.class, collectionName).stream()
+        .filter(doc -> doc.containsKey(FIELD_SUBMISSION_DATE) || (doc.containsKey(FIELD_STATUS)
+            && doc.get(FIELD_STATUS, Document.class).containsKey(FIELD_SUBMITTED))) // Remove draft.
+        .sorted(
+            Comparator
+                .comparing(this::getSubmissionInstant)
+                .thenComparing(doc -> doc.get(FIELD_ID).toString())
+        )
+        .map(doc -> doc.get(FIELD_ID).toString())
+        .toList();
+
+    int submittedIndex = documentIds.indexOf(form.get(FIELD_ID).toString());
+    return "formr_part%s_%s_%03d"
+        .formatted(formClass == FormRPartA.class ? "a" : "b", traineeId, submittedIndex + 1);
+  }
+
+  /**
+   * Get the submission instant for a form, will use the submission date if present or the submitted
+   * timestamp from the status if not.
+   *
+   * @param doc The form document to get the submission instant for.
+   * @return The submission instant for the form.
+   */
+  private Instant getSubmissionInstant(Document doc) {
+    return (doc.containsKey(FIELD_SUBMISSION_DATE)
+        ? doc.get(FIELD_SUBMISSION_DATE, Date.class)
+        : doc.getEmbedded(List.of(FIELD_STATUS, FIELD_SUBMITTED), Date.class)).toInstant();
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAuditedTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAuditedTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -69,6 +70,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.springframework.core.env.Environment;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -130,6 +133,9 @@ class ConvertFormrToAuditedTest {
 
     when(mongoTemplate.getCollectionName(any())).thenReturn("");
     when(mongoTemplate.remove(any(), any(String.class))).thenReturn(DeleteResult.acknowledged(0));
+
+    when(mongoTemplate.aggregate(any(Aggregation.class), anyString(), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()));
   }
 
   @ParameterizedTest
@@ -158,8 +164,11 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before1, before2));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(before2), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before2), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before1), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before1), new Document()));
 
     when(s3Client.listObjectVersions(
         ArgumentMatchers.<Consumer<ListObjectVersionsRequest.Builder>>any()))
@@ -209,8 +218,11 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before1, before2));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(before2), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before2), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before1), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before1), new Document()));
 
     when(s3Client.listObjectVersions(
         ArgumentMatchers.<Consumer<ListObjectVersionsRequest.Builder>>any()))
@@ -260,8 +272,11 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before1, before2));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(before2), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before2), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before1), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before1), new Document()));
 
     when(s3Client.listObjectVersions(
         ArgumentMatchers.<Consumer<ListObjectVersionsRequest.Builder>>any()))
@@ -323,8 +338,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before1, before2));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(before2), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before1), new Document()));
 
     when(s3Client.listObjectVersions(
         ArgumentMatchers.<Consumer<ListObjectVersionsRequest.Builder>>any()))
@@ -385,8 +401,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before1, before2));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(before2), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before1), new Document()));
 
     when(s3Client.listObjectVersions(
         ArgumentMatchers.<Consumer<ListObjectVersionsRequest.Builder>>any()))
@@ -396,7 +413,8 @@ class ConvertFormrToAuditedTest {
 
     assertThrows(RuntimeException.class, () -> migration.migrateCollections());
 
-    verify(mongoTemplate, never()).save(any(), eq(collectionName));
+    // Draft should still save.
+    verify(mongoTemplate, times(1)).save(any(), eq(collectionName));
   }
 
   @ParameterizedTest
@@ -417,8 +435,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()));
 
     mockS3Endpoints(1);
 
@@ -456,8 +475,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()));
 
     migration.migrateCollections();
 
@@ -493,8 +513,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()));
 
     migration.migrateCollections();
 
@@ -527,8 +548,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()));
 
     when(s3Client.listObjectVersions(
         ArgumentMatchers.<Consumer<ListObjectVersionsRequest.Builder>>any()))
@@ -554,14 +576,26 @@ class ConvertFormrToAuditedTest {
         "surname", "Gilliam",
         "email", "anthony.gilliam@example.com",
         "lifecycleState", state.toString(),
+        "submissionDate", Date.from(SUBMISSION_DATE_2),
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_A_COLLECTION)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(PART_A_COLLECTION), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()));
 
-    when(mongoTemplate.count(any(), eq(PART_A_COLLECTION)))
-        .thenReturn(2L);
+    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_A_COLLECTION)))
+        .thenReturn(List.of(
+            new Document(Map.of(
+                "_id", UUID.randomUUID(),
+                "submissionDate", Date.from(SUBMISSION_DATE_1)
+            )),
+            new Document(Map.of(
+                "_id", UUID.randomUUID(),
+                "submissionDate", Date.from(SUBMISSION_DATE_1)
+            )),
+            before
+        ));
 
     when(s3Client.listObjectVersions(
         ArgumentMatchers.<Consumer<ListObjectVersionsRequest.Builder>>any()))
@@ -636,8 +670,15 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(state == UNSUBMITTED ? List.of(before) : List.of(),
+            new Document()))
+        .thenReturn(new AggregationResults<>(state == UNSUBMITTED ? List.of(before) : List.of(),
+            new Document()))
+        .thenReturn(new AggregationResults<>(state != UNSUBMITTED ? List.of(before) : List.of(),
+            new Document()))
+        .thenReturn(new AggregationResults<>(state != UNSUBMITTED ? List.of(before) : List.of(),
+            new Document()));
 
     when(s3Client.listObjectVersions(
         ArgumentMatchers.<Consumer<ListObjectVersionsRequest.Builder>>any()))
@@ -667,8 +708,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()));
 
     migration.migrateCollections();
 
@@ -695,8 +737,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()));
 
     mockS3Endpoints(3);
 
@@ -728,8 +771,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()));
 
     migration.migrateCollections();
 
@@ -766,8 +810,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()));
 
     migration.migrateCollections();
 
@@ -797,15 +842,22 @@ class ConvertFormrToAuditedTest {
         "surname", "Gilliam",
         "email", "anthony.gilliam@example.com",
         "lifecycleState", state.toString(),
-        "submissionDate", Date.from(SUBMISSION_DATE_1),
+        "submissionDate", Date.from(SUBMISSION_DATE_2),
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_A_COLLECTION)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(PART_A_COLLECTION), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()));
 
-    when(mongoTemplate.count(any(), eq(PART_A_COLLECTION)))
-        .thenReturn(2L);
+    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_A_COLLECTION)))
+        .thenReturn(List.of(
+            new Document(Map.of(
+                "_id", UUID.randomUUID(),
+                "submissionDate", Date.from(SUBMISSION_DATE_1)
+            )),
+            before
+        ));
 
     when(s3Client.listObjectVersions(
         ArgumentMatchers.<Consumer<ListObjectVersionsRequest.Builder>>any()))
@@ -881,8 +933,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()));
 
     migration.migrateCollections();
 
@@ -916,8 +969,11 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_A_COLLECTION)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(PART_A_COLLECTION), eq(Document.class)))
+        .thenReturn(
+            new AggregationResults<>(state == DRAFT ? List.of(before) : List.of(), new Document()))
+        .thenReturn(new AggregationResults<>(state == SUBMITTED ? List.of(before) : List.of(),
+            new Document()));
 
     when(s3Client.listObjectVersions(
         ArgumentMatchers.<Consumer<ListObjectVersionsRequest.Builder>>any()))
@@ -978,8 +1034,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_A_COLLECTION)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(PART_A_COLLECTION), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()));
 
     when(s3Client.listObjectVersions(
         ArgumentMatchers.<Consumer<ListObjectVersionsRequest.Builder>>any()))
@@ -1062,8 +1119,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()));
 
     when(s3Client.listObjectVersions(
         ArgumentMatchers.<Consumer<ListObjectVersionsRequest.Builder>>any()))
@@ -1124,8 +1182,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()));
 
     mockS3Endpoints(4);
 
@@ -1185,8 +1244,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(DELETED_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()));
 
     when(s3Client.listObjectVersions(
         ArgumentMatchers.<Consumer<ListObjectVersionsRequest.Builder>>any()))
@@ -1243,8 +1303,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(SUBMITTED_2_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()));
 
     when(s3Client.listObjectVersions(
         ArgumentMatchers.<Consumer<Builder>>any()))
@@ -1303,8 +1364,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(earlierModified),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()));
 
     when(s3Client.listObjectVersions(
         ArgumentMatchers.<Consumer<ListObjectVersionsRequest.Builder>>any()))
@@ -1401,8 +1463,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(SUBMITTED_2_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()));
 
     mockListObjectVersions(1);
     mockHeadObject();
@@ -1467,6 +1530,10 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()));
+
     when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
         .thenReturn(List.of(before));
 
@@ -1517,8 +1584,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()));
 
     mockListObjectVersions(3);
     mockHeadObject();
@@ -1613,8 +1681,9 @@ class ConvertFormrToAuditedTest {
         "lastModifiedDate", Date.from(LAST_MODIFIED),
         "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
     ));
-    when(mongoTemplate.find(any(), eq(Document.class), eq(collectionName)))
-        .thenReturn(List.of(before));
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(collectionName), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()))
+        .thenReturn(new AggregationResults<>(List.of(before), new Document()));
 
     mockS3Endpoints(3);
 


### PR DESCRIPTION
Migrating FormRs to the audited form structure will take some time due to the rebuild of the history from S3. To reduce the impact on trainees, the in-work forms (DRAFT/UNSUBMITTED) should be processed first so they can be made available again.
The remaining forms should be processed in submission order, so more recent forms are available sooner in case of any need to un-submit or otherwise access a recent form.

Due to the change of ordering the form reference generator must be changed to accomodate.

TIS21-8706
TIS21-8707
TIS21-8788