### PR TITLE
feat: migrate failed Form R Part B

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.69.1"
+version = "0.70.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAudited2IntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAudited2IntegrationTest.java
@@ -1,0 +1,573 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package uk.nhs.hee.tis.trainee.forms.migration;
+
+import static java.time.ZoneOffset.UTC;
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.DRAFT;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMITTED;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TimeZone;
+import java.util.UUID;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.forms.DockerImageNames;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status.StatusInfo;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractFormR;
+import uk.nhs.hee.tis.trainee.forms.model.CovidDeclaration;
+import uk.nhs.hee.tis.trainee.forms.model.Declaration;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
+import uk.nhs.hee.tis.trainee.forms.model.FormrPartbSubmissionHistory;
+import uk.nhs.hee.tis.trainee.forms.model.Person;
+import uk.nhs.hee.tis.trainee.forms.model.Work;
+import uk.nhs.hee.tis.trainee.forms.model.content.FormContent;
+import uk.nhs.hee.tis.trainee.forms.model.content.FormrPartbContent;
+import uk.nhs.hee.tis.trainee.forms.repository.FormRPartBRepository;
+import uk.nhs.hee.tis.trainee.forms.repository.FormrPartbSubmissionHistoryRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+class ConvertFormrToAudited2IntegrationTest {
+
+  private static final String FIELD_FORM_ID = "_id";
+  private static final String FIELD_TRAINEE_ID = "traineeTisId";
+  private static final String FIELD_LIFECYCLE_STATE = "lifecycleState";
+  private static final String FIELD_SUBMISSION_DATE = "submissionDate";
+  private static final String FIELD_LAST_MODIFIED_DATE = "lastModifiedDate";
+  private static final String FIELD_FORM_CLASS = "_class";
+
+  private static TimeZone originalTimeZone;
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @BeforeAll
+  static void setUpBeforeAll() {
+    originalTimeZone = TimeZone.getDefault();
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+  }
+
+  @AfterAll
+  static void tearDownAfterAll() {
+    TimeZone.setDefault(originalTimeZone);
+  }
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @Autowired
+  private FormRPartBRepository partbRepository;
+
+  @Autowired
+  private FormrPartbSubmissionHistoryRepository partbSubmissionHistoryRepository;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  private ConvertFormrToAudited2 migration;
+
+  @BeforeEach
+  void setUp() {
+    migration = new ConvertFormrToAudited2(mongoTemplate);
+  }
+
+  @AfterEach
+  void tearDown() {
+    mongoTemplate.remove(new Query(), FormRPartB.class);
+    mongoTemplate.remove(new Query(), FormrPartbSubmissionHistory.class);
+  }
+
+  @Test
+  void shouldMigrateFormMetadata() {
+    UUID formId = UUID.randomUUID();
+    String traineeId = UUID.randomUUID().toString();
+    LocalDateTime submissionDate = LocalDateTime.now().minusDays(10);
+    LocalDateTime lastModifiedDate = LocalDateTime.now().minusDays(5);
+    Map<String, Object> originalFields = createFormFields(formId, traineeId, SUBMITTED,
+        submissionDate, lastModifiedDate, "1");
+
+    String collectionName = mongoTemplate.getCollectionName(FormRPartB.class);
+    mongoTemplate.save(new Document(originalFields), collectionName);
+
+    migration.migrateFormrPartb();
+
+    Optional<? extends AbstractFormR<?>> foundForm = partbRepository.findById(formId);
+    assertThat("Expected form not found.", foundForm.isPresent(), is(true));
+
+    AbstractFormR<?> migratedForm = foundForm.get();
+    assertThat("Unexpected form type.", migratedForm, instanceOf(FormRPartB.class));
+
+    assertThat("Unexpected form ID.", migratedForm.getId(), is(formId));
+    assertThat("Unexpected trainee ID.", migratedForm.getTraineeTisId(), is(traineeId));
+
+    String expectedFormRef = "formr_partb_%s_001".formatted(traineeId);
+    assertThat("Unexpected form reference.", migratedForm.getFormRef(), is(expectedFormRef));
+    assertThat("Unexpected revision.", migratedForm.getRevision(), is(0));
+
+    assertThat("Unexpected lifecycle state.", migratedForm.getLifecycleState(), is(SUBMITTED));
+    assertThat("Unexpected created.", migratedForm.getCreated(),
+        is(submissionDate.toInstant(UTC).truncatedTo(MILLIS)));
+    assertThat("Unexpected last modified.", migratedForm.getLastModified(),
+        is(submissionDate.toInstant(UTC).truncatedTo(MILLIS)));
+  }
+
+  @Test
+  void shouldMigrateFormStatus() {
+    UUID formId = UUID.randomUUID();
+    String traineeId = UUID.randomUUID().toString();
+    LocalDateTime submissionDate = LocalDateTime.now().minusDays(10);
+    LocalDateTime lastModifiedDate = LocalDateTime.now().minusDays(5);
+    Map<String, Object> originalFields = createFormFields(formId, traineeId, SUBMITTED,
+        submissionDate, lastModifiedDate, "1");
+
+    String collectionName = mongoTemplate.getCollectionName(FormRPartB.class);
+    mongoTemplate.save(new Document(originalFields), collectionName);
+
+    migration.migrateFormrPartb();
+
+    Optional<? extends AbstractFormR<?>> foundForm = partbRepository.findById(formId);
+    assertThat("Expected form not found.", foundForm.isPresent(), is(true));
+
+    AbstractFormR<?> migratedForm = foundForm.get();
+    assertThat("Unexpected form type.", migratedForm, instanceOf(FormRPartB.class));
+
+    Status status = migratedForm.getStatus();
+    assertThat("Unexpected submitted timestamp.", status.submitted(),
+        is(submissionDate.toInstant(UTC).truncatedTo(MILLIS)));
+
+    StatusInfo current = status.current();
+    assertThat("Unexpected current state.", current.state(), is(SUBMITTED));
+    assertThat("Unexpected current revision.", current.revision(), is(0));
+    assertThat("Unexpected current modified by.", current.modifiedBy(), is(Person.builder()
+        .name("forename_1 surname_1")
+        .email("email_1")
+        .role("TRAINEE")
+        .build()
+    ));
+    assertThat("Unexpected current assigned admin.", current.assignedAdmin(), nullValue());
+    assertThat("Unexpected current detail.", current.detail(), nullValue());
+
+    // The status timestamp is based on S3 version history, we cannot assert exact values because it
+    // is tied to the insertion into the localstack S3 instance and NOT any data we easily control.
+    assertThat("Unexpected current timestamp.", current.timestamp(), notNullValue());
+
+    List<StatusInfo> statusHistory = status.history();
+    assertThat("Unexpected status history count.", statusHistory, hasSize(2));
+    assertThat("Unexpected lastest status history.", statusHistory.get(1), is(current));
+
+    StatusInfo status1 = statusHistory.get(0);
+    assertThat("Unexpected history state.", status1.state(), is(DRAFT));
+    assertThat("Unexpected history revision.", status1.revision(), is(0));
+    assertThat("Unexpected history modified by.", status1.modifiedBy(), is(Person.builder()
+        .name("forename_1 surname_1")
+        .email("email_1")
+        .role("TRAINEE")
+        .build()
+    ));
+    assertThat("Unexpected history assigned admin.", status1.assignedAdmin(), nullValue());
+    assertThat("Unexpected history detail.", status1.detail(), nullValue());
+    assertThat("Unexpected history timestamp.", status1.timestamp(), notNullValue());
+  }
+
+  @Test
+  void shouldMigrateFormContent() {
+    UUID formId = UUID.randomUUID();
+    String traineeId = UUID.randomUUID().toString();
+    LocalDateTime submissionDate = LocalDateTime.now().minusDays(10);
+    LocalDateTime lastModifiedDate = LocalDateTime.now().minusDays(5);
+    Map<String, Object> originalFields = createFormFields(formId, traineeId, SUBMITTED,
+        submissionDate, lastModifiedDate, "1");
+
+    String collectionName = mongoTemplate.getCollectionName(FormRPartB.class);
+    mongoTemplate.save(new Document(originalFields), collectionName);
+
+    migration.migrateFormrPartb();
+
+    Optional<? extends AbstractFormR<?>> foundForm = partbRepository.findById(formId);
+    assertThat("Expected form not found.", foundForm.isPresent(), is(true));
+
+    AbstractFormR<?> migratedForm = foundForm.get();
+    assertThat("Unexpected form type.", migratedForm, instanceOf(FormRPartB.class));
+
+    FormContent content = migratedForm.getContent();
+    assertPartbContent((FormrPartbContent) content, originalFields);
+  }
+
+  @Test
+  void shouldMigrateSubmittedHistory() {
+    UUID formId = UUID.randomUUID();
+    String traineeId = UUID.randomUUID().toString();
+    LocalDateTime submissionDate = LocalDateTime.now().plusDays(5);
+    LocalDateTime lastModifiedDate = LocalDateTime.now().plusDays(10);
+    Map<String, Object> originalFields = createFormFields(formId, traineeId, SUBMITTED,
+        submissionDate, lastModifiedDate, "1");
+
+    String collectionName = mongoTemplate.getCollectionName(FormRPartB.class);
+    mongoTemplate.save(new Document(originalFields), collectionName);
+
+    migration.migrateFormrPartb();
+
+    Optional<? extends AbstractFormR<?>> foundForm = partbRepository.findById(formId);
+    assertThat("Expected form not found.", foundForm.isPresent(), is(true));
+
+    AbstractFormR<?> migratedForm = foundForm.get();
+    assertThat("Unexpected form type.", migratedForm, instanceOf(FormRPartB.class));
+
+    Status status = migratedForm.getStatus();
+    List<StatusInfo> statusHistory = status.history();
+    assertThat("Unexpected status history count.", statusHistory, hasSize(2));
+    assertThat("Unexpected lastest status history.", statusHistory.get(1), is(status.current()));
+
+    StatusInfo status1 = statusHistory.get(0);
+    assertThat("Unexpected history state.", status1.state(), is(DRAFT));
+    assertThat("Unexpected history revision.", status1.revision(), is(0));
+
+    StatusInfo status2 = statusHistory.get(1);
+    assertThat("Unexpected history state.", status2.state(), is(SUBMITTED));
+    assertThat("Unexpected history revision.", status2.revision(), is(0));
+  }
+
+  @Test
+  void shouldSnapshotSubmittedFormHistoryMetadata() {
+    UUID formId = UUID.randomUUID();
+    String traineeId = UUID.randomUUID().toString();
+    LocalDateTime submissionDate = LocalDateTime.now().minusDays(10);
+    LocalDateTime lastModifiedDate = LocalDateTime.now().minusDays(5);
+    Map<String, Object> originalFields = createFormFields(formId, traineeId, SUBMITTED,
+        submissionDate, lastModifiedDate, "1");
+
+    String collectionName = mongoTemplate.getCollectionName(FormRPartB.class);
+    mongoTemplate.save(new Document(originalFields), collectionName);
+
+    migration.migrateFormrPartb();
+
+    List<? extends AbstractAuditedForm<?>> historyList = partbSubmissionHistoryRepository
+        .findByTraineeTisId(traineeId);
+
+    assertThat("Expected form history count.", historyList, hasSize(1));
+
+    AbstractAuditedForm<?> history = historyList.get(0);
+
+    assertThat("Unexpected form ID.", history.getId(), not(formId));
+    assertThat("Unexpected trainee ID.", history.getTraineeTisId(), is(traineeId));
+
+    String expectedFormRef = "formr_partb_%s_001".formatted(traineeId);
+    assertThat("Unexpected form reference.", history.getFormRef(), is(expectedFormRef));
+    assertThat("Unexpected revision.", history.getRevision(), is(0));
+
+    assertThat("Unexpected lifecycle state.", history.getLifecycleState(), is(SUBMITTED));
+    assertThat("Unexpected created.", history.getCreated(),
+        is(submissionDate.toInstant(UTC).truncatedTo(MILLIS)));
+    assertThat("Unexpected last modified.", history.getLastModified(),
+        is(submissionDate.toInstant(UTC).truncatedTo(MILLIS)));
+  }
+
+  @Test
+  void shouldSnapshotSubmittedFormHistoryStatus() {
+    UUID formId = UUID.randomUUID();
+    String traineeId = UUID.randomUUID().toString();
+    LocalDateTime submissionDate = LocalDateTime.now().minusDays(10);
+    LocalDateTime lastModifiedDate = LocalDateTime.now().minusDays(5);
+    Map<String, Object> originalFields = createFormFields(formId, traineeId, SUBMITTED,
+        submissionDate, lastModifiedDate, "1");
+
+    String collectionName = mongoTemplate.getCollectionName(FormRPartB.class);
+    mongoTemplate.save(new Document(originalFields), collectionName);
+
+    migration.migrateFormrPartb();
+
+    List<? extends AbstractAuditedForm<?>> historyList = partbSubmissionHistoryRepository
+        .findByTraineeTisId(traineeId);
+
+    assertThat("Expected form history count.", historyList, hasSize(1));
+
+    Status status = historyList.get(0).getStatus();
+    assertThat("Unexpected submitted timestamp.", status.submitted(),
+        is(submissionDate.toInstant(UTC).truncatedTo(MILLIS)));
+
+    StatusInfo current = status.current();
+    assertThat("Unexpected current state.", current.state(), is(SUBMITTED));
+    assertThat("Unexpected current revision.", current.revision(), is(0));
+    assertThat("Unexpected current modified by.", current.modifiedBy(), is(Person.builder()
+        .name("forename_1 surname_1")
+        .email("email_1")
+        .role("TRAINEE")
+        .build()
+    ));
+    assertThat("Unexpected current assigned admin.", current.assignedAdmin(), nullValue());
+    assertThat("Unexpected current detail.", current.detail(), nullValue());
+
+    // The status timestamp is based on S3 version history, we cannot assert exact values because it
+    // is tied to the insertion into the localstack S3 instance and NOT any data we easily control.
+    assertThat("Unexpected current timestamp.", current.timestamp(), notNullValue());
+
+    List<StatusInfo> statusHistory = status.history();
+    assertThat("Unexpected status history count.", statusHistory, hasSize(2));
+    assertThat("Unexpected lastest status history.", statusHistory.get(1), is(current));
+
+    StatusInfo status1 = statusHistory.get(0);
+    assertThat("Unexpected history state.", status1.state(), is(DRAFT));
+    assertThat("Unexpected history revision.", status1.revision(), is(0));
+    assertThat("Unexpected history modified by.", status1.modifiedBy(), is(Person.builder()
+        .name("forename_1 surname_1")
+        .email("email_1")
+        .role("TRAINEE")
+        .build()
+    ));
+    assertThat("Unexpected history assigned admin.", status1.assignedAdmin(), nullValue());
+    assertThat("Unexpected history detail.", status1.detail(), nullValue());
+    assertThat("Unexpected history timestamp.", status1.timestamp(), notNullValue());
+  }
+
+  @Test
+  void shouldSnapshotSubmittedFormHistoryContent() {
+    UUID formId = UUID.randomUUID();
+    String traineeId = UUID.randomUUID().toString();
+    LocalDateTime submissionDate = LocalDateTime.now().minusDays(10);
+    LocalDateTime lastModifiedDate = LocalDateTime.now().minusDays(5);
+    Map<String, Object> originalFields = createFormFields(formId, traineeId, SUBMITTED,
+        submissionDate, lastModifiedDate, "1");
+
+    String collectionName = mongoTemplate.getCollectionName(FormRPartB.class);
+    mongoTemplate.save(new Document(originalFields), collectionName);
+
+    migration.migrateFormrPartb();
+
+    List<? extends AbstractAuditedForm<?>> historyList = partbSubmissionHistoryRepository
+        .findByTraineeTisId(traineeId);
+
+    assertThat("Expected form history count.", historyList, hasSize(1));
+
+    FormContent content = historyList.get(0).getContent();
+    assertPartbContent((FormrPartbContent) content, originalFields);
+  }
+
+  /**
+   * Create a content map for the given form class.
+   *
+   * @param formId           The ID of the form.
+   * @param traineeId        The trainee ID.
+   * @param lifecycleState   The lifecycle state of the form.
+   * @param submissionDate   The date the form was submitted, may be null.
+   * @param lastModifiedDate The date of the last modification to the form.
+   * @param contentSuffix    A suffix to apply to content values.
+   * @return The created form.
+   */
+  private Map<String, Object> createFormFields(UUID formId, String traineeId,
+      LifecycleState lifecycleState, LocalDateTime submissionDate, LocalDateTime lastModifiedDate,
+      String contentSuffix) {
+    Map<String, Object> formFields = new HashMap<>();
+    formFields.put(FIELD_FORM_ID, formId);
+    formFields.put(FIELD_TRAINEE_ID, traineeId);
+    formFields.put(FIELD_LIFECYCLE_STATE, lifecycleState.toString());
+    formFields.put(FIELD_LAST_MODIFIED_DATE, lastModifiedDate);
+    formFields.put(FIELD_FORM_CLASS, FormRPartB.class.getName());
+
+    if (submissionDate != null) {
+      formFields.put(FIELD_SUBMISSION_DATE, submissionDate);
+    }
+
+    Map<String, Object> contentFields = createPartbContent(contentSuffix);
+    formFields.putAll(contentFields);
+
+    return formFields;
+  }
+
+  /**
+   * Create a content map for Form-R Part B.
+   *
+   * @param suffix The suffix to apply to string fields.
+   * @return The created content map.
+   */
+  private Map<String, Object> createPartbContent(String suffix) {
+    return Map.ofEntries(
+        Map.entry("isArcp", true),
+        Map.entry("programmeMembershipId", UUID.randomUUID()),
+        Map.entry("forename", "forename_" + suffix),
+        Map.entry("surname", "surname_" + suffix),
+        Map.entry("gmcNumber", "gmcNumber_" + suffix),
+        Map.entry("gdcNumber", "gdcNumber_" + suffix),
+        Map.entry("publicHealthNumber", "publicHealthNumber_" + suffix),
+        Map.entry("email", "email_" + suffix),
+        Map.entry("localOfficeName", "localOfficeName_" + suffix),
+        Map.entry("prevRevalBody", "prevRevalBody_" + suffix),
+        Map.entry("prevRevalBodyOther", "prevRevalBodyOther_" + suffix),
+        Map.entry("currRevalDate", LocalDate.now().minusDays(5)),
+        Map.entry("prevRevalDate", LocalDate.now().minusDays(10)),
+        Map.entry("programmeSpecialty", "programmeSpecialty_" + suffix),
+        Map.entry("dualSpecialty", "dualSpecialty_" + suffix),
+        Map.entry("work", List.of(
+            Work.builder()
+                .typeOfWork("typeOfWork_" + suffix)
+                .startDate(LocalDate.now().minusDays(15))
+                .endDate(LocalDate.now().minusDays(20))
+                .trainingPost("trainingPost_" + suffix)
+                .site("site_" + suffix)
+                .siteLocation("siteLocation_" + suffix)
+                .siteKnownAs("siteKnownAs_" + suffix)
+                .build()
+        )),
+        Map.entry("sicknessAbsence", 1),
+        Map.entry("parentalLeave", 2),
+        Map.entry("careerBreaks", 3),
+        Map.entry("paidLeave", 4),
+        Map.entry("unauthorisedLeave", 5),
+        Map.entry("otherLeave", 6),
+        Map.entry("totalLeave", 21),
+        Map.entry("isHonest", true),
+        Map.entry("isHealthy", true),
+        Map.entry("isWarned", true),
+        Map.entry("isComplying", true),
+        Map.entry("healthStatement", "healthStatement_" + suffix),
+        Map.entry("havePreviousDeclarations", true),
+        Map.entry("previousDeclarations", List.of(
+            Declaration.builder()
+                .declarationType("declarationType_" + suffix)
+                .dateOfEntry(LocalDate.now().minusDays(25))
+                .title("title_" + suffix)
+                .locationOfEntry("locationOfEntry_" + suffix)
+                .build()
+        )),
+        Map.entry("previousDeclarationSummary", "previousDeclarationSummary_" + suffix),
+        Map.entry("haveCurrentDeclarations", true),
+        Map.entry("currentDeclarations", List.of(
+            Declaration.builder()
+                .declarationType("declarationType_" + suffix)
+                .dateOfEntry(LocalDate.now().minusDays(30))
+                .title("title_" + suffix)
+                .locationOfEntry("locationOfEntry_" + suffix)
+                .build()
+        )),
+        Map.entry("currentDeclarationSummary", "currentDeclarationSummary_" + suffix),
+        Map.entry("compliments", "compliments_" + suffix),
+        Map.entry("haveCovidDeclarations", true),
+        Map.entry("covidDeclaration", CovidDeclaration.builder()
+            .selfRateForCovid("selfRateForCovid_" + suffix)
+            .reasonOfSelfRate("reasonOfSelfRate_" + suffix)
+            .otherInformationForPanel("otherInformationForPanel_" + suffix)
+            .discussWithSupervisorChecked(true)
+            .discussWithSomeoneChecked(true)
+            .haveChangesToPlacement(true)
+            .changeCircumstances("changeCircumstances_" + suffix)
+            .changeCircumstanceOther("changeCircumstanceOther_" + suffix)
+            .howPlacementAdjusted("howPlacementAdjusted_" + suffix)
+            .educationSupervisorName("educationSupervisorName_" + suffix)
+            .educationSupervisorEmail("educationSupervisorEmail_" + suffix)
+            .build()
+        ),
+        Map.entry("haveCurrentUnresolvedDeclarations", true),
+        Map.entry("havePreviousUnresolvedDeclarations", true)
+    );
+  }
+
+  /**
+   * Assert that all migrated Part B content fields match the original document content.
+   *
+   * @param content        The migrated content.
+   * @param originalFields The original stored document fields.
+   */
+  private void assertPartbContent(FormrPartbContent content, Map<String, Object> originalFields) {
+    Map<String, Object> contentFields = Map.ofEntries(
+        Map.entry("programmeMembershipId", content.getProgrammeMembershipId()),
+        Map.entry("isArcp", content.getIsArcp()),
+        Map.entry("forename", content.getForename()),
+        Map.entry("surname", content.getSurname()),
+        Map.entry("gmcNumber", content.getGmcNumber()),
+        Map.entry("gdcNumber", content.getGdcNumber()),
+        Map.entry("publicHealthNumber", content.getPublicHealthNumber()),
+        Map.entry("email", content.getEmail()),
+        Map.entry("localOfficeName", content.getLocalOfficeName()),
+        Map.entry("prevRevalBody", content.getPrevRevalBody()),
+        Map.entry("prevRevalBodyOther", content.getPrevRevalBodyOther()),
+        Map.entry("currRevalDate", content.getCurrRevalDate()),
+        Map.entry("prevRevalDate", content.getPrevRevalDate()),
+        Map.entry("programmeSpecialty", content.getProgrammeSpecialty()),
+        Map.entry("dualSpecialty", content.getDualSpecialty()),
+        Map.entry("work", content.getWork()),
+        Map.entry("sicknessAbsence", content.getSicknessAbsence()),
+        Map.entry("parentalLeave", content.getParentalLeave()),
+        Map.entry("careerBreaks", content.getCareerBreaks()),
+        Map.entry("paidLeave", content.getPaidLeave()),
+        Map.entry("unauthorisedLeave", content.getUnauthorisedLeave()),
+        Map.entry("otherLeave", content.getOtherLeave()),
+        Map.entry("totalLeave", content.getTotalLeave()),
+        Map.entry("isHonest", content.getIsHonest()),
+        Map.entry("isHealthy", content.getIsHealthy()),
+        Map.entry("isWarned", content.getIsWarned()),
+        Map.entry("isComplying", content.getIsComplying()),
+        Map.entry("healthStatement", content.getHealthStatement()),
+        Map.entry("havePreviousDeclarations", content.getHavePreviousDeclarations()),
+        Map.entry("previousDeclarations", content.getPreviousDeclarations()),
+        Map.entry("previousDeclarationSummary", content.getPreviousDeclarationSummary()),
+        Map.entry("haveCurrentDeclarations", content.getHaveCurrentDeclarations()),
+        Map.entry("currentDeclarations", content.getCurrentDeclarations()),
+        Map.entry("currentDeclarationSummary", content.getCurrentDeclarationSummary()),
+        Map.entry("compliments", content.getCompliments()),
+        Map.entry("haveCovidDeclarations", content.getHaveCovidDeclarations()),
+        Map.entry("covidDeclaration", content.getCovidDeclaration()),
+        Map.entry("haveCurrentUnresolvedDeclarations",
+            content.getHaveCurrentUnresolvedDeclarations()),
+        Map.entry("havePreviousUnresolvedDeclarations",
+            content.getHavePreviousUnresolvedDeclarations())
+    );
+
+    assertThat("Unexpected content field count.", contentFields.keySet(), hasSize(39));
+    contentFields.forEach((contentField, contentValue) ->
+        assertThat("Unexpected %s.".formatted(contentField), contentValue,
+            is(originalFields.get(contentField)))
+    );
+  }
+}

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAuditedIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAuditedIntegrationTest.java
@@ -1219,24 +1219,4 @@ class ConvertFormrToAuditedIntegrationTest {
         RequestBody.fromBytes(objectMapper.writeValueAsBytes(formFields))
     );
   }
