### PR TITLE
feat: hide unmigrated FormRs from GET results

### DIFF
--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminFormRPartAResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminFormRPartAResourceIntegrationTest.java
@@ -209,6 +209,7 @@ class AdminFormRPartAResourceIntegrationTest {
     form.setTraineeTisId(TRAINEE_ID);
     form.setStatus(Status.builder().submitted(Instant.now()).build());
     form.setLifecycleState(excludedState);
+    form.setContent(FormrPartaContent.builder().build());
     template.insert(form);
 
     mockMvc.perform(get("/api/admin/formr-parta/{formId}", FORM_ID)
@@ -225,6 +226,7 @@ class AdminFormRPartAResourceIntegrationTest {
     form.setTraineeTisId(TRAINEE_ID);
     form.setStatus(Status.builder().submitted(Instant.now()).build());
     form.setLifecycleState(includedState);
+    form.setContent(FormrPartaContent.builder().build());
     template.insert(form);
 
     mockMvc.perform(get("/api/admin/formr-parta/{formId}", FORM_ID)
@@ -247,6 +249,7 @@ class AdminFormRPartAResourceIntegrationTest {
     form.setId(FORM_ID);
     form.setTraineeTisId(TRAINEE_ID);
     form.setLifecycleState(SUBMITTED);
+    form.setContent(FormrPartaContent.builder().build());
     template.insert(form);
 
     when(snsClient.publish(any(PublishRequest.class))).thenReturn(mock());
@@ -263,6 +266,7 @@ class AdminFormRPartAResourceIntegrationTest {
     submittedForm.setId(UUID.randomUUID());
     submittedForm.setTraineeTisId(TRAINEE_ID);
     submittedForm.setLifecycleState(SUBMITTED);
+    submittedForm.setContent(FormrPartaContent.builder().build());
     template.insert(submittedForm);
 
     FormRPartA excludedForm = new FormRPartA();
@@ -273,6 +277,7 @@ class AdminFormRPartAResourceIntegrationTest {
             : null)
         .build());
     excludedForm.setLifecycleState(excludedState);
+    excludedForm.setContent(FormrPartaContent.builder().build());
     template.insert(excludedForm);
 
     mockMvc.perform(get("/api/admin/formr-parta")
@@ -291,6 +296,7 @@ class AdminFormRPartAResourceIntegrationTest {
     submittedForm.setId(UUID.randomUUID());
     submittedForm.setTraineeTisId(TRAINEE_ID);
     submittedForm.setLifecycleState(SUBMITTED);
+    submittedForm.setContent(FormrPartaContent.builder().build());
     LocalDateTime submissionDate = LocalDateTime.ofInstant(submittedForm.getStatus().submitted(),
         timezone);
 

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminFormRPartBResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminFormRPartBResourceIntegrationTest.java
@@ -214,6 +214,7 @@ class AdminFormRPartBResourceIntegrationTest {
     form.setId(FORM_ID);
     form.setTraineeTisId(TRAINEE_ID);
     form.setLifecycleState(SUBMITTED);
+    form.setContent(FormrPartbContent.builder().build());
     template.insert(form);
 
     when(snsClient.publish(any(PublishRequest.class))).thenReturn(mock());
@@ -236,6 +237,7 @@ class AdminFormRPartBResourceIntegrationTest {
     form.setId(FORM_ID);
     form.setTraineeTisId(TRAINEE_ID);
     form.setStatus(Status.builder().submitted(Instant.now()).build());
+    form.setContent(FormrPartbContent.builder().build());
     template.insert(form);
 
     mockMvc.perform(request(method, uriTemplate, FORM_ID)
@@ -250,6 +252,7 @@ class AdminFormRPartBResourceIntegrationTest {
     submittedForm.setId(UUID.randomUUID());
     submittedForm.setTraineeTisId(TRAINEE_ID);
     submittedForm.setLifecycleState(SUBMITTED);
+    submittedForm.setContent(FormrPartbContent.builder().build());
     template.insert(submittedForm);
 
     FormRPartB excludedForm = new FormRPartB();
@@ -260,6 +263,7 @@ class AdminFormRPartBResourceIntegrationTest {
             : null)
         .build());
     excludedForm.setLifecycleState(excludedState);
+    excludedForm.setContent(FormrPartbContent.builder().build());
     template.insert(excludedForm);
 
     mockMvc.perform(get("/api/admin/formr-partb")
@@ -280,12 +284,14 @@ class AdminFormRPartBResourceIntegrationTest {
     includedForm.setTraineeTisId(TRAINEE_ID);
     includedForm.setStatus(Status.builder().submitted(Instant.now()).build());
     includedForm.setLifecycleState(includedState);
+    includedForm.setContent(FormrPartbContent.builder().build());
     template.insert(includedForm);
 
     FormRPartB draftForm = new FormRPartB();
     draftForm.setId(UUID.randomUUID());
     draftForm.setTraineeTisId(TRAINEE_ID);
     draftForm.setLifecycleState(DRAFT);
+    draftForm.setContent(FormrPartbContent.builder().build());
     template.insert(draftForm);
 
     FormRPartB deletedForm = new FormRPartB();
@@ -294,6 +300,7 @@ class AdminFormRPartBResourceIntegrationTest {
     deletedForm.setStatus(
         Status.builder().submitted(Instant.now().minus(Duration.ofDays(2))).build());
     deletedForm.setLifecycleState(DELETED);
+    deletedForm.setContent(FormrPartbContent.builder().build());
     template.insert(deletedForm);
 
     mockMvc.perform(get("/api/admin/formr-partb")
@@ -312,6 +319,7 @@ class AdminFormRPartBResourceIntegrationTest {
     submittedForm.setId(UUID.randomUUID());
     submittedForm.setTraineeTisId(TRAINEE_ID);
     submittedForm.setLifecycleState(SUBMITTED);
+    submittedForm.setContent(FormrPartbContent.builder().build());
     LocalDateTime submissionDate = LocalDateTime.ofInstant(submittedForm.getStatus().submitted(),
         timezone);
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResource.java
@@ -163,12 +163,16 @@ public class FormRPartAResource {
   public ResponseEntity<FormRPartADto> getFormRPartAsById(@PathVariable String id) {
     log.info("FormRPartA by id {}", id);
 
-    FormRPartADto formRPartADto = service.getFormRPartAById(id);
-    if (formRPartADto != null) {
-      log.info("Retrieved FormRPartA id {} for trainee {} programme membership {}", id,
-          formRPartADto.getTraineeTisId(), formRPartADto.getContent().getProgrammeMembershipId());
-    }
-    return ResponseEntity.of(Optional.ofNullable(formRPartADto));
+    Optional<FormRPartADto> formRPartADto = service.getFormRPartAById(id);
+
+    formRPartADto.ifPresent(dto -> {
+      if (dto.getContent() != null) {
+        log.info("Retrieved FormRPartA id {} for trainee {} programme membership {}", id,
+            dto.getTraineeTisId(), dto.getContent().getProgrammeMembershipId());
+      }
+    });
+
+    return ResponseEntity.of(formRPartADto);
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResource.java
@@ -162,12 +162,16 @@ public class FormRPartBResource {
   public ResponseEntity<FormRPartBDto> getFormRPartBsById(@PathVariable String id) {
     log.info("FormRPartB by id {}", id);
 
-    FormRPartBDto formRPartBDto = service.getFormRPartBById(id);
-    if (formRPartBDto != null) {
-      log.info("Retrieved FormRPartB id {} for trainee {} programme membership {}", id,
-          formRPartBDto.getTraineeTisId(), formRPartBDto.getContent().getProgrammeMembershipId());
-    }
-    return ResponseEntity.of(Optional.ofNullable(formRPartBDto));
+    Optional<FormRPartBDto> formRPartBDto = service.getFormRPartBById(id);
+
+    formRPartBDto.ifPresent(dto -> {
+      if (dto.getContent() != null) {
+        log.info("Retrieved FormRPartB id {} for trainee {} programme membership {}", id,
+            dto.getTraineeTisId(), dto.getContent().getProgrammeMembershipId());
+      }
+    });
+
+    return ResponseEntity.of(formRPartBDto);
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
@@ -169,7 +169,9 @@ public class FormRPartAService extends AbstractAuditedFormService<FormRPartA> {
   public List<FormRPartSimpleDto> getFormRPartAs() {
     String traineeId = identityResolver.requireTraineeIdentity().getTraineeId();
     log.info("Request to get FormRPartA list by trainee profileId : {}", traineeId);
-    List<FormRPartA> formRPartAList = repository.findByTraineeTisId(traineeId);
+    List<FormRPartA> formRPartAList = repository.findByTraineeTisId(traineeId).stream()
+        .filter(form -> form.getContent() != null)
+        .toList();
     return mapper.toSimpleDtos(formRPartAList);
   }
 
@@ -182,7 +184,10 @@ public class FormRPartAService extends AbstractAuditedFormService<FormRPartA> {
   public List<FormRPartSimpleDto> getFormRPartAs(String traineeId) {
     log.info("Request to get FormRPartA list by trainee profileId : {}", traineeId);
 
-    List<FormRPartA> formRPartAList = repository.findNotDraftNorDeletedByTraineeTisId(traineeId);
+    List<FormRPartA> formRPartAList = repository.findNotDraftNorDeletedByTraineeTisId(traineeId)
+        .stream()
+        .filter(form -> form.getContent() != null)
+        .toList();
 
     return mapper.toSimpleDtos(formRPartAList);
   }
@@ -190,14 +195,13 @@ public class FormRPartAService extends AbstractAuditedFormService<FormRPartA> {
   /**
    * get FormRPartA by id.
    */
-  public FormRPartADto getFormRPartAById(String id) {
+  public Optional<FormRPartADto> getFormRPartAById(String id) {
     log.info("Request to get FormRPartA by id : {}", id);
 
     String traineeId = identityResolver.requireTraineeIdentity().getTraineeId();
-    Optional<FormRPartA> optionalDbForm = repository.findByIdAndTraineeTisId(UUID.fromString(id),
-        traineeId);
-
-    return mapper.toDto(optionalDbForm.orElse(null));
+    return repository.findByIdAndTraineeTisId(UUID.fromString(id), traineeId)
+        .filter(form -> form.getContent() != null)
+        .map(mapper::toDto);
   }
 
   /**
@@ -210,6 +214,7 @@ public class FormRPartAService extends AbstractAuditedFormService<FormRPartA> {
     log.info("Request to get FormRPartA by id : {}", id);
 
     return repository.findByIdAndNotDraftNorDeleted(UUID.fromString(id))
+        .filter(form -> form.getContent() != null)
         .map(mapper::toDto);
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
@@ -170,7 +170,9 @@ public class FormRPartBService extends AbstractAuditedFormService<FormRPartB> {
   public List<FormRPartSimpleDto> getFormRPartBs() {
     String traineeId = identityResolver.requireTraineeIdentity().getTraineeId();
     log.info("Request to get FormRPartB list by trainee profileId : {}", traineeId);
-    List<FormRPartB> formRPartBList = formRPartBRepository.findByTraineeTisId(traineeId);
+    List<FormRPartB> formRPartBList = formRPartBRepository.findByTraineeTisId(traineeId).stream()
+        .filter(form -> form.getContent() != null)
+        .toList();
     return formRPartBMapper.toSimpleDtos(formRPartBList);
   }
 
@@ -184,7 +186,9 @@ public class FormRPartBService extends AbstractAuditedFormService<FormRPartB> {
     log.info("Request to get FormRPartB list by trainee profileId : {}", traineeId);
 
     List<FormRPartB> formRPartBList = formRPartBRepository
-        .findNotDraftNorDeletedByTraineeTisId(traineeId);
+        .findNotDraftNorDeletedByTraineeTisId(traineeId).stream()
+        .filter(form -> form.getContent() != null)
+        .toList();
 
     return formRPartBMapper.toSimpleDtos(formRPartBList);
   }
@@ -192,14 +196,13 @@ public class FormRPartBService extends AbstractAuditedFormService<FormRPartB> {
   /**
    * get FormRPartB by id.
    */
-  public FormRPartBDto getFormRPartBById(String id) {
+  public Optional<FormRPartBDto> getFormRPartBById(String id) {
     log.info("Request to get FormRPartB by id : {}", id);
 
     String traineeId = identityResolver.requireTraineeIdentity().getTraineeId();
-    Optional<FormRPartB> optionalDbForm = formRPartBRepository.findByIdAndTraineeTisId(
-        UUID.fromString(id), traineeId);
-
-    return formRPartBMapper.toDto(optionalDbForm.orElse(null));
+    return formRPartBRepository.findByIdAndTraineeTisId(UUID.fromString(id), traineeId)
+        .filter(form -> form.getContent() != null)
+        .map(formRPartBMapper::toDto);
   }
 
   /**
@@ -212,6 +215,7 @@ public class FormRPartBService extends AbstractAuditedFormService<FormRPartB> {
     log.info("Request to get FormRPartB by id : {}", id);
 
     return formRPartBRepository.findByIdAndNotDraftNorDeleted(UUID.fromString(id))
+        .filter(form -> form.getContent() != null)
         .map(formRPartBMapper::toDto);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceTest.java
@@ -445,7 +445,7 @@ class FormRPartAResourceTest {
 
   @Test
   void getByIdShouldNotReturnFormWhenFormIsNotTrainees() throws Exception {
-    when(service.getFormRPartAById(DEFAULT_ID)).thenReturn(null);
+    when(service.getFormRPartAById(DEFAULT_ID)).thenReturn(Optional.empty());
 
     mockMvc.perform(get("/api/formr-parta/" + DEFAULT_ID)
             .contentType(TestUtil.APPLICATION_JSON_UTF8)
@@ -455,7 +455,7 @@ class FormRPartAResourceTest {
 
   @Test
   void getByIdShouldReturnFormWhenFormIsTrainees() throws Exception {
-    when(service.getFormRPartAById(DEFAULT_ID)).thenReturn(dto);
+    when(service.getFormRPartAById(DEFAULT_ID)).thenReturn(Optional.of(dto));
 
     mockMvc.perform(get("/api/formr-parta/" + DEFAULT_ID)
             .contentType(TestUtil.APPLICATION_JSON_UTF8)

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResourceTest.java
@@ -444,7 +444,7 @@ class FormRPartBResourceTest {
 
   @Test
   void getByIdShouldNotReturnFormWhenFormIsNotTrainees() throws Exception {
-    when(service.getFormRPartBById(DEFAULT_ID)).thenReturn(null);
+    when(service.getFormRPartBById(DEFAULT_ID)).thenReturn(Optional.empty());
 
     mockMvc.perform(get("/api/formr-partb/" + DEFAULT_ID)
             .contentType(TestUtil.APPLICATION_JSON_UTF8)
@@ -454,7 +454,7 @@ class FormRPartBResourceTest {
 
   @Test
   void getByIdShouldReturnFormWhenFormIsTrainees() throws Exception {
-    when(service.getFormRPartBById(DEFAULT_ID)).thenReturn(dto);
+    when(service.getFormRPartBById(DEFAULT_ID)).thenReturn(Optional.of(dto));
 
     mockMvc.perform(get("/api/formr-partb/" + DEFAULT_ID)
             .contentType(TestUtil.APPLICATION_JSON_UTF8)

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceTest.java
@@ -412,6 +412,17 @@ class FormRPartAServiceTest {
   }
 
   @Test
+  void shouldReturnEmptyGettingFormRPartAsWhenNoContent() {
+    entity.setContent(null);
+    List<FormRPartA> entities = Collections.singletonList(entity);
+    when(repositoryMock.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID)).thenReturn(entities);
+
+    List<FormRPartSimpleDto> dtos = service.getFormRPartAs();
+
+    assertThat("Unexpected numbers of forms.", dtos.size(), is(0));
+  }
+
+  @Test
   void shouldGetFormRPartAs() {
     List<FormRPartA> entities = Collections.singletonList(entity);
     when(repositoryMock.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID)).thenReturn(entities);
@@ -426,13 +437,29 @@ class FormRPartAServiceTest {
   }
 
   @Test
-  void shouldReturnNullGettingFormRPartAByIdWhenFormNotExists() {
+  void shouldReturnEmptyGettingFormRPartAByIdWhenFormNotExists() {
     when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
         .thenReturn(Optional.empty());
 
-    FormRPartADto dto = service.getFormRPartAById(DEFAULT_ID_STRING);
+    Optional<FormRPartADto> dto = service.getFormRPartAById(DEFAULT_ID_STRING);
 
-    assertThat("Unexpected form.", dto, nullValue());
+    assertThat("Unexpected form presence.", dto.isPresent(), is(false));
+  }
+
+  @Test
+  void shouldReturnEmptyWhenFormExistsWithNoContent() {
+    FormRPartA form = new FormRPartA();
+    form.setId(DEFAULT_ID);
+    form.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
+    form.setLifecycleState(UNSUBMITTED);
+    form.setContent(null);
+
+    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(Optional.of(form));
+
+    Optional<FormRPartADto> optionalDto = service.getFormRPartAById(DEFAULT_ID_STRING);
+
+    assertThat("Unexpected form presence.", optionalDto.isPresent(), is(false));
   }
 
   @Test
@@ -441,12 +468,16 @@ class FormRPartAServiceTest {
     form.setId(DEFAULT_ID);
     form.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
     form.setLifecycleState(UNSUBMITTED);
+    form.setContent(FormrPartaContent.builder().build());
 
     when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
         .thenReturn(Optional.of(form));
 
-    FormRPartADto dto = service.getFormRPartAById(DEFAULT_ID_STRING);
+    Optional<FormRPartADto> optionalDto = service.getFormRPartAById(DEFAULT_ID_STRING);
 
+    assertThat("Unexpected form presence.", optionalDto.isPresent(), is(true));
+
+    FormRPartADto dto = optionalDto.get();
     assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected status.", dto.getLifecycleState(), is(UNSUBMITTED));
@@ -736,8 +767,19 @@ class FormRPartAServiceTest {
   }
 
   @Test
-  void shouldGetFormRPartAsByTraineeId() {
+  void shouldReturnEmptyWhenGettingFormsByTraineeTisIdAndNoContent() {
+    entity.setContent(null);
+    List<FormRPartA> entities = Collections.singletonList(entity);
+    when(repositoryMock.findNotDraftNorDeletedByTraineeTisId(DEFAULT_TRAINEE_TIS_ID)).thenReturn(
+        entities);
 
+    List<FormRPartSimpleDto> dtos = service.getFormRPartAs(DEFAULT_TRAINEE_TIS_ID);
+
+    assertThat("Unexpected numbers of forms.", dtos.size(), is(0));
+  }
+
+  @Test
+  void shouldGetFormRPartAsByTraineeId() {
     List<FormRPartA> entities = Collections.singletonList(entity);
 
     when(repositoryMock.findNotDraftNorDeletedByTraineeTisId(DEFAULT_TRAINEE_TIS_ID))
@@ -753,6 +795,19 @@ class FormRPartAServiceTest {
     assertThat("Unexpected programme name.", dto.getProgrammeName(),
         is(DEFAULT_PROGRAMME_SPECIALTY));
     assertThat("Unexpected isArcp.", dto.getIsArcp(), is(true));
+  }
+
+  @Test
+  void shouldReturnEmptyAdminsFormRPartAByIdWhenNoContent() {
+    entity.setLifecycleState(UNSUBMITTED);
+    entity.setContent(null);
+
+    when(repositoryMock.findByIdAndNotDraftNorDeleted(DEFAULT_ID))
+        .thenReturn(Optional.of(entity));
+
+    Optional<FormRPartADto> optionalDto = service.getAdminsFormRPartAById(DEFAULT_ID_STRING);
+
+    assertThat("Unexpected DTO.", optionalDto.isPresent(), is(false));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceTest.java
@@ -522,7 +522,18 @@ class FormRPartBServiceTest {
   }
 
   @Test
-  void shouldGetFormRPartBsByTraineeTisId() {
+  void shouldReturnEmptyWhenGettingFormsAndNoContent() {
+    entity.setContent(null);
+    List<FormRPartB> entities = Collections.singletonList(entity);
+    when(repositoryMock.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID)).thenReturn(entities);
+
+    List<FormRPartSimpleDto> dtos = service.getFormRPartBs();
+
+    assertThat("Unexpected numbers of forms.", dtos.size(), is(0));
+  }
+
+  @Test
+  void shouldGetFormRPartBs() {
     List<FormRPartB> entities = Collections.singletonList(entity);
     when(repositoryMock.findByTraineeTisId(DEFAULT_TRAINEE_TIS_ID)).thenReturn(entities);
 
@@ -536,13 +547,29 @@ class FormRPartBServiceTest {
   }
 
   @Test
-  void shouldReturnNullGettingFormRPartBByIdWhenFormNotExists() {
+  void shouldReturnEmptyGettingFormRPartBByIdWhenFormNotExists() {
     when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
         .thenReturn(Optional.empty());
 
-    FormRPartBDto dto = service.getFormRPartBById(DEFAULT_ID_STRING);
+    Optional<FormRPartBDto> dto = service.getFormRPartBById(DEFAULT_ID_STRING);
 
-    assertThat("Unexpected form.", dto, nullValue());
+    assertThat("Unexpected form presence.", dto.isPresent(), is(false));
+  }
+
+  @Test
+  void shouldReturnEmptyWhenFormExistsWithNoContent() {
+    FormRPartB form = new FormRPartB();
+    form.setId(DEFAULT_ID);
+    form.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
+    form.setLifecycleState(UNSUBMITTED);
+    form.setContent(null);
+
+    when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
+        .thenReturn(Optional.of(form));
+
+    Optional<FormRPartBDto> optionalDto = service.getFormRPartBById(DEFAULT_ID_STRING);
+
+    assertThat("Unexpected form presence.", optionalDto.isPresent(), is(false));
   }
 
   @Test
@@ -551,12 +578,16 @@ class FormRPartBServiceTest {
     form.setId(DEFAULT_ID);
     form.setTraineeTisId(DEFAULT_TRAINEE_TIS_ID);
     form.setLifecycleState(UNSUBMITTED);
+    form.setContent(FormrPartbContent.builder().build());
 
     when(repositoryMock.findByIdAndTraineeTisId(DEFAULT_ID, DEFAULT_TRAINEE_TIS_ID))
         .thenReturn(Optional.of(form));
 
-    FormRPartBDto dto = service.getFormRPartBById(DEFAULT_ID_STRING);
+    Optional<FormRPartBDto> optionalDto = service.getFormRPartBById(DEFAULT_ID_STRING);
 
+    assertThat("Unexpected form presence.", optionalDto.isPresent(), is(true));
+
+    FormRPartBDto dto = optionalDto.get();
     assertThat("Unexpected form ID.", dto.getId(), is(DEFAULT_ID_STRING));
     assertThat("Unexpected trainee ID.", dto.getTraineeTisId(), is(DEFAULT_TRAINEE_TIS_ID));
     assertThat("Unexpected status.", dto.getLifecycleState(), is(UNSUBMITTED));
@@ -827,6 +858,18 @@ class FormRPartBServiceTest {
   }
 
   @Test
+  void shouldReturnEmptyWhenGettingFormsByTraineeTisIdAndNoContent() {
+    entity.setContent(null);
+    List<FormRPartB> entities = Collections.singletonList(entity);
+    when(repositoryMock.findNotDraftNorDeletedByTraineeTisId(DEFAULT_TRAINEE_TIS_ID)).thenReturn(
+        entities);
+
+    List<FormRPartSimpleDto> dtos = service.getFormRPartBs(DEFAULT_TRAINEE_TIS_ID);
+
+    assertThat("Unexpected numbers of forms.", dtos.size(), is(0));
+  }
+
+  @Test
   void shouldGetFormRPartBsByTraineeId() {
 
     List<FormRPartB> entities = Collections.singletonList(entity);
@@ -844,6 +887,19 @@ class FormRPartBServiceTest {
     assertThat("Unexpected programme name.", dto.getProgrammeName(),
         is(DEFAULT_PROGRAMME_SPECIALTY));
     assertThat("Unexpected isArcp.", dto.getIsArcp(), is(true));
+  }
+
+  @Test
+  void shouldGetEmptyAdminsFormRPartBByIdWhenNoContent() {
+    entity.setLifecycleState(UNSUBMITTED);
+    entity.setContent(null);
+
+    when(repositoryMock.findByIdAndNotDraftNorDeleted(DEFAULT_ID))
+        .thenReturn(Optional.of(entity));
+
+    Optional<FormRPartBDto> optionalDto = service.getAdminsFormRPartBById(DEFAULT_ID_STRING);
+
+    assertThat("Unexpected DTO.", optionalDto.isPresent(), is(false));
   }
 
   @Test


### PR DESCRIPTION
feat: hide unmigrated FormRs from GET results
During migration a trainee or admin interacting with an unmigrated form
is likely to cause issues due to missing content.

Ignore any form results with a `null` content field.
This is a temporary measure while the migration is running, due to the
length of time it may take. Ideally the filtering would be done at the
service level to avoid loading the forms in to memory at all, but in
this case it's done at the service level for ease and limiting potential
side-effects.

TIS21-8706
TIS21-8827