### PR TITLE
feat: make `formRef` unique for audited forms

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.70.1"
+version = "0.71.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartARepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartARepositoryIntegrationTest.java
@@ -34,13 +34,16 @@ import com.mongodb.client.FindIterable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -58,6 +61,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import uk.nhs.hee.tis.trainee.forms.DockerImageNames;
 import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -78,6 +82,12 @@ class FormRPartARepositoryIntegrationTest {
   @Autowired
   private FormRPartARepository repository;
 
+  private static Stream<Arguments> customSingleFieldIndexes() {
+    return Stream.of(
+        Arguments.of("formRef", "formRef", new IndexFlags(false, false, true, true, false))
+    );
+  }
+
   @AfterEach
   void tearDown() {
     template.findAllAndRemove(new Query(), FormRPartA.class);
@@ -87,11 +97,10 @@ class FormRPartARepositoryIntegrationTest {
   @CsvSource(delimiter = '|', textBlock = """
       _id_                 | _id
       traineeTisId         | traineeTisId
-      formRef              | formRef
       status.current.state | status.current.state
       status.history.state | status.history.state
       """)
-  void shouldCreateSingleFieldIndexes(String indexName, String fieldName) {
+  void shouldCreateDefaultSingleFieldIndexes(String indexName, String fieldName) {
     IndexOperations indexOperations = template.indexOps(FormRPartA.class);
     List<IndexInfo> indexes = indexOperations.getIndexInfo();
 
@@ -114,6 +123,34 @@ class FormRPartARepositoryIntegrationTest {
     assertThat("Unexpected sparse index.", index.isSparse(), is(false));
     assertThat("Unexpected unique index.", index.isUnique(), is(false));
     assertThat("Unexpected wildcard index.", index.isWildcard(), is(false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("customSingleFieldIndexes")
+  void shouldCreateCustomSingleFieldIndexes(String indexName, String fieldName,
+      IndexFlags indexFlags) {
+    IndexOperations indexOperations = template.indexOps(FormRPartB.class);
+    List<IndexInfo> indexes = indexOperations.getIndexInfo();
+
+    assertThat("Unexpected index count.", indexes, hasSize(5));
+
+    IndexInfo index = indexes.stream()
+        .filter(i -> i.getName().equals(indexName))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Expected index not found."));
+
+    List<IndexField> indexFields = index.getIndexFields();
+    assertThat("Unexpected index field count.", indexFields, hasSize(1));
+
+    IndexField indexField = indexFields.get(0);
+    assertThat("Unexpected index field key.", indexField.getKey(), is(fieldName));
+    assertThat("Unexpected index field direction.", indexField.getDirection(), is(ASC));
+
+    assertThat("Unexpected hidden index.", index.isHidden(), is(indexFlags.hidden()));
+    assertThat("Unexpected hashed index.", index.isHashed(), is(indexFlags.hashed()));
+    assertThat("Unexpected sparse index.", index.isSparse(), is(indexFlags.sparse()));
+    assertThat("Unexpected unique index.", index.isUnique(), is(indexFlags.unique()));
+    assertThat("Unexpected wildcard index.", index.isWildcard(), is(indexFlags.wildcard()));
   }
 
   @Test

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartBRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/FormRPartBRepositoryIntegrationTest.java
@@ -34,13 +34,16 @@ import com.mongodb.client.FindIterable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -78,6 +81,12 @@ class FormRPartBRepositoryIntegrationTest {
   @Autowired
   private FormRPartBRepository repository;
 
+  private static Stream<Arguments> customSingleFieldIndexes() {
+    return Stream.of(
+        Arguments.of("formRef", "formRef", new IndexFlags(false, false, true, true, false))
+    );
+  }
+
   @AfterEach
   void tearDown() {
     template.findAllAndRemove(new Query(), FormRPartB.class);
@@ -87,11 +96,10 @@ class FormRPartBRepositoryIntegrationTest {
   @CsvSource(delimiter = '|', textBlock = """
       _id_                 | _id
       traineeTisId         | traineeTisId
-      formRef              | formRef
       status.current.state | status.current.state
       status.history.state | status.history.state
       """)
-  void shouldCreateSingleFieldIndexes(String indexName, String fieldName) {
+  void shouldCreateDefaultSingleFieldIndexes(String indexName, String fieldName) {
     IndexOperations indexOperations = template.indexOps(FormRPartB.class);
     List<IndexInfo> indexes = indexOperations.getIndexInfo();
 
@@ -114,6 +122,34 @@ class FormRPartBRepositoryIntegrationTest {
     assertThat("Unexpected sparse index.", index.isSparse(), is(false));
     assertThat("Unexpected unique index.", index.isUnique(), is(false));
     assertThat("Unexpected wildcard index.", index.isWildcard(), is(false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("customSingleFieldIndexes")
+  void shouldCreateCustomSingleFieldIndexes(String indexName, String fieldName,
+      IndexFlags indexFlags) {
+    IndexOperations indexOperations = template.indexOps(FormRPartB.class);
+    List<IndexInfo> indexes = indexOperations.getIndexInfo();
+
+    assertThat("Unexpected index count.", indexes, hasSize(5));
+
+    IndexInfo index = indexes.stream()
+        .filter(i -> i.getName().equals(indexName))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Expected index not found."));
+
+    List<IndexField> indexFields = index.getIndexFields();
+    assertThat("Unexpected index field count.", indexFields, hasSize(1));
+
+    IndexField indexField = indexFields.get(0);
+    assertThat("Unexpected index field key.", indexField.getKey(), is(fieldName));
+    assertThat("Unexpected index field direction.", indexField.getDirection(), is(ASC));
+
+    assertThat("Unexpected hidden index.", index.isHidden(), is(indexFlags.hidden()));
+    assertThat("Unexpected hashed index.", index.isHashed(), is(indexFlags.hashed()));
+    assertThat("Unexpected sparse index.", index.isSparse(), is(indexFlags.sparse()));
+    assertThat("Unexpected unique index.", index.isUnique(), is(indexFlags.unique()));
+    assertThat("Unexpected wildcard index.", index.isWildcard(), is(indexFlags.wildcard()));
   }
 
   @Test
@@ -203,5 +239,4 @@ class FormRPartBRepositoryIntegrationTest {
     assertThat("Expected form to be present.", result, hasSize(1));
     assertThat("Unexpected lifecycle state.", result.get(0).getLifecycleState(), is(state));
   }
-
 }

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/IndexFlags.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/IndexFlags.java
@@ -20,31 +20,23 @@
  *
  */
 
-package uk.nhs.hee.tis.trainee.forms.model;
-
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
-import org.springframework.data.mongodb.core.mapping.Document;
-import uk.nhs.hee.tis.trainee.forms.model.content.FormrPartaContent;
+package uk.nhs.hee.tis.trainee.forms.repository;
 
 /**
- * A FormR Part A form submission entity.
+ * A set of flags to describe an index.
+ *
+ * @param hidden   Whether it is a hidden index.
+ * @param hashed   Whether it is a hashed index.
+ * @param sparse   Whether it is a sparse index.
+ * @param unique   Whether it is a unique index.
+ * @param wildcard Whether it is a wildcard index.
  */
-@Document("FormrPartaSubmissionHistory")
-@Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-public class FormrPartaSubmissionHistory extends AbstractAuditedForm<FormrPartaContent> implements
-    FormSubmissionHistory {
+public record IndexFlags(
+    boolean hidden,
+    boolean hashed,
+    boolean sparse,
+    boolean unique,
+    boolean wildcard
+) {
 
-  @Override
-  public String getFormType() {
-    return "formrPartaSubmissionHistory";
-  }
-
-  @Override
-  public String getFormReferencePrefix() {
-    return null;
-  }
 }

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/LtftRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/repository/LtftRepositoryIntegrationTest.java
@@ -36,11 +36,14 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -56,6 +59,7 @@ import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import uk.nhs.hee.tis.trainee.forms.DockerImageNames;
+import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
 
@@ -77,6 +81,12 @@ class LtftRepositoryIntegrationTest {
   @MockitoBean
   private JwtDecoder jwtDecoder;
 
+  private static Stream<Arguments> customSingleFieldIndexes() {
+    return Stream.of(
+        Arguments.of("formRef", "formRef", new IndexFlags(false, false, true, true, false))
+    );
+  }
+
   @AfterEach
   void tearDown() {
     template.findAllAndRemove(new Query(), LtftForm.class);
@@ -84,20 +94,19 @@ class LtftRepositoryIntegrationTest {
 
   @ParameterizedTest
   @CsvSource(delimiter = '|', textBlock = """
-      _id_                                  | _id
-      traineeTisId                          | traineeTisId
-      formRef                               | formRef
-      content.personalDetails.forenames     | content.personalDetails.forenames
-      content.personalDetails.gdcNumber     | content.personalDetails.gdcNumber
-      content.personalDetails.gmcNumber     | content.personalDetails.gmcNumber
-      content.personalDetails.surname       | content.personalDetails.surname
-      content.programmeMembership.id        | content.programmeMembership.id
-      content.programmeMembership.dbc       | content.programmeMembership.designatedBodyCode
-      content.programmeMembership.name      | content.programmeMembership.name
-      status.current.state                  | status.current.state
-      status.history.state                  | status.history.state
+      _id_                              | _id
+      traineeTisId                      | traineeTisId
+      content.personalDetails.forenames | content.personalDetails.forenames
+      content.personalDetails.gdcNumber | content.personalDetails.gdcNumber
+      content.personalDetails.gmcNumber | content.personalDetails.gmcNumber
+      content.personalDetails.surname   | content.personalDetails.surname
+      content.programmeMembership.id    | content.programmeMembership.id
+      content.programmeMembership.dbc   | content.programmeMembership.designatedBodyCode
+      content.programmeMembership.name  | content.programmeMembership.name
+      status.current.state              | status.current.state
+      status.history.state              | status.history.state
       """)
-  void shouldCreateSingleFieldIndexes(String indexName, String fieldName) {
+  void shouldCreateDefaultSingleFieldIndexes(String indexName, String fieldName) {
     IndexOperations indexOperations = template.indexOps(LtftForm.class);
     List<IndexInfo> indexes = indexOperations.getIndexInfo();
 
@@ -120,6 +129,34 @@ class LtftRepositoryIntegrationTest {
     assertThat("Unexpected sparse index.", index.isSparse(), is(false));
     assertThat("Unexpected unique index.", index.isUnique(), is(false));
     assertThat("Unexpected wildcard index.", index.isWildcard(), is(false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("customSingleFieldIndexes")
+  void shouldCreateCustomSingleFieldIndexes(String indexName, String fieldName,
+      IndexFlags indexFlags) {
+    IndexOperations indexOperations = template.indexOps(FormRPartB.class);
+    List<IndexInfo> indexes = indexOperations.getIndexInfo();
+
+    assertThat("Unexpected index count.", indexes, hasSize(5));
+
+    IndexInfo index = indexes.stream()
+        .filter(i -> i.getName().equals(indexName))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Expected index not found."));
+
+    List<IndexField> indexFields = index.getIndexFields();
+    assertThat("Unexpected index field count.", indexFields, hasSize(1));
+
+    IndexField indexField = indexFields.get(0);
+    assertThat("Unexpected index field key.", indexField.getKey(), is(fieldName));
+    assertThat("Unexpected index field direction.", indexField.getDirection(), is(ASC));
+
+    assertThat("Unexpected hidden index.", index.isHidden(), is(indexFlags.hidden()));
+    assertThat("Unexpected hashed index.", index.isHashed(), is(indexFlags.hashed()));
+    assertThat("Unexpected sparse index.", index.isSparse(), is(indexFlags.sparse()));
+    assertThat("Unexpected unique index.", index.isUnique(), is(indexFlags.unique()));
+    assertThat("Unexpected wildcard index.", index.isWildcard(), is(indexFlags.wildcard()));
   }
 
   @Test

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractAuditedForm.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/AbstractAuditedForm.java
@@ -53,7 +53,6 @@ import uk.nhs.hee.tis.trainee.forms.model.content.FormContent;
 public abstract class AbstractAuditedForm<T extends FormContent> extends AbstractForm implements
     Persistable<UUID> {
 
-  @Indexed
   private String formRef;
   private int revision;
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/CurrentForm.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/CurrentForm.java
@@ -22,29 +22,12 @@
 
 package uk.nhs.hee.tis.trainee.forms.model;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
-import org.springframework.data.mongodb.core.mapping.Document;
-import uk.nhs.hee.tis.trainee.forms.model.content.FormrPartaContent;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
 
 /**
- * A FormR Part A form submission entity.
+ * An interface representing the current version of a form, stored in the main collection.
  */
-@Document("FormrPartaSubmissionHistory")
-@Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-public class FormrPartaSubmissionHistory extends AbstractAuditedForm<FormrPartaContent> implements
-    FormSubmissionHistory {
+@CompoundIndex(name = "formRef", def = "{'formRef': 1}", unique = true, sparse = true)
+public interface CurrentForm {
 
-  @Override
-  public String getFormType() {
-    return "formrPartaSubmissionHistory";
-  }
-
-  @Override
-  public String getFormReferencePrefix() {
-    return null;
-  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormRPartA.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormRPartA.java
@@ -31,7 +31,7 @@ import uk.nhs.hee.tis.trainee.forms.model.content.FormrPartaContent;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class FormRPartA extends AbstractFormR<FormrPartaContent> {
+public class FormRPartA extends AbstractFormR<FormrPartaContent> implements CurrentForm {
 
   @Override
   public String getFormType() {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormRPartB.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormRPartB.java
@@ -30,7 +30,7 @@ import uk.nhs.hee.tis.trainee.forms.model.content.FormrPartbContent;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class FormRPartB extends AbstractFormR<FormrPartbContent> {
+public class FormRPartB extends AbstractFormR<FormrPartbContent> implements CurrentForm {
 
   @Override
   public String getFormType() {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormSubmissionHistory.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormSubmissionHistory.java
@@ -22,9 +22,13 @@
 
 package uk.nhs.hee.tis.trainee.forms.model;
 
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+
 /**
  * An interface representing the history of form submissions.
  */
+@CompoundIndex(name = "formRef", def = "{'formRef': 1}")
+@CompoundIndex(def = "{'formRef': 1, 'revision': 1}", unique = true)
 public interface FormSubmissionHistory {
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormrPartbSubmissionHistory.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/FormrPartbSubmissionHistory.java
@@ -25,7 +25,6 @@ package uk.nhs.hee.tis.trainee.forms.model;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
 import uk.nhs.hee.tis.trainee.forms.model.content.FormrPartbContent;
 
@@ -36,7 +35,6 @@ import uk.nhs.hee.tis.trainee.forms.model.content.FormrPartbContent;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@CompoundIndex(def = "{'formRef': 1, 'revision': 1}", unique = true)
 public class FormrPartbSubmissionHistory extends AbstractAuditedForm<FormrPartbContent> implements
     FormSubmissionHistory {
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/LtftForm.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/LtftForm.java
@@ -34,7 +34,7 @@ import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class LtftForm extends AbstractAuditedForm<LtftContent> {
+public class LtftForm extends AbstractAuditedForm<LtftContent> implements CurrentForm {
 
   @Override
   public String getFormType() {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/LtftSubmissionHistory.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/LtftSubmissionHistory.java
@@ -24,7 +24,6 @@ package uk.nhs.hee.tis.trainee.forms.model;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
 
@@ -35,7 +34,6 @@ import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@CompoundIndex(def = "{'formRef': 1, 'revision': 1}", unique = true)
 public class LtftSubmissionHistory extends AbstractAuditedForm<LtftContent> implements
     FormSubmissionHistory {
 


### PR DESCRIPTION
The `formRef` field should always be unique but there is no enforcement of it.
Update the form classes to change the `formRef` index to ensure uniqueness, sparse should be used to ignore non-submitted forms which won't have a formRef.

Create a `CurrentForm` to act as live form equivalent of `FormSubmissionHistory`, each of Form R A/B and LTFT will implement this interface to inherit the indexing.

Move the `formRef` indexing from `AbstractAuditedForm` to `CurrentForm` and `FormSubmissionHistory` to allow differing index types between the actual form and the history snapshots.

As Mongock is unable to replace the existing indexes without disabling auto-index creation, the existing indexes must be manually deleted to allow deployment.

TIS21-8867
TIS21-8869