-
-  /**
-   * Assert that the given modifiedBy user matches the expected values.
-   *
-   * @param lifecycleState The lifecycle state of the form.
-   * @param modifiedBy     The modifiedBy user to check.
-   * @param suffix         The suffix used to generate the expected values.
-   */
-  private void assertModifiedBy(LifecycleState lifecycleState, Person modifiedBy, String suffix) {
-    if (lifecycleState == DRAFT || lifecycleState == SUBMITTED) {
-      assertThat("Unexpected modifiedBy name.", modifiedBy.name(),
-          is("Forename_" + suffix + " Surname_" + suffix));
-      assertThat("Unexpected modifiedBy email.", modifiedBy.email(), is("email_" + suffix));
-      assertThat("Unexpected modifiedBy role.", modifiedBy.role(), is("TRAINEE"));
-    } else {
-      assertThat("Unexpected modifiedBy name.", modifiedBy.name(), is("Unknown Admin"));
-      assertThat("Unexpected modifiedBy email.", modifiedBy.email(), is("no-reply@tis.nhs.uk"));
-      assertThat("Unexpected modifiedBy role.", modifiedBy.role(), is("ADMIN"));
-    }
-  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/AddPartialDeleteMetadataToS3.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/AddPartialDeleteMetadataToS3.java
@@ -45,7 +45,7 @@ import uk.nhs.hee.tis.trainee.forms.dto.enumeration.DeleteType;
  * Add partial delete related metadata to existing forms on S3.
  */
 @Slf4j
-@ChangeUnit(id = "AddPartialDeleteMetadataToS3", order = "7")
+@ChangeUnit(id = "AddPartialDeleteMetadataToS3", order = "007")
 public class AddPartialDeleteMetadataToS3 {
 
   private final S3Client s3Client;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAudited.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAudited.java
@@ -80,7 +80,7 @@ import uk.nhs.hee.tis.trainee.forms.model.FormrPartbSubmissionHistory;
  * database.
  */
 @Slf4j
-@ChangeUnit(id = "convertFormrToAudited", order = "9")
+@ChangeUnit(id = "convertFormrToAudited", order = "009")
 public class ConvertFormrToAudited {
 
   private static final String FIELD_ID = "_id";

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAudited2.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAudited2.java
@@ -1,0 +1,256 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package uk.nhs.hee.tis.trainee.forms.migration;
+
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.DRAFT;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMITTED;
+
+import com.mongodb.client.result.DeleteResult;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
+import uk.nhs.hee.tis.trainee.forms.model.FormrPartbSubmissionHistory;
+
+/**
+ * Mongock change unit to migrate remaining Part B forms to the audited form structure. This
+ * performs similarly to {@link ConvertFormrToAudited} but with a narrowed scope to address a
+ * handful of remaining forms and their unique scenario.
+ */
+@Slf4j
+@ChangeUnit(id = "convertFormrToAudited2", order = "10")
+public class ConvertFormrToAudited2 {
+
+  private static final String FIELD_ID = "_id";
+  private static final String FIELD_TRAINEE_ID = "traineeTisId";
+  private static final String FIELD_LIFECYCLE_STATE = "lifecycleState";
+  private static final String FIELD_FORENAME = "forename";
+  private static final String FIELD_SURNAME = "surname";
+  private static final String FIELD_EMAIL = "email";
+  private static final String FIELD_SUBMISSION_DATE = "submissionDate";
+  private static final String FIELD_LAST_MODIFIED_DATE = "lastModifiedDate";
+  private static final String FIELD_CLASS = "_class";
+
+  private static final String FIELD_FORM_REF = "formRef";
+  private static final String FIELD_REVISION = "revision";
+  private static final String FIELD_CONTENT = "content";
+  private static final String FIELD_STATUS = "status";
+  private static final String FIELD_CURRENT = "current";
+  private static final String FIELD_HISTORY = "history";
+  private static final String FIELD_STATE = "state";
+  private static final String FIELD_MODIFIED_BY = "modifiedBy";
+  private static final String FIELD_NAME = "name";
+  private static final String FIELD_ROLE = "role";
+  private static final String FIELD_TIMESTAMP = "timestamp";
+  private static final String FIELD_SUBMITTED = "submitted";
+  private static final String FIELD_CREATED = "created";
+  private static final String FIELD_LAST_MODIFIED = "lastModified";
+
+  private final MongoTemplate mongoTemplate;
+
+  /**
+   * Constructor for ConvertFormrToAudited2.
+   */
+  public ConvertFormrToAudited2(MongoTemplate mongoTemplate) {
+    this.mongoTemplate = mongoTemplate;
+  }
+
+  /**
+   * Migrate the remaining Form-R Part B forms to the audited form structure.
+   */
+  @Execution
+  public void migrateFormrPartb() {
+    String collectionName = mongoTemplate.getCollectionName(FormRPartB.class);
+    Query query = Query.query(
+        Criteria.where(FIELD_CONTENT).exists(false)
+            .and(FIELD_LIFECYCLE_STATE).is(SUBMITTED));
+    List<Document> forms = mongoTemplate.find(query, Document.class, collectionName);
+    log.info("Found {} forms of type {} in state SUBMITTED", forms.size(), collectionName);
+
+    for (Document form : forms) {
+      // The target forms are all known to be 001.
+      String formRef = "formr_partb_%s_001".formatted(form.getString(FIELD_TRAINEE_ID));
+
+      // Delete any built submission history so it can be retried without duplication.
+      deleteSubmissionHistory(formRef);
+
+      List<Map<String, Object>> history = rebuildHistory(formRef, form);
+
+      Document migratedForm = transformForm(true, formRef, form, history);
+      mongoTemplate.save(migratedForm, collectionName);
+    }
+
+    log.info("Successfully migrated {} forms of type {}", forms.size(), collectionName);
+  }
+
+  /**
+   * Rebuild the status history of the form based on the database data. Submitted forms will be
+   * snapshotted and saved in the form's submission history.
+   *
+   * @param formRef The form reference for the form.
+   * @param form    The form to rebuild the history for.
+   * @return A list of statuses representing the form history.
+   */
+  private List<Map<String, Object>> rebuildHistory(String formRef, Document form) {
+    List<Map<String, Object>> history = new ArrayList<>();
+    Instant submitted = ((Date) form.remove(FIELD_SUBMISSION_DATE)).toInstant();
+
+    // Create a dummy DRAFT version.
+    history.add(buildStatusInfo(DRAFT, form, submitted));
+
+    // Create the SUBMITTED version.
+    history.add(buildStatusInfo(SUBMITTED, form, submitted));
+
+    // Create submission snapshot.
+    Document document = transformForm(false, formRef, form, history);
+    String historyCollection = mongoTemplate.getCollectionName(FormrPartbSubmissionHistory.class);
+    mongoTemplate.save(document, historyCollection);
+
+    return history;
+  }
+
+  /**
+   * Transform the structure of the form to fit the audited form structure. Any non-recognized
+   * fields will be considered content.
+   *
+   * @param copyFormId Whether to copy the form ID to the new version. Generally true for actual
+   *                   forms and false for history snapshots.
+   * @param formRef    The form reference for the form.
+   * @param form       The form to transform.
+   * @param history    The pre-built history to inject in to the audit history of the form. The
+   *                   current status will be pulled from the latest history item.
+   * @return The transformed form as a {@link Document}.
+   */
+  private Document transformForm(boolean copyFormId, String formRef, Document form,
+      List<Map<String, Object>> history) {
+    Map<String, Object> content = new HashMap<>(form);
+
+    // Remove non-content fields.
+    content.remove(FIELD_CLASS);
+    content.remove(FIELD_LAST_MODIFIED_DATE);
+    content.remove(FIELD_LIFECYCLE_STATE);
+    content.remove(FIELD_SUBMISSION_DATE);
+
+    UUID formId = UUID.fromString(content.remove(FIELD_ID).toString());
+    String traineeId = (String) content.remove(FIELD_TRAINEE_ID);
+
+    Document migratedForm = new Document();
+    migratedForm.put(FIELD_ID, copyFormId ? formId : UUID.randomUUID());
+    migratedForm.put(FIELD_TRAINEE_ID, traineeId);
+    migratedForm.put(FIELD_FORM_REF, formRef);
+    migratedForm.put(FIELD_REVISION, 0);
+    migratedForm.put(FIELD_CONTENT, content);
+
+    // Build status.
+    Map<String, Object> status = new LinkedHashMap<>();
+    Map<String, Object> latestHistory = history.get(history.size() - 1);
+    status.put(FIELD_CURRENT, latestHistory);
+    status.put(FIELD_HISTORY, history);
+    migratedForm.put(FIELD_STATUS, status);
+
+    // Each of the targeted forms only has a single timestamp available.
+    Instant timestamp = (Instant) latestHistory.get(FIELD_TIMESTAMP);
+    status.put(FIELD_SUBMITTED, timestamp);
+    migratedForm.put(FIELD_CREATED, timestamp);
+    migratedForm.put(FIELD_LAST_MODIFIED, timestamp);
+
+    migratedForm.put(FIELD_CLASS, FormRPartB.class.getName());
+    return migratedForm;
+  }
+
+  /**
+   * Get the details of the modifying user.
+   *
+   * @param form The form content to get details from.
+   * @return A map containing the details of the modifying user.
+   */
+  private Map<String, String> getModifiedBy(Document form) {
+    Map<String, String> modifiedBy = new LinkedHashMap<>();
+    modifiedBy.put(FIELD_NAME, "%s %s".formatted(
+        form.getString(FIELD_FORENAME),
+        form.getString(FIELD_SURNAME)
+    ).trim());
+    modifiedBy.put(FIELD_EMAIL, form.getString(FIELD_EMAIL));
+    modifiedBy.put(FIELD_ROLE, "TRAINEE");
+    return modifiedBy;
+  }
+
+  /**
+   * Build a status info map for the given lifecycle state and form details.
+   *
+   * @param state        The lifecycle state to build the status info for.
+   * @param form         The form document, will be used to retrieve name and email details.
+   * @param lastModified The timestamp of the last modification.
+   * @return The built status information.
+   */
+  private Map<String, Object> buildStatusInfo(LifecycleState state, Document form,
+      Instant lastModified) {
+    Map<String, Object> statusInfo = new LinkedHashMap<>();
+    statusInfo.put(FIELD_STATE, state);
+    statusInfo.put(FIELD_MODIFIED_BY, getModifiedBy(form));
+    statusInfo.put(FIELD_TIMESTAMP, lastModified);
+    statusInfo.put(FIELD_REVISION, 0);
+
+    return statusInfo;
+  }
+
+  /**
+   * Delete submission history for the given form reference. This is used to clean up any history
+   * created for forms that fail to migrate, to avoid orphaned history documents remaining after the
+   * migration is complete.
+   *
+   * @param formRef The form reference to delete for.
+   */
+  private void deleteSubmissionHistory(String formRef) {
+    log.debug("Rolling back form ref {}", formRef);
+    String collectionName = mongoTemplate.getCollectionName(FormrPartbSubmissionHistory.class);
+
+    Query query = Query.query(Criteria.where(FIELD_FORM_REF).is(formRef));
+    DeleteResult result = mongoTemplate.remove(query, collectionName);
+    log.debug("Removed {} submission history documents for form ref {}", result.getDeletedCount(),
+        formRef);
+  }
+
+  /**
+   * Do not attempt rollback, any successfully migrated forms should stay updated.
+   */
+  @RollbackExecution
+  public void rollback() {
+    log.warn(
+        "Rollback requested but not available for 'ConvertFormrToAudited2' migration.");
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAudited2.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAudited2.java
@@ -52,7 +52,7 @@ import uk.nhs.hee.tis.trainee.forms.model.FormrPartbSubmissionHistory;
  * handful of remaining forms and their unique scenario.
  */
 @Slf4j
-@ChangeUnit(id = "convertFormrToAudited2", order = "10")
+@ChangeUnit(id = "convertFormrToAudited2", order = "010")
 public class ConvertFormrToAudited2 {
 
   private static final String FIELD_ID = "_id";

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertObjectIdsToUuidStrings.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertObjectIdsToUuidStrings.java
@@ -48,7 +48,7 @@ import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
  * Convert existing ObjectID based form IDs to UUID strings.
  */
 @Slf4j
-@ChangeUnit(id = "convertObjectIdsToUuidStrings", order = "5")
+@ChangeUnit(id = "convertObjectIdsToUuidStrings", order = "005")
 public class ConvertObjectIdsToUuidStrings {
 
   private static final String ID_FIELD = "_id";

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertUuidStringsToUuidObjects.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertUuidStringsToUuidObjects.java
@@ -40,7 +40,7 @@ import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
  * Convert existing UUID string based form IDs to UUID objects.
  */
 @Slf4j
-@ChangeUnit(id = "ConvertUuidStringsToUuidObjects", order = "6")
+@ChangeUnit(id = "ConvertUuidStringsToUuidObjects", order = "006")
 public class ConvertUuidStringsToUuidObjects {
 
   private static final String ID_FIELD = "_id";

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/DeletePilotForms.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/DeletePilotForms.java
@@ -38,7 +38,7 @@ import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
  * Delete all forms created during the non-ARCP pilot.
  */
 @Slf4j
-@ChangeUnit(id = "deletePilotForms", order = "1")
+@ChangeUnit(id = "deletePilotForms", order = "001")
 public class DeletePilotForms {
 
   private final MongoTemplate mongoTemplate;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/DeleteTestForm.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/DeleteTestForm.java
@@ -36,7 +36,7 @@ import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
  * This form was submitted to validate that there was no problem with the user's account/data.
  */
 @Slf4j
-@ChangeUnit(id = "deleteTestForm", order = "3")
+@ChangeUnit(id = "deleteTestForm", order = "003")
 public class DeleteTestForm {
 
   private final MongoTemplate mongoTemplate;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/FixLtftSubmissionDates.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/FixLtftSubmissionDates.java
@@ -44,7 +44,7 @@ import uk.nhs.hee.tis.trainee.forms.service.LtftService;
  * Repair submission dates for LTFT forms where admin assignment has incorrectly overwritten them.
  */
 @Slf4j
-@ChangeUnit(id = "fixLtftSubmissionDates", order = "8")
+@ChangeUnit(id = "fixLtftSubmissionDates", order = "008")
 public class FixLtftSubmissionDates {
 
   private final MongoTemplate mongoTemplate;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/RecalculateTotalLeave.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/RecalculateTotalLeave.java
@@ -39,7 +39,7 @@ import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
  * populated correctly.
  */
 @Slf4j
-@ChangeUnit(id = "recalculateTotalLeave", order = "2")
+@ChangeUnit(id = "recalculateTotalLeave", order = "002")
 public class RecalculateTotalLeave {
 
   private static final String TOTAL_LEAVE = "totalLeave";

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/SortWorkPlacements.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/SortWorkPlacements.java
@@ -39,7 +39,7 @@ import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
  * Sort the work placements on Form R Part Bs by descending endDate.
  */
 @Slf4j
-@ChangeUnit(id = "sortWorkPlacements", order = "4")
+@ChangeUnit(id = "sortWorkPlacements", order = "004")
 public class SortWorkPlacements {
 
   private final MongoTemplate mongoTemplate;

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAudited2Test.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAudited2Test.java
@@ -1,0 +1,413 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package uk.nhs.hee.tis.trainee.forms.migration;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.SUBMITTED;
+
+import com.mongodb.client.result.DeleteResult;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
+import uk.nhs.hee.tis.trainee.forms.model.FormrPartbSubmissionHistory;
+
+class ConvertFormrToAudited2Test {
+
+  private static final UUID FORM_ID = UUID.randomUUID();
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+  private static final Instant SUBMISSION_DATE = Instant.now().minus(10, DAYS);
+
+  private static final String PART_B_COLLECTION = "form-r-part-b";
+  private static final String PART_B_HISTORY_COLLECTION = "form-r-part-b-history";
+
+  private ConvertFormrToAudited2 migration;
+
+  private MongoTemplate mongoTemplate;
+
+  @BeforeEach
+  void setUp() {
+    mongoTemplate = mock(MongoTemplate.class);
+    migration = new ConvertFormrToAudited2(mongoTemplate);
+
+    when(mongoTemplate.getCollectionName(FormRPartB.class)).thenReturn(PART_B_COLLECTION);
+    when(mongoTemplate.getCollectionName(FormrPartbSubmissionHistory.class)).thenReturn(
+        PART_B_HISTORY_COLLECTION);
+
+    when(mongoTemplate.remove(any(), any(String.class))).thenReturn(DeleteResult.acknowledged(0));
+  }
+
+  @Test
+  void shouldStopMigrationWhenUnhandledExceptionOccurs() {
+    Document before1 = new Document(Map.of(
+        "_id", UUID.randomUUID(),
+        "traineeTisId", TRAINEE_ID,
+        "forename", "Anthony",
+        "surname", "Gilliam",
+        "email", "anthony.gilliam@example.com",
+        "lifecycleState", "SUBMITTED",
+        "submissionDate", Date.from(SUBMISSION_DATE),
+        "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
+    ));
+    Document before2 = new Document(Map.of(
+        "_id", FORM_ID,
+        "traineeTisId", TRAINEE_ID,
+        "forename", "Anthony",
+        "surname", "Gilliam",
+        "email", "anthony.gilliam@example.com",
+        "lifecycleState", "SUBMITTED",
+        "submissionDate", Date.from(SUBMISSION_DATE),
+        "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
+    ));
+    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_B_COLLECTION)))
+        .thenReturn(List.of(before1, before2));
+
+    when(mongoTemplate.remove(any(), any(String.class)))
+        .thenReturn(DeleteResult.acknowledged(1))
+        .thenThrow(RuntimeException.class);
+
+    assertThrows(RuntimeException.class, () -> migration.migrateFormrPartb());
+
+    // First form should still save.
+    verify(mongoTemplate, times(1)).save(any(), eq(PART_B_COLLECTION));
+  }
+
+  @Test
+  void shouldMigrateToAuditedStructure() {
+    Document before = new Document(Map.of(
+        "_id", FORM_ID,
+        "traineeTisId", TRAINEE_ID,
+        "forename", "Anthony",
+        "surname", "Gilliam",
+        "email", "anthony.gilliam@example.com",
+        "contentKey", "contentValue",
+        "lifecycleState", "SUBMITTED",
+        "submissionDate", Date.from(SUBMISSION_DATE),
+        "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
+    ));
+    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_B_COLLECTION)))
+        .thenReturn(List.of(before));
+
+    migration.migrateFormrPartb();
+
+    ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate).save(documentCaptor.capture(), eq(PART_B_COLLECTION));
+
+    Document migrated = documentCaptor.getValue();
+    assertThat("Unexpected migrated form.", migrated, notNullValue());
+
+    assertThat("Unexpected root keys.", migrated.keySet(),
+        containsInAnyOrder("_id", "traineeTisId", "formRef", "revision", "content", "status",
+            "created", "lastModified", "_class"));
+
+    Map<String, Object> migratedStatus = getEmbeddedMap(migrated, List.of("status"));
+    assertThat("Unexpected status keys.", migratedStatus.keySet(),
+        containsInAnyOrder("current", "submitted", "history"));
+  }
+
+  @Test
+  void shouldSetFormMetadata() {
+    Document before = new Document(Map.of(
+        "_id", FORM_ID,
+        "traineeTisId", TRAINEE_ID,
+        "forename", "Anthony",
+        "surname", "Gilliam",
+        "email", "anthony.gilliam@example.com",
+        "contentKey", "contentValue",
+        "lifecycleState", "SUBMITTED",
+        "submissionDate", Date.from(SUBMISSION_DATE),
+        "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
+    ));
+    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_B_COLLECTION)))
+        .thenReturn(List.of(before));
+
+    migration.migrateFormrPartb();
+
+    ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate).save(documentCaptor.capture(), eq(PART_B_COLLECTION));
+
+    Document migrated = documentCaptor.getValue();
+    assertThat("Unexpected migrated form.", migrated, notNullValue());
+
+    assertThat("Unexpected ID.", migrated.get("_id", UUID.class), is(FORM_ID));
+    assertThat("Unexpected trainee ID.", migrated.getString("traineeTisId"), is(TRAINEE_ID));
+
+    assertThat("Unexpected created timestamp.", migrated.get("created", Instant.class),
+        is(SUBMISSION_DATE.truncatedTo(MILLIS)));
+    assertThat("Unexpected modified timestamp.", migrated.get("lastModified", Instant.class),
+        is(SUBMISSION_DATE.truncatedTo(MILLIS)));
+    assertThat("Unexpected document class.", migrated.getString("_class"),
+        is(FormRPartB.class.getName()));
+  }
+
+  @Test
+  void shouldSetFormRef() {
+    Document before = new Document(Map.of(
+        "_id", FORM_ID,
+        "traineeTisId", TRAINEE_ID,
+        "forename", "Anthony",
+        "surname", "Gilliam",
+        "email", "anthony.gilliam@example.com",
+        "lifecycleState", "SUBMITTED",
+        "submissionDate", Date.from(SUBMISSION_DATE),
+        "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
+    ));
+    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_B_COLLECTION)))
+        .thenReturn(List.of(before));
+
+    migration.migrateFormrPartb();
+
+    ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate).save(documentCaptor.capture(), eq(PART_B_COLLECTION));
+
+    Document migrated = documentCaptor.getValue();
+    assertThat("Unexpected migrated form.", migrated, notNullValue());
+
+    assertThat("Unexpected form reference.", migrated.get("formRef"),
+        is("formr_partb_" + TRAINEE_ID + "_001"));
+  }
+
+  @Test
+  void shouldCleanUpHistory() {
+
+    Document before = new Document(Map.of(
+        "_id", UUID.randomUUID(),
+        "traineeTisId", TRAINEE_ID,
+        "forename", "Anthony",
+        "surname", "Gilliam",
+        "email", "anthony.gilliam@example.com",
+        "lifecycleState", "SUBMITTED",
+        "submissionDate", Date.from(SUBMISSION_DATE),
+        "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
+    ));
+    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_B_COLLECTION)))
+        .thenReturn(List.of(before));
+
+    when(mongoTemplate.remove(any(), any(String.class))).thenReturn(DeleteResult.acknowledged(1));
+
+    migration.migrateFormrPartb();
+
+    verify(mongoTemplate).remove(any(), eq(PART_B_HISTORY_COLLECTION));
+  }
+
+  @Test
+  void shouldSetRevision() {
+    Document before = new Document(Map.of(
+        "_id", FORM_ID,
+        "traineeTisId", TRAINEE_ID,
+        "forename", "Anthony",
+        "surname", "Gilliam",
+        "email", "anthony.gilliam@example.com",
+        "lifecycleState", "SUBMITTED",
+        "submissionDate", Date.from(SUBMISSION_DATE),
+        "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
+    ));
+    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_B_COLLECTION)))
+        .thenReturn(List.of(before));
+
+    migration.migrateFormrPartb();
+
+    ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate).save(documentCaptor.capture(), eq(PART_B_COLLECTION));
+
+    Document migrated = documentCaptor.getValue();
+    assertThat("Unexpected migrated form.", migrated, notNullValue());
+
+    assertThat("Unexpected revision.", migrated.get("revision"), is(0));
+  }
+
+  @Test
+  void shouldSetContent() {
+    Document before = new Document(Map.of(
+        "_id", FORM_ID,
+        "traineeTisId", TRAINEE_ID,
+        "forename", "Anthony",
+        "surname", "Gilliam",
+        "email", "anthony.gilliam@example.com",
+        "contentKey", "contentValue",
+        "lifecycleState", "SUBMITTED",
+        "submissionDate", Date.from(SUBMISSION_DATE),
+        "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
+    ));
+    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_B_COLLECTION)))
+        .thenReturn(List.of(before));
+
+    migration.migrateFormrPartb();
+
+    ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate).save(documentCaptor.capture(), eq(PART_B_COLLECTION));
+
+    Document migrated = documentCaptor.getValue();
+    assertThat("Unexpected migrated form.", migrated, notNullValue());
+
+    Map<String, Object> migratedContent = getEmbeddedMap(migrated, List.of("content"));
+    assertThat("Unexpected content keys.", migratedContent.keySet(),
+        containsInAnyOrder("forename", "surname", "email", "contentKey"));
+    assertThat("Unexpected forename.", migratedContent.get("forename"), is("Anthony"));
+    assertThat("Unexpected surname.", migratedContent.get("surname"), is("Gilliam"));
+    assertThat("Unexpected email.", migratedContent.get("email"),
+        is("anthony.gilliam@example.com"));
+    assertThat("Unexpected content.", migratedContent.get("contentKey"), is("contentValue"));
+  }
+
+  @Test
+  void shouldSetSubmitted() {
+    Document before = new Document(Map.of(
+        "_id", FORM_ID,
+        "traineeTisId", TRAINEE_ID,
+        "forename", "Anthony",
+        "surname", "Gilliam",
+        "email", "anthony.gilliam@example.com",
+        "lifecycleState", "SUBMITTED",
+        "submissionDate", Date.from(SUBMISSION_DATE),
+        "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
+    ));
+    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_B_COLLECTION)))
+        .thenReturn(List.of(before));
+
+    migration.migrateFormrPartb();
+
+    ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate).save(documentCaptor.capture(), eq(PART_B_COLLECTION));
+
+    Document migrated = documentCaptor.getValue();
+    assertThat("Unexpected migrated form.", migrated, notNullValue());
+
+    Map<String, Object> migratedStatus = getEmbeddedMap(migrated, List.of("status"));
+    assertThat("Unexpected status keys.", migratedStatus.keySet(),
+        containsInAnyOrder("current", "submitted", "history"));
+
+    var submitted = migratedStatus.get("submitted");
+    assertThat("Unexpected submitted date.", submitted, is(SUBMISSION_DATE.truncatedTo(MILLIS)));
+  }
+
+  @Test
+  void shouldSetCurrentStatus() {
+    Document before = new Document(Map.of(
+        "_id", FORM_ID,
+        "traineeTisId", TRAINEE_ID,
+        "forename", "Anthony",
+        "surname", "Gilliam",
+        "email", "anthony.gilliam@example.com",
+        "contentKey", "contentValue",
+        "lifecycleState", "SUBMITTED",
+        "submissionDate", Date.from(SUBMISSION_DATE),
+        "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
+    ));
+    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_B_COLLECTION))).thenReturn(
+        List.of(before));
+
+    migration.migrateFormrPartb();
+
+    ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate).save(documentCaptor.capture(), eq(PART_B_COLLECTION));
+
+    Document migrated = documentCaptor.getValue();
+    assertThat("Unexpected migrated form.", migrated, notNullValue());
+
+    Map<String, Object> migratedCurrent = getEmbeddedMap(migrated, List.of("status", "current"));
+    assertThat("Unexpected current status keys.", migratedCurrent.keySet(),
+        containsInAnyOrder("state", "modifiedBy", "timestamp", "revision"));
+    assertThat("Unexpected lifecycle state.", migratedCurrent.get("state"), is(SUBMITTED));
+    assertThat("Unexpected current status timestamp.", migratedCurrent.get("timestamp"),
+        is(SUBMISSION_DATE.truncatedTo(MILLIS)));
+    assertThat("Unexpected current status revision.", migratedCurrent.get("revision"), is(0));
+  }
+
+  @Test
+  void shouldSetCurrentModifiedByToTrainee() {
+    Document before = new Document(Map.of(
+        "_id", FORM_ID,
+        "traineeTisId", TRAINEE_ID,
+        "forename", "Anthony",
+        "surname", "Gilliam",
+        "email", "anthony.gilliam@example.com",
+        "lifecycleState", "SUBMITTED",
+        "submissionDate", Date.from(SUBMISSION_DATE),
+        "_class", "uk.tis.nhs.trainee.forms.model.MyForm"
+    ));
+    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_B_COLLECTION))).thenReturn(
+        List.of(before));
+
+    migration.migrateFormrPartb();
+
+    ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate).save(documentCaptor.capture(), eq(PART_B_COLLECTION));
+
+    Document migrated = documentCaptor.getValue();
+    assertThat("Unexpected migrated form.", migrated, notNullValue());
+
+    Map<String, Object> modifiedBy = getEmbeddedMap(migrated,
+        List.of("status", "current", "modifiedBy"));
+    assertThat("Unexpected modifiedBy keys.", modifiedBy.keySet(),
+        containsInAnyOrder("name", "email", "role"));
+    assertThat("Unexpected modifiedBy name.", modifiedBy.get("name"), is("Anthony Gilliam"));
+    assertThat("Unexpected modifiedBy email.", modifiedBy.get("email"),
+        is("anthony.gilliam@example.com"));
+    assertThat("Unexpected modifiedBy role.", modifiedBy.get("role"), is("TRAINEE"));
+  }
+
+  @Test
+  void shouldNotAttemptRollback() {
+    migration.rollback();
+    verifyNoInteractions(mongoTemplate);
+  }
+
+  /**
+   * Get an embedded {@code Map<String, Object>} from a Document by traversing the specified keys.
+   *
+   * @param document The document to get an embedded map from.
+   * @param keys     A list of keys, each item represents a level of nesting to traverse to get the
+   *                 target embedded map.
+   * @return The embedded map.
+   */
+  private Map<String, Object> getEmbeddedMap(Document document, List<String> keys) {
+    Map<String, Object> current = document;
+
+    for (String key : keys) {
+      current = (Map<String, Object>) current.get(key);
+    }
+
+    return current;
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAuditedTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertFormrToAuditedTest.java
@@ -1109,7 +1109,8 @@ class ConvertFormrToAuditedTest {
 
   @ParameterizedTest
   @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
-  void shouldSetCurrentModifiedByToDummyTraineeWhenVersionsDeletedAndNullFields(Class<?> formClass) {
+  void shouldSetCurrentModifiedByToDummyTraineeWhenVersionsDeletedAndNullFields(
+      Class<?> formClass) {
     String collectionName = formClass == FormRPartA.class ? PART_A_COLLECTION : PART_B_COLLECTION;
     when(mongoTemplate.getCollectionName(formClass)).thenReturn(collectionName);
 
@@ -1190,7 +1191,8 @@ class ConvertFormrToAuditedTest {
 
   @ParameterizedTest
   @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
-  void shouldSetCurrentModifiedByToDummyTraineeWhenVersionsDeletedAndEmptyFields(Class<?> formClass) {
+  void shouldSetCurrentModifiedByToDummyTraineeWhenVersionsDeletedAndEmptyFields(
+      Class<?> formClass) {
     String collectionName = formClass == FormRPartA.class ? PART_A_COLLECTION : PART_B_COLLECTION;
     when(mongoTemplate.getCollectionName(formClass)).thenReturn(collectionName);
 
@@ -1270,7 +1272,8 @@ class ConvertFormrToAuditedTest {
 
   @ParameterizedTest
   @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
-  void shouldSetCurrentModifiedByToDummyTraineeWhenVersionsDeletedAndMissingFields(Class<?> formClass) {
+  void shouldSetCurrentModifiedByToDummyTraineeWhenVersionsDeletedAndMissingFields(
+      Class<?> formClass) {
     String collectionName = formClass == FormRPartA.class ? PART_A_COLLECTION : PART_B_COLLECTION;
     when(mongoTemplate.getCollectionName(formClass)).thenReturn(collectionName);
 


### PR DESCRIPTION
Several Form R Part B failed migration due to an unexpected state, with no record of their first submission available in S3.

Create a migrator to deal with these failures, it will assume the following due to lack of other available data.
 - All forms are the trainee's first submission (form ref 001)
 - The forms had a single submission (revision data lost)
 - There is no reliable history in S3
 - All forms are at SUBMITTED in the DB

As a result a lot of assumptions can be made and the original migrator can be trimmed down significantly.
 - Only two history items: DRAFT -> SUBMITTED
 - Form Ref is `formr_partb_{traineeId}_001`
 - ModifiedBy is always the trainee themselves
 - Timestamps will all copy the known submission timestamp

TIS21-8706