### PR TITLE
fix: duplicate FormR formRefs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.70.0"
+version = "0.70.1"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/migration/FixDuplicateFormrRefsIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/migration/FixDuplicateFormrRefsIntegrationTest.java
@@ -1,0 +1,325 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package uk.nhs.hee.tis.trainee.forms.migration;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import uk.nhs.hee.tis.trainee.forms.DockerImageNames;
+import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractFormR;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
+import uk.nhs.hee.tis.trainee.forms.model.FormSubmissionHistory;
+import uk.nhs.hee.tis.trainee.forms.model.FormrPartaSubmissionHistory;
+import uk.nhs.hee.tis.trainee.forms.model.FormrPartbSubmissionHistory;
+import uk.nhs.hee.tis.trainee.forms.model.content.FormrPartaContent;
+import uk.nhs.hee.tis.trainee.forms.model.content.FormrPartbContent;
+import uk.nhs.hee.tis.trainee.forms.service.FormRPartAService;
+import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+class FixDuplicateFormrRefsIntegrationTest {
+
+  private static final String UPDATED_TOPIC = "integration-formr-updated-topic";
+  private static final String FILE_TOPIC = "integration-formr-file-topic";
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @DynamicPropertySource
+  private static void overrideProperties(DynamicPropertyRegistry registry) {
+    registry.add("application.aws.sns.formr-updated", () -> UPDATED_TOPIC);
+    registry.add("application.aws.sns.formr-file-event", () -> FILE_TOPIC);
+  }
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @Autowired
+  private FormRPartAService partaService;
+
+  @Autowired
+  private FormRPartBService partbService;
+
+  @Value("${application.aws.sns.formr-updated}")
+  private String formrUpdatedTopic;
+
+  @Value("${application.aws.sns.formr-file-event}")
+  private String formrFileTopic;
+
+  @MockitoBean
+  private SnsClient snsClient;
+
+  private FixDuplicateFormrRefs migration;
+
+  @BeforeEach
+  void setUp() {
+    migration = new FixDuplicateFormrRefs(mongoTemplate, partaService, partbService);
+  }
+
+  @AfterEach
+  void tearDown() {
+    mongoTemplate.remove(new Query(), FormRPartA.class);
+    mongoTemplate.remove(new Query(), FormRPartB.class);
+    mongoTemplate.remove(new Query(), FormrPartaSubmissionHistory.class);
+    mongoTemplate.remove(new Query(), FormrPartbSubmissionHistory.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
+  void shouldFixDuplicateRefsUsingCreatedDateOrdering(Class<? extends AbstractFormR<?>> formClass) {
+    String traineeWithDuplicates = UUID.randomUUID().toString();
+    String traineeWithoutDuplicates = UUID.randomUUID().toString();
+
+    UUID latestId = UUID.randomUUID();
+    UUID middleId = UUID.randomUUID();
+    UUID oldestId = UUID.randomUUID();
+
+    String collectionName = mongoTemplate.getCollectionName(formClass);
+    String baseRef = getFormRefPrefix(formClass, traineeWithDuplicates);
+
+    mongoTemplate.save(createForm(formClass, latestId, traineeWithDuplicates, baseRef + "001",
+        Instant.now().minus(1, DAYS)), collectionName);
+    mongoTemplate.save(createForm(formClass, middleId, traineeWithDuplicates, baseRef + "001",
+        Instant.now().minus(2, DAYS)), collectionName);
+    mongoTemplate.save(createForm(formClass, oldestId, traineeWithDuplicates, baseRef + "001",
+        Instant.now().minus(3, DAYS)), collectionName);
+
+    // A non-duplicated trainee should not be changed by the migration.
+    String uniqueBaseRef = getFormRefPrefix(formClass, traineeWithoutDuplicates);
+    UUID uniqueId1 = UUID.randomUUID();
+    UUID uniqueId2 = UUID.randomUUID();
+    mongoTemplate.save(
+        createForm(formClass, uniqueId1, traineeWithoutDuplicates, uniqueBaseRef + "002",
+            Instant.now().minus(4, DAYS)), collectionName);
+    mongoTemplate.save(
+        createForm(formClass, uniqueId2, traineeWithoutDuplicates, uniqueBaseRef + "001",
+            Instant.now().minus(5, DAYS)), collectionName);
+
+    migration.migrateCollections();
+
+    assertThat("Unexpected latest form ref.",
+        findFormRef(collectionName, latestId), is(baseRef + "003"));
+    assertThat("Unexpected middle form ref.",
+        findFormRef(collectionName, middleId), is(baseRef + "002"));
+    assertThat("Unexpected oldest form ref.",
+        findFormRef(collectionName, oldestId), is(baseRef + "001"));
+
+    assertThat("Unexpected non-duplicate form ref.",
+        findFormRef(collectionName, uniqueId1), is(uniqueBaseRef + "002"));
+    assertThat("Unexpected non-duplicate form ref.",
+        findFormRef(collectionName, uniqueId2), is(uniqueBaseRef + "001"));
+
+    String historyCollection = mongoTemplate.getCollectionName(getHistoryClass(formClass));
+    List<Document> snapshots = mongoTemplate.find(
+        Query.query(Criteria.where("traineeTisId").is(traineeWithDuplicates)),
+        Document.class, historyCollection);
+    assertThat("Unexpected history snapshot count.", snapshots, hasSize(2));
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
+  void shouldSkipUpdatesWhenGeneratedFormRefAlreadyExistsInHistory(
+      Class<? extends AbstractFormR<?>> formClass) {
+    String traineeId = UUID.randomUUID().toString();
+    String collectionName = mongoTemplate.getCollectionName(formClass);
+    String historyCollection = mongoTemplate.getCollectionName(getHistoryClass(formClass));
+
+    UUID latestId = UUID.randomUUID();
+    UUID olderId = UUID.randomUUID();
+    String baseRef = getFormRefPrefix(formClass, traineeId);
+
+    mongoTemplate.save(createForm(formClass, latestId, traineeId, baseRef + "001",
+        Instant.now().minus(1, DAYS)), collectionName);
+    mongoTemplate.save(createForm(formClass, olderId, traineeId, baseRef + "001",
+        Instant.now().minus(2, DAYS)), collectionName);
+
+    // For two forms the generated latest ref would be ..._002, which this history row blocks.
+    mongoTemplate.save(new Document("formRef", baseRef + "002"), historyCollection);
+
+    migration.migrateCollections();
+
+    assertThat("Unexpected latest form ref.",
+        findFormRef(collectionName, latestId), is(baseRef + "001"));
+    assertThat("Unexpected older form ref.",
+        findFormRef(collectionName, olderId), is(baseRef + "001"));
+
+    verifyNoInteractions(snsClient);
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
+  void shouldPublishToUpdatedTopicWhenRefChanges(Class<? extends AbstractFormR<?>> formClass) {
+    String traineeId = UUID.randomUUID().toString();
+    String collectionName = mongoTemplate.getCollectionName(formClass);
+
+    UUID latestId = UUID.randomUUID();
+    String baseRef = getFormRefPrefix(formClass, traineeId);
+
+    mongoTemplate.save(createForm(formClass, latestId, traineeId, baseRef + "001",
+        Instant.now().minus(1, DAYS)), collectionName);
+    mongoTemplate.save(createForm(formClass, UUID.randomUUID(), traineeId, baseRef + "001",
+        Instant.now().minus(2, DAYS)), collectionName);
+
+    migration.migrateCollections();
+
+    ArgumentCaptor<PublishRequest> requestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+    verify(snsClient, times(2)).publish(requestCaptor.capture());
+
+    List<PublishRequest> requests = requestCaptor.getAllValues();
+    PublishRequest updatedRequest = requests.stream()
+        .filter(request -> formrUpdatedTopic.equals(request.topicArn()))
+        .findFirst()
+        .orElse(null);
+    assertThat("Expected updated topic publish request was not sent.", updatedRequest,
+        notNullValue());
+
+    String expectedFormType = formClass == FormRPartA.class ? "formr-a" : "formr-b";
+    assertThat("Unexpected updated event formType attribute.",
+        updatedRequest.messageAttributes().get("formType").stringValue(), is(expectedFormType));
+    assertThat("Unexpected updated event message group ID.",
+        updatedRequest.messageGroupId(), is(latestId.toString()));
+
+    PublishRequest fileRequest = requests.stream()
+        .filter(request -> formrFileTopic.equals(request.topicArn()))
+        .findFirst()
+        .orElse(null);
+    assertThat("Expected file topic publish request was not sent.", fileRequest, notNullValue());
+    assertThat("Unexpected file event_type attribute.",
+        fileRequest.messageAttributes().get("event_type").stringValue(), is("FORM_R"));
+  }
+
+  /**
+   * Find a form reference by document ID from a given collection.
+   *
+   * @param collectionName The Mongo collection to query.
+   * @param id             The form document ID.
+   * @return The form reference if found, otherwise {@code null}.
+   */
+  private String findFormRef(String collectionName, UUID id) {
+    Document document = mongoTemplate.findById(id, Document.class, collectionName);
+    return document == null ? null : document.getString("formRef");
+  }
+
+  /**
+   * Resolve the submission history class for a Form-R type.
+   *
+   * @param formClass The Form-R class.
+   * @return The matching submission history class.
+   */
+  private Class<? extends FormSubmissionHistory> getHistoryClass(
+      Class<? extends AbstractFormR<?>> formClass) {
+    return formClass == FormRPartA.class ? FormrPartaSubmissionHistory.class
+        : FormrPartbSubmissionHistory.class;
+  }
+
+  /**
+   * Build a form reference prefix for a trainee and Form-R type.
+   *
+   * @param formClass The Form-R class.
+   * @param traineeId The trainee ID.
+   * @return The form reference prefix.
+   */
+  private String getFormRefPrefix(Class<? extends AbstractFormR<?>> formClass, String traineeId) {
+    String formType = formClass == FormRPartA.class ? "parta" : "partb";
+    return "formr_" + formType + "_" + traineeId + "_";
+  }
+
+  /**
+   * Create a minimal submitted Form-R instance for migration testing.
+   *
+   * @param formClass The Form-R class to instantiate.
+   * @param id        The form ID.
+   * @param traineeId The trainee ID.
+   * @param formRef   The form reference.
+   * @param created   The created/last-modified timestamp.
+   * @return The populated Form-R instance.
+   */
+  private AbstractFormR<?> createForm(Class<? extends AbstractFormR<?>> formClass, UUID id,
+      String traineeId, String formRef, Instant created) {
+    AbstractFormR<?> form;
+
+    if (formClass == FormRPartA.class) {
+      FormRPartA parta = new FormRPartA();
+      parta.setContent(FormrPartaContent.builder()
+          .forename("Forename")
+          .surname("Surname")
+          .email("formr-a@example.com")
+          .build());
+      form = parta;
+    } else {
+      FormRPartB partb = new FormRPartB();
+      partb.setContent(FormrPartbContent.builder()
+          .forename("Forename")
+          .surname("Surname")
+          .email("formr-b@example.com")
+          .build());
+      form = partb;
+    }
+
+    form.setId(id);
+    form.setTraineeTisId(traineeId);
+    form.setFormRef(formRef);
+    form.setRevision(0);
+    form.setLifecycleState(LifecycleState.SUBMITTED);
+    form.setCreated(created);
+    form.setLastModified(created);
+    return form;
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/FixDuplicateFormrRefs.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/FixDuplicateFormrRefs.java
@@ -1,0 +1,230 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package uk.nhs.hee.tis.trainee.forms.migration;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import java.util.List;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import uk.nhs.hee.tis.trainee.forms.model.AbstractFormR;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
+import uk.nhs.hee.tis.trainee.forms.model.FormSubmissionHistory;
+import uk.nhs.hee.tis.trainee.forms.model.FormrPartaSubmissionHistory;
+import uk.nhs.hee.tis.trainee.forms.model.FormrPartbSubmissionHistory;
+import uk.nhs.hee.tis.trainee.forms.service.FormRPartAService;
+import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
+
+/**
+ * Mongock change unit to recalculate form refs where they are duplicated.
+ */
+@Slf4j
+@ChangeUnit(id = "fixDuplicateFormrRefs", order = "011")
+public class FixDuplicateFormrRefs {
+
+  private static final String FIELD_ID = "_id";
+  private static final String FIELD_CLASS = "_class";
+  private static final String FIELD_TRAINEE_ID = "traineeTisId";
+  private static final String FIELD_FORM_REF = "formRef";
+  private static final String FIELD_REVISION = "revision";
+  private static final String FIELD_CREATED = "created";
+
+  private static final int FORM_REF_SUFFIX_LENGTH = 3;
+
+  private final MongoTemplate mongoTemplate;
+
+  private final FormRPartAService partaService;
+  private final FormRPartBService partbService;
+
+  /**
+   * Constructor for FixDuplicateFormrRefs.
+   */
+  public FixDuplicateFormrRefs(MongoTemplate mongoTemplate, FormRPartAService partaService,
+      FormRPartBService partbService) {
+    this.mongoTemplate = mongoTemplate;
+    this.partaService = partaService;
+    this.partbService = partbService;
+  }
+
+  /**
+   * Recalculate form references for duplicated forms.
+   */
+  @Execution
+  public void migrateCollections() {
+    int fixCount = migrateCollection(FormRPartA.class, FormrPartaSubmissionHistory.class);
+    fixCount += migrateCollection(FormRPartB.class, FormrPartbSubmissionHistory.class);
+    log.info("Fixed a total of {} duplicate formRefs across all collections.", fixCount);
+  }
+
+  private int migrateCollection(Class<? extends AbstractFormR<?>> formClass,
+      Class<? extends FormSubmissionHistory> historyClass) {
+    String formCollection = mongoTemplate.getCollectionName(formClass);
+    String historyCollection = mongoTemplate.getCollectionName(historyClass);
+
+    List<String> traineeIds = getTraineeIdsWithDuplicates(formCollection);
+
+    log.info("Found {} trainee(s) with duplicate formRefs in collection {}.", traineeIds.size(),
+        formCollection);
+
+    int fixCount = traineeIds.stream()
+        .mapToInt(
+            traineeId -> fixTraineeForms(traineeId, formClass, historyClass, formCollection,
+                historyCollection))
+        .sum();
+
+    log.info("Fixed {} duplicate formRefs in collection {}.", fixCount, formCollection);
+    return fixCount;
+  }
+
+  private List<String> getTraineeIdsWithDuplicates(String collectionName) {
+    Aggregation aggregation = Aggregation.newAggregation(
+        Aggregation.match(
+            Criteria.where(FIELD_FORM_REF).exists(true).ne(null)
+        ),
+        // Count occurrences of each formRef per trainee
+        Aggregation.group(FIELD_TRAINEE_ID, FIELD_FORM_REF)
+            .count().as("count"),
+
+        // Keep only duplicate formRefs
+        Aggregation.match(
+            Criteria.where("count").gt(1)
+        ),
+
+        // Collapse back down to one document per trainee
+        Aggregation.group("_id." + FIELD_TRAINEE_ID),
+
+        // Return just the traineeTisId
+        Aggregation.project()
+            .and(FIELD_ID).as(FIELD_TRAINEE_ID)
+            .andExclude(FIELD_ID)
+    );
+
+    return mongoTemplate.aggregate(aggregation, collectionName, Document.class)
+        .getMappedResults()
+        .stream()
+        .map(document -> document.getString(FIELD_TRAINEE_ID))
+        .toList();
+  }
+
+  private int fixTraineeForms(String traineeId, Class<? extends AbstractFormR<?>> formClass,
+      Class<? extends FormSubmissionHistory> historyClass, String formCollection,
+      String historyCollection) {
+    Query query = Query.query(
+            Criteria.where(FIELD_TRAINEE_ID).is(traineeId)
+                .and(FIELD_FORM_REF).exists(true).ne(null))
+        .with(Sort.by(
+            // Latest form first to avoid creating new overlaps when there are multiple per-trainee.
+            Sort.Order.desc(FIELD_CREATED),
+            Sort.Order.asc(FIELD_ID)
+        ));
+
+    List<Document> forms = mongoTemplate.find(query, Document.class, formCollection);
+    log.debug("Found {} forms for trainee {} in collection {}.", forms.size(), traineeId,
+        formCollection);
+    final int formCount = forms.size();
+    int fixCount = 0;
+
+    for (int i = 0; i < formCount; i++) {
+      Document form = forms.get(i);
+      String formRef = form.getString(FIELD_FORM_REF);
+      String formRefPrefix = formRef.substring(0, formRef.length() - FORM_REF_SUFFIX_LENGTH);
+      int formRefSuffix = Integer.parseInt(
+          formRef.substring(formRef.length() - FORM_REF_SUFFIX_LENGTH));
+      int expectedSuffix = formCount - i; // Forms are latest first.
+
+      if (formRefSuffix != expectedSuffix) {
+        if (i != 0) {
+          // Not a truly significant event, but logging gives better visibility for manual checks.
+          log.info("Generating a new formRef for non-latest form {}", form.get(FIELD_ID));
+        }
+
+        String newFormRef = formRefPrefix + "%03d".formatted(expectedSuffix);
+        boolean historyExists = mongoTemplate.exists(
+            Query.query(Criteria.where(FIELD_FORM_REF).is(newFormRef)), historyCollection);
+
+        if (historyExists) {
+          log.error(
+              "Generated formRef {} already has snapshots, unable to update form {}.",
+              newFormRef, formRef);
+          continue;
+        }
+
+        // Should never be null, but default to 0 to avoid NPEs if it is.
+        int revision = form.getInteger(FIELD_REVISION, 0);
+
+        if (revision != 0) {
+          log.warn(
+              "Form {} for trainee {} has revision {}, earlier snapshots will not be generated.",
+              formRef, traineeId, revision);
+        }
+
+        form.put(FIELD_FORM_REF, newFormRef);
+        log.info("Saving form {} with updated form ref {} (previously {})", form.get(FIELD_ID),
+            newFormRef, formRef);
+        mongoTemplate.save(form, formCollection);
+
+        Document history = new Document(form);
+        history.put(FIELD_ID, UUID.randomUUID());
+        history.put(FIELD_CLASS, historyClass.getName());
+        log.debug("Saving history for new form ref {}", newFormRef);
+        mongoTemplate.save(history, historyCollection);
+
+        publishFormUpdate(form, formClass);
+        fixCount++;
+      }
+    }
+
+    return fixCount;
+  }
+
+  private void publishFormUpdate(Document form, Class<? extends AbstractFormR<?>> formClass) {
+    if (formClass.equals(FormRPartA.class)) {
+      log.debug("Publishing FormRPartA update event for new form ref {}",
+          form.getString(FIELD_FORM_REF));
+      partaService.getAdminsFormRPartAById(form.get(FIELD_ID, UUID.class).toString()).ifPresent(
+          partaService::publishFormRUpdateEvent);
+    } else {
+      log.debug("Publishing FormRPartB update event for new form ref {}",
+          form.getString(FIELD_FORM_REF));
+      partbService.getAdminsFormRPartBById(form.get(FIELD_ID, UUID.class).toString()).ifPresent(
+          partbService::publishFormRUpdateEvent);
+    }
+  }
+
+  /**
+   * Do not attempt rollback, any successfully migrated forms should stay updated.
+   */
+  @RollbackExecution
+  public void rollback() {
+    log.warn(
+        "Rollback requested but not available for 'FixDuplicateFormrRefs' migration.");
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAService.java
@@ -317,7 +317,7 @@ public class FormRPartAService extends AbstractAuditedFormService<FormRPartA> {
   /**
    * Publish Form-R status update notification.
    *
-   * @param form The updated LTFT form.
+   * @param form The updated form.
    */
   @Override
   public void publishStatusUpdateNotification(FormRPartA form) {
@@ -342,7 +342,7 @@ public class FormRPartAService extends AbstractAuditedFormService<FormRPartA> {
    *
    * @param formDto The form DTO to publish.
    */
-  private void publishFormRUpdateEvent(FormRPartADto formDto) {
+  public void publishFormRUpdateEvent(FormRPartADto formDto) {
     log.debug("Publishing FormRPartA {} event for form id: {}",
         formDto.getLifecycleState(), formDto.getId());
     publishUpdateNotification(formDto, formRPartAUpdatedTopic);

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBService.java
@@ -318,7 +318,7 @@ public class FormRPartBService extends AbstractAuditedFormService<FormRPartB> {
   /**
    * Publish Form-R status update notification.
    *
-   * @param form The updated LTFT form.
+   * @param form The updated form.
    */
   @Override
   public void publishStatusUpdateNotification(FormRPartB form) {
@@ -343,7 +343,7 @@ public class FormRPartBService extends AbstractAuditedFormService<FormRPartB> {
    *
    * @param formDto The form DTO to publish.
    */
-  private void publishFormRUpdateEvent(FormRPartBDto formDto) {
+  public void publishFormRUpdateEvent(FormRPartBDto formDto) {
     log.debug("Publishing FormRPartB {} event for form id: {}",
         formDto.getLifecycleState(), formDto.getId());
     publishUpdateNotification(formDto, formRPartBUpdatedTopic);

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/FixDuplicateFormrRefsTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/FixDuplicateFormrRefsTest.java
@@ -1,0 +1,477 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package uk.nhs.hee.tis.trainee.forms.migration;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import uk.nhs.hee.tis.trainee.forms.dto.FormRPartADto;
+import uk.nhs.hee.tis.trainee.forms.dto.FormRPartBDto;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
+import uk.nhs.hee.tis.trainee.forms.model.FormrPartaSubmissionHistory;
+import uk.nhs.hee.tis.trainee.forms.model.FormrPartbSubmissionHistory;
+import uk.nhs.hee.tis.trainee.forms.service.FormRPartAService;
+import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
+
+class FixDuplicateFormrRefsTest {
+
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+
+  private static final String PART_A_COLLECTION = "form-r-part-a";
+  private static final String PART_B_COLLECTION = "form-r-part-b";
+
+  private static final String PART_A_HISTORY_COLLECTION = "form-r-part-a-history";
+  private static final String PART_B_HISTORY_COLLECTION = "form-r-part-b-history";
+
+  private FixDuplicateFormrRefs migration;
+
+  private MongoTemplate mongoTemplate;
+  private FormRPartAService partaService;
+  private FormRPartBService partbService;
+
+  @BeforeEach
+  void setUp() {
+    mongoTemplate = mock(MongoTemplate.class);
+    partaService = mock(FormRPartAService.class);
+    partbService = mock(FormRPartBService.class);
+    migration = new FixDuplicateFormrRefs(mongoTemplate, partaService, partbService);
+
+    when(mongoTemplate.getCollectionName(FormRPartA.class)).thenReturn(PART_A_COLLECTION);
+    when(mongoTemplate.getCollectionName(FormRPartB.class)).thenReturn(PART_B_COLLECTION);
+    when(mongoTemplate.getCollectionName(FormrPartaSubmissionHistory.class)).thenReturn(
+        PART_A_HISTORY_COLLECTION);
+    when(mongoTemplate.getCollectionName(FormrPartbSubmissionHistory.class)).thenReturn(
+        PART_B_HISTORY_COLLECTION);
+
+    when(mongoTemplate.aggregate(any(Aggregation.class), anyString(), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()));
+    when(partaService.getFormRPartAById(anyString())).thenReturn(Optional.empty());
+    when(partbService.getFormRPartBById(anyString())).thenReturn(Optional.empty());
+  }
+
+  @Test
+  void shouldNotAttemptRollback() {
+    migration.rollback();
+
+    verifyNoInteractions(mongoTemplate, partaService, partbService);
+  }
+
+  @Test
+  void shouldDoNothingWhenNoDuplicateFormRefsFound() {
+    when(mongoTemplate.aggregate(any(Aggregation.class), anyString(), eq(Document.class)))
+        .thenReturn(new AggregationResults<>(List.of(), new Document()));
+
+    migration.migrateCollections();
+
+    verify(mongoTemplate, never()).save(any(Document.class), anyString());
+    verifyNoInteractions(partaService, partbService);
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
+  void shouldUpdateLatestFormRefWhenDuplicateExists(Class<?> formClass) {
+    String formCollection = getCollectionName(formClass);
+    String historyCollection = getHistoryCollectionName(formClass);
+    String formRefPrefix = getFormRefPrefix(formClass);
+    UUID latestFormId = UUID.randomUUID();
+
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(formCollection), eq(Document.class)))
+        .thenReturn(duplicateTrainees(TRAINEE_ID));
+
+    when(mongoTemplate.find(any(), eq(Document.class), eq(formCollection)))
+        .thenReturn(List.of(
+            createForm(latestFormId, formRefPrefix + "001", 0, Instant.now()),
+            createForm(UUID.randomUUID(), formRefPrefix + "001", 0, Instant.now().minus(1, DAYS))
+        ));
+
+    when(mongoTemplate.exists(any(), eq(historyCollection))).thenReturn(false);
+
+    migration.migrateCollections();
+
+    ArgumentCaptor<Document> formCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate).save(formCaptor.capture(), eq(formCollection));
+
+    Document migratedForm = formCaptor.getValue();
+    assertThat("Unexpected ID.", migratedForm.get("_id", UUID.class),
+        is(latestFormId));
+    assertThat("Unexpected updated form reference.", migratedForm.getString("formRef"),
+        is(formRefPrefix + "002"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
+  void shouldUpdateNonLatestFormRefWhenDuplicateExists(Class<?> formClass) {
+    String formCollection = getCollectionName(formClass);
+    String historyCollection = getHistoryCollectionName(formClass);
+    String formRefPrefix = getFormRefPrefix(formClass);
+    UUID nonLatestFormId = UUID.randomUUID();
+
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(formCollection), eq(Document.class)))
+        .thenReturn(duplicateTrainees(TRAINEE_ID));
+
+    when(mongoTemplate.find(any(), eq(Document.class), eq(formCollection)))
+        .thenReturn(List.of(
+            createForm(UUID.randomUUID(), formRefPrefix + "004", 0, Instant.now()),
+            createForm(nonLatestFormId, formRefPrefix + "002", 0, Instant.now().minus(1, DAYS)),
+            createForm(UUID.randomUUID(), formRefPrefix + "002", 0, Instant.now().minus(2, DAYS)),
+            createForm(UUID.randomUUID(), formRefPrefix + "001", 0, Instant.now().minus(3, DAYS))
+        ));
+
+    when(mongoTemplate.exists(any(), eq(historyCollection))).thenReturn(false);
+
+    migration.migrateCollections();
+
+    ArgumentCaptor<Document> formCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate).save(formCaptor.capture(), eq(formCollection));
+
+    Document migratedForm = formCaptor.getValue();
+    assertThat("Unexpected ID.", migratedForm.get("_id", UUID.class),
+        is(nonLatestFormId));
+    assertThat("Unexpected updated form reference.", migratedForm.getString("formRef"),
+        is(formRefPrefix + "003"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
+  void shouldCreateHistoryWhenDuplicateExists(Class<?> formClass) {
+    String formCollection = getCollectionName(formClass);
+    String historyCollection = getHistoryCollectionName(formClass);
+    String formRefPrefix = getFormRefPrefix(formClass);
+    UUID latestFormId = UUID.randomUUID();
+
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(formCollection), eq(Document.class)))
+        .thenReturn(duplicateTrainees(TRAINEE_ID));
+
+    when(mongoTemplate.find(any(), eq(Document.class), eq(formCollection)))
+        .thenReturn(List.of(
+            createForm(latestFormId, formRefPrefix + "001", 0, Instant.now()),
+            createForm(UUID.randomUUID(), formRefPrefix + "001", 0, Instant.now().minus(1, DAYS))
+        ));
+
+    when(mongoTemplate.exists(any(), eq(historyCollection))).thenReturn(false);
+
+    migration.migrateCollections();
+
+    ArgumentCaptor<Document> historyCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate).save(historyCaptor.capture(), eq(historyCollection));
+
+    Document history = historyCaptor.getValue();
+    assertThat("Unexpected history form reference.", history.getString("formRef"),
+        is(formRefPrefix + "002"));
+    assertThat("Expected a new history ID.", history.get("_id", UUID.class), is(not(latestFormId)));
+
+    var historyClass = formClass == FormRPartA.class
+        ? FormrPartaSubmissionHistory.class
+        : FormrPartbSubmissionHistory.class;
+    assertThat("Unexpected history class.", history.getString("_class"),
+        is(historyClass.getName()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
+  void shouldUpdateAllTraineesWithDuplicates(Class<?> formClass) {
+    String formCollection = getCollectionName(formClass);
+    String historyCollection = getHistoryCollectionName(formClass);
+    String formRefPrefix = getFormRefPrefix(formClass);
+    UUID latestFormId1 = UUID.randomUUID();
+    UUID latestFormId2 = UUID.randomUUID();
+    UUID latestFormId3 = UUID.randomUUID();
+
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(formCollection), eq(Document.class)))
+        .thenReturn(duplicateTrainees(TRAINEE_ID, "123", "456"));
+
+    when(mongoTemplate.find(any(), eq(Document.class), eq(formCollection)))
+        .thenReturn(List.of(
+            createForm(latestFormId1, formRefPrefix + "001", 0, Instant.now()),
+            createForm(UUID.randomUUID(), formRefPrefix + "001", 0, Instant.now().minus(1, DAYS))
+        ))
+        .thenReturn(List.of(
+            createForm(latestFormId2, formRefPrefix + "001", 0, Instant.now()),
+            createForm(UUID.randomUUID(), formRefPrefix + "001", 0, Instant.now().minus(1, DAYS))
+        )).thenReturn(List.of(
+            createForm(latestFormId3, formRefPrefix + "001", 0, Instant.now()),
+            createForm(UUID.randomUUID(), formRefPrefix + "001", 0, Instant.now().minus(1, DAYS))
+        ));
+
+    when(mongoTemplate.exists(any(), eq(historyCollection))).thenReturn(false);
+
+    migration.migrateCollections();
+
+    ArgumentCaptor<Document> formCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate, times(3)).save(formCaptor.capture(), eq(formCollection));
+
+    List<Document> migratedForms = formCaptor.getAllValues();
+    Document migratedForm = migratedForms.get(0);
+    assertThat("Unexpected ID.", migratedForm.get("_id", UUID.class),
+        is(latestFormId1));
+
+    migratedForm = migratedForms.get(1);
+    assertThat("Unexpected ID.", migratedForm.get("_id", UUID.class),
+        is(latestFormId2));
+
+    migratedForm = migratedForms.get(2);
+    assertThat("Unexpected ID.", migratedForm.get("_id", UUID.class),
+        is(latestFormId3));
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
+  void shouldUpdateFormRefWhenNotLatestRevision(Class<?> formClass) {
+    String formCollection = getCollectionName(formClass);
+    String historyCollection = getHistoryCollectionName(formClass);
+    String formRefPrefix = getFormRefPrefix(formClass);
+    UUID latestFormId = UUID.randomUUID();
+
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(formCollection), eq(Document.class)))
+        .thenReturn(duplicateTrainees(TRAINEE_ID));
+
+    when(mongoTemplate.find(any(), eq(Document.class), eq(formCollection)))
+        .thenReturn(List.of(
+            createForm(latestFormId, formRefPrefix + "001", 5, Instant.now()),
+            createForm(UUID.randomUUID(), formRefPrefix + "001", 0, Instant.now().minus(1, DAYS))
+        ));
+
+    when(mongoTemplate.exists(any(), eq(historyCollection))).thenReturn(false);
+
+    migration.migrateCollections();
+
+    ArgumentCaptor<Document> formCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate).save(formCaptor.capture(), eq(formCollection));
+
+    Document migratedForm = formCaptor.getValue();
+    assertThat("Unexpected updated form reference.", migratedForm.getString("formRef"),
+        is(formRefPrefix + "002"));
+    assertThat("Unexpected revision.", migratedForm.getInteger("revision"), is(5));
+
+    ArgumentCaptor<Document> historyCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate).save(historyCaptor.capture(), eq(historyCollection));
+
+    Document history = historyCaptor.getValue();
+    assertThat("Unexpected history form reference.", history.getString("formRef"),
+        is(formRefPrefix + "002"));
+    assertThat("Expected a new history ID.", history.get("_id", UUID.class), is(not(latestFormId)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
+  void shouldSkipUpdateWhenGeneratedFormRefAlreadyInHistory(Class<?> formClass) {
+    String formCollection = getCollectionName(formClass);
+    String historyCollection = getHistoryCollectionName(formClass);
+    String formRefPrefix = getFormRefPrefix(formClass);
+
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(formCollection), eq(Document.class)))
+        .thenReturn(duplicateTrainees(TRAINEE_ID));
+
+    when(mongoTemplate.find(any(), eq(Document.class), eq(formCollection)))
+        .thenReturn(List.of(
+            createForm(UUID.randomUUID(), formRefPrefix + "001", 0, Instant.now()),
+            createForm(UUID.randomUUID(), formRefPrefix + "001", 0, Instant.now().minus(1, DAYS))
+        ));
+
+    when(mongoTemplate.exists(any(), eq(historyCollection))).thenReturn(true);
+
+    migration.migrateCollections();
+
+    verify(mongoTemplate, never()).save(any(Document.class), eq(formCollection));
+    verify(mongoTemplate, never()).save(any(Document.class), eq(historyCollection));
+    verifyNoInteractions(partaService, partbService);
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {FormRPartA.class, FormRPartB.class})
+  void shouldRecalculateAllMismatchedFormRefsForTrainee(Class<?> formClass) {
+    String formCollection = getCollectionName(formClass);
+    String historyCollection = getHistoryCollectionName(formClass);
+    String formRefPrefix = getFormRefPrefix(formClass);
+
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(formCollection), eq(Document.class)))
+        .thenReturn(duplicateTrainees(TRAINEE_ID));
+
+    when(mongoTemplate.find(any(), eq(Document.class), eq(formCollection)))
+        .thenReturn(List.of(
+            createForm(UUID.randomUUID(), formRefPrefix + "001", 0, Instant.now()),
+            createForm(UUID.randomUUID(), formRefPrefix + "001", 0, Instant.now().minus(1, DAYS)),
+            createForm(UUID.randomUUID(), formRefPrefix + "001", 0, Instant.now().minus(2, DAYS))
+        ));
+
+    when(mongoTemplate.exists(any(), eq(historyCollection))).thenReturn(false);
+
+    migration.migrateCollections();
+
+    ArgumentCaptor<Document> formCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate, times(2)).save(formCaptor.capture(), eq(formCollection));
+
+    List<String> savedFormRefs = formCaptor.getAllValues().stream()
+        .map(document -> document.getString("formRef"))
+        .toList();
+    assertThat("Unexpected updated form references.", savedFormRefs,
+        containsInAnyOrder(formRefPrefix + "003", formRefPrefix + "002"));
+
+    ArgumentCaptor<Document> historyCaptor = ArgumentCaptor.captor();
+    verify(mongoTemplate, times(2)).save(historyCaptor.capture(), eq(historyCollection));
+
+    List<String> savedHistoryRefs = historyCaptor.getAllValues().stream()
+        .map(document -> document.getString("formRef"))
+        .toList();
+    assertThat("Unexpected history form references.", savedHistoryRefs,
+        containsInAnyOrder(formRefPrefix + "003", formRefPrefix + "002"));
+  }
+
+  @Test
+  void shouldPublishUpdateForPartA() {
+    String formRefPrefix = getFormRefPrefix(FormRPartA.class);
+    UUID latestFormId = UUID.randomUUID();
+    FormRPartADto form = new FormRPartADto();
+
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(PART_A_COLLECTION), eq(Document.class)))
+        .thenReturn(duplicateTrainees(TRAINEE_ID));
+    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_A_COLLECTION)))
+        .thenReturn(List.of(
+            createForm(latestFormId, formRefPrefix + "001", 0, Instant.now()),
+            createForm(UUID.randomUUID(), formRefPrefix + "001", 0, Instant.now().minus(1, DAYS))
+        ));
+    when(mongoTemplate.exists(any(), eq(PART_A_HISTORY_COLLECTION))).thenReturn(false);
+    when(partaService.getAdminsFormRPartAById(latestFormId.toString()))
+        .thenReturn(Optional.of(form));
+
+    migration.migrateCollections();
+
+    verify(partaService).getAdminsFormRPartAById(latestFormId.toString());
+    verify(partaService).publishFormRUpdateEvent(form);
+    verifyNoInteractions(partbService);
+  }
+
+  @Test
+  void shouldPublishUpdateForPartB() {
+    String formRefPrefix = getFormRefPrefix(FormRPartB.class);
+    UUID latestFormId = UUID.randomUUID();
+    FormRPartBDto form = new FormRPartBDto();
+
+    when(mongoTemplate.aggregate(any(Aggregation.class), eq(PART_B_COLLECTION), eq(Document.class)))
+        .thenReturn(duplicateTrainees(TRAINEE_ID));
+    when(mongoTemplate.find(any(), eq(Document.class), eq(PART_B_COLLECTION)))
+        .thenReturn(List.of(
+            createForm(latestFormId, formRefPrefix + "001", 0, Instant.now()),
+            createForm(UUID.randomUUID(), formRefPrefix + "001", 0, Instant.now().minus(1, DAYS))
+        ));
+    when(mongoTemplate.exists(any(), eq(PART_B_HISTORY_COLLECTION))).thenReturn(false);
+    when(partbService.getAdminsFormRPartBById(latestFormId.toString()))
+        .thenReturn(Optional.of(form));
+
+    migration.migrateCollections();
+
+    verify(partbService).getAdminsFormRPartBById(latestFormId.toString());
+    verify(partbService).publishFormRUpdateEvent(form);
+    verifyNoInteractions(partaService);
+  }
+
+  /**
+   * Get a list of trainee IDs that have duplicate form references in the given collection.
+   *
+   * @param traineeIds The trainee IDs to get duplicates for.
+   * @return An aggregation result containing the trainee IDs with duplicate form references.
+   */
+  private AggregationResults<Document> duplicateTrainees(String... traineeIds) {
+    List<Document> results = java.util.Arrays.stream(traineeIds)
+        .map(traineeId -> new Document(Map.of("traineeTisId", traineeId)))
+        .toList();
+    return new AggregationResults<>(results, new Document());
+  }
+
+  /**
+   * Create a form document with the given parameters.
+   *
+   * @param id       The ID of the form.
+   * @param formRef  The form reference number.
+   * @param revision The revision of the form.
+   * @param created  The created timestamp.
+   * @return The created form.
+   */
+  private Document createForm(UUID id, String formRef, int revision, Instant created) {
+    return new Document(Map.of(
+        "_id", id,
+        "traineeTisId", TRAINEE_ID,
+        "formRef", formRef,
+        "revision", revision,
+        "created", Date.from(created)
+    ));
+  }
+
+  /**
+   * Get the collection name for the given form class.
+   *
+   * @param formClass The form class to get the collection name for.
+   * @return The collection name.
+   */
+  private String getCollectionName(Class<?> formClass) {
+    return formClass == FormRPartA.class ? PART_A_COLLECTION : PART_B_COLLECTION;
+  }
+
+  /**
+   * Get the history collection name for the given form class.
+   *
+   * @param formClass The form class to get the history collection name for.
+   * @return The history collection name.
+   */
+  private String getHistoryCollectionName(Class<?> formClass) {
+    return formClass == FormRPartA.class ? PART_A_HISTORY_COLLECTION : PART_B_HISTORY_COLLECTION;
+  }
+
+  /**
+   * Get the form reference prefix for the given form class.
+   *
+   * @param formClass The form class to get the prefix for.
+   * @return The form reference prefix.
+   */
+  private String getFormRefPrefix(Class<?> formClass) {
+    return (formClass == FormRPartA.class ? "formr_parta_" : "formr_partb_") + TRAINEE_ID + "_";
+  }
+}


### PR DESCRIPTION
During the FormR migration several forms were submitted by trainees while their existing forms were still being processed. This led to some duplicate form references being used.

The formRef does not yet have a unique index, but this will be added in a follow-up once the migrator has fixed the existing duplications.

TIS21-8867
TIS21-8868