### PR TITLE
refactor: form-r ID migration for UUID

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.70.1"
+version = "0.71.2"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartAResourceIntegrationTest.java
@@ -425,7 +425,7 @@ class FormRPartAResourceIntegrationTest {
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.lifecycleState").value("SUBMITTED"));
 
-    ArgumentCaptor<PublishRequest> requestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+    ArgumentCaptor<PublishRequest> requestCaptor = ArgumentCaptor.captor();
     verify(snsClient, times(2)).publish(requestCaptor.capture());
 
     PublishRequest publishRequest1 = requestCaptor.getAllValues().get(0);

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/FormRPartBResourceIntegrationTest.java
@@ -379,7 +379,7 @@ class FormRPartBResourceIntegrationTest {
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.lifecycleState").value("SUBMITTED"));
 
-    ArgumentCaptor<PublishRequest> requestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+    ArgumentCaptor<PublishRequest> requestCaptor = ArgumentCaptor.captor();
     verify(snsClient, times(2)).publish(requestCaptor.capture());
 
     PublishRequest publishRequest1 = requestCaptor.getAllValues().get(0);

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/JobResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/JobResourceIntegrationTest.java
@@ -164,7 +164,7 @@ class JobResourceIntegrationTest {
     mockMvc.perform(post("/api/job/formr-parta/publish-refresh"))
         .andExpect(status().isOk());
 
-    ArgumentCaptor<PublishRequest> captor = ArgumentCaptor.forClass(PublishRequest.class);
+    ArgumentCaptor<PublishRequest> captor = ArgumentCaptor.captor();
     verify(snsClient).publish(captor.capture());
 
     PublishRequest request = captor.getValue();
@@ -230,7 +230,7 @@ class JobResourceIntegrationTest {
     mockMvc.perform(post("/api/job/formr-partb/publish-refresh"))
         .andExpect(status().isOk());
 
-    ArgumentCaptor<PublishRequest> captor = ArgumentCaptor.forClass(PublishRequest.class);
+    ArgumentCaptor<PublishRequest> captor = ArgumentCaptor.captor();
     verify(snsClient).publish(captor.capture());
 
     PublishRequest request = captor.getValue();

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/migration/FixDuplicateFormrRefsIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/migration/FixDuplicateFormrRefsIntegrationTest.java
@@ -219,7 +219,7 @@ class FixDuplicateFormrRefsIntegrationTest {
 
     migration.migrateCollections();
 
-    ArgumentCaptor<PublishRequest> requestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+    ArgumentCaptor<PublishRequest> requestCaptor = ArgumentCaptor.captor();
     verify(snsClient, times(2)).publish(requestCaptor.capture());
 
     List<PublishRequest> requests = requestCaptor.getAllValues();

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertObjectIdsToUuidStrings.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertObjectIdsToUuidStrings.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.forms.migration;
 
+import static org.springframework.data.mongodb.core.schema.JsonSchemaObject.Type.OBJECT_ID;
+
 import com.mongodb.client.result.DeleteResult;
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
@@ -29,20 +31,14 @@ import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
-import org.springframework.core.env.Environment;
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
-import software.amazon.awssdk.services.s3.S3Client;
-import uk.nhs.hee.tis.trainee.forms.dto.FormRPartADto;
-import uk.nhs.hee.tis.trainee.forms.dto.FormRPartBDto;
-import uk.nhs.hee.tis.trainee.forms.mapper.FormRPartAMapper;
-import uk.nhs.hee.tis.trainee.forms.mapper.FormRPartBMapper;
 import uk.nhs.hee.tis.trainee.forms.model.AbstractForm;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
-import uk.nhs.hee.tis.trainee.forms.service.FormRPartAService;
-import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
 
 /**
  * Convert existing ObjectID based form IDs to UUID strings.
@@ -52,31 +48,14 @@ import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
 public class ConvertObjectIdsToUuidStrings {
 
   private static final String ID_FIELD = "_id";
-  private static final String UUID_REGEX =
-      "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}";
 
   private final MongoTemplate mongoTemplate;
-  private final S3Client s3Client;
-  private final String bucketName;
-  private final FormRPartAService formAService;
-  private final FormRPartAMapper formAMapper;
-  private final FormRPartBService formBService;
-  private final FormRPartBMapper formBMapper;
 
   /**
    * Convert existing ObjectID based form IDs to UUID strings.
    */
-  public ConvertObjectIdsToUuidStrings(MongoTemplate mongoTemplate, S3Client s3Client,
-      Environment env,
-      FormRPartAService formAService, FormRPartAMapper formAMapper,
-      FormRPartBService formBService, FormRPartBMapper formBMapper) {
+  public ConvertObjectIdsToUuidStrings(MongoTemplate mongoTemplate) {
     this.mongoTemplate = mongoTemplate;
-    this.s3Client = s3Client;
-    this.bucketName = env.getProperty("application.file-store.bucket");
-    this.formAService = formAService;
-    this.formAMapper = formAMapper;
-    this.formBService = formBService;
-    this.formBMapper = formBMapper;
   }
 
   /**
@@ -88,86 +67,63 @@ public class ConvertObjectIdsToUuidStrings {
     migrateCollection(FormRPartB.class);
   }
 
+  /**
+   * Migrate a collection of forms from ObjectId to UUID string.
+   *
+   * @param formClass The class of the forms to migrate.
+   */
   private void migrateCollection(Class<? extends AbstractForm> formClass) {
     String collectionName = mongoTemplate.getCollectionName(formClass);
     log.info("Generating UUID strings for forms in collection {}.", collectionName);
 
+    int total = 0;
+    int batchSize;
+
     // Filter to only ObjectId forms, so that retries can skip migrated forms.
-    List<Document> allForms = mongoTemplate.findAll(Document.class, collectionName);
-    List<Document> objectIdForms = allForms.stream()
-        .filter(form -> !form.get(ID_FIELD).toString().matches(UUID_REGEX))
-        .toList();
+    Query query = Query.query(Criteria.where(ID_FIELD).type(OBJECT_ID))
+        .with(Sort.by(ID_FIELD))
+        .limit(1000);
 
-    log.info("Found {} form(s) that require UUID strings generating.", objectIdForms.size());
+    do {
+      List<Document> forms = mongoTemplate.find(query, Document.class, collectionName);
+      batchSize = forms.size();
+      total += batchSize;
+      log.debug("Found batch of {} form(s) that require UUID strings generating.", batchSize);
 
-    for (Document form : objectIdForms) {
-      String originalId = form.get(ID_FIELD).toString();
+      for (Document form : forms) {
+        migrateForm(form, collectionName);
+      }
+    } while (batchSize > 0);
 
-      // Generate a UUID string for the form.
-      String uuid = UUID.randomUUID().toString();
-      form.put(ID_FIELD, uuid);
-      log.info("UUID {} was generated for form {}.", uuid, originalId);
-
-      // Now the ID has been set generically we can convert to the correct Form object.
-      AbstractForm abstractForm = mongoTemplate.getConverter().read(formClass, form);
-
-      // Save the updated form to the database and S3.
-      saveNewForm(abstractForm);
-
-      // Delete the existing form from the database and S3.
-      deleteOriginalForms(originalId, abstractForm);
-    }
+    log.info("Generated UUID strings for {} form(s) in collection {}.", total, collectionName);
   }
 
   /**
-   * Save the new form to both the database and S3.
+   * Migrate a single form from ObjectId to UUID string.
    *
-   * @param abstractForm The form to save.
+   * @param form           The form to migrate.
+   * @param collectionName The collection the form belongs to.
    */
-  private void saveNewForm(AbstractForm abstractForm) {
-    log.info("Saving updated form {}.", abstractForm.getId());
+  private void migrateForm(Document form, String collectionName) {
+    ObjectId originalId = form.getObjectId(ID_FIELD);
 
-    // Select the correct mapper and service based on the form class.
-    if (abstractForm instanceof FormRPartA form) {
-      FormRPartADto dto = formAMapper.toDto(form);
-      formAService.save(dto);
-    } else if (abstractForm instanceof FormRPartB form) {
-      FormRPartBDto dto = formBMapper.toDto(form);
-      formBService.save(dto);
-    }
+    // Generate a UUID string for the form.
+    String uuid = UUID.randomUUID().toString();
+    Document newForm = new Document(form);
+    newForm.put(ID_FIELD, uuid);
+    log.debug("UUID {} was generated for form {}.", uuid, originalId);
 
-    log.info("Saved updated form {}.", abstractForm.getId());
-  }
+    // Insert the updated form to the database.
+    mongoTemplate.insert(newForm, collectionName);
 
-  /**
-   * Delete the original forms from the database and S3.
-   *
-   * @param originalId  The original ID of the form to delete.
-   * @param updatedForm The updated version of the form (will not be deleted).
-   */
-  private void deleteOriginalForms(String originalId, AbstractForm updatedForm) {
-    log.info("Deleting previous form {} from the database.", originalId);
-    Criteria originalFormCriteria = Criteria.where(ID_FIELD).is(originalId);
-    Query originalFormQuery = Query.query(originalFormCriteria);
-    DeleteResult result = mongoTemplate.remove(originalFormQuery, updatedForm.getClass());
+    // Remove the original form.
+    DeleteResult result = mongoTemplate.remove(Query.query(Criteria.where(ID_FIELD).is(originalId)),
+        collectionName);
 
     if (result.getDeletedCount() != 1) {
       // Log an error, but do not fail the migration so that other forms can still be migrated.
       log.error("Unexpected delete count of {} for form ID {}.", result.getDeletedCount(),
           originalId);
-    } else {
-      log.info("Deleted previous form {} from the database.", originalId);
-    }
-
-    log.info("Deleting previous form {} from S3.", originalId);
-    String objectKey = String.format("%s/forms/%s/%s.json", updatedForm.getTraineeTisId(),
-        updatedForm.getFormType(), originalId);
-    try {
-      s3Client.deleteObject(request -> request.bucket(bucketName).key(objectKey));
-      log.info("Deleted previous form {} from S3.", originalId);
-    } catch (Exception e) {
-      String message = String.format("Failed to delete form ID %s from S3.", originalId);
-      log.error(message, e);
     }
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertUuidStringsToUuidObjects.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertUuidStringsToUuidObjects.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.forms.migration;
 
+import static org.springframework.data.mongodb.core.schema.JsonSchemaObject.Type.STRING;
+
 import com.mongodb.client.result.DeleteResult;
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
@@ -29,6 +31,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -54,7 +57,7 @@ public class ConvertUuidStringsToUuidObjects {
   }
 
   /**
-   * Generate a new UUID object for each UUID string form.
+   * Convert existing UUID string based form IDs to UUID for each form.
    */
   @Execution
   public void migrateCollections() {
@@ -62,50 +65,62 @@ public class ConvertUuidStringsToUuidObjects {
     migrateCollection(FormRPartB.class);
   }
 
+  /**
+   * Migrate a collection of forms from UUID string to UUID.
+   *
+   * @param formClass The class of the forms to migrate.
+   */
   private void migrateCollection(Class<? extends AbstractForm> formClass) {
     String collectionName = mongoTemplate.getCollectionName(formClass);
     log.info("Converting UUID strings to objects for forms in collection {}.", collectionName);
 
-    // Filter to only non UUID objects, so that retries can skip migrated forms on retry.
-    List<Document> allDocuments = mongoTemplate.findAll(Document.class, collectionName);
-    List<Document> uuidStringDocuments = allDocuments.stream()
-        .filter(document -> document.get(ID_FIELD) instanceof String)
-        .toList();
-    log.info("Found {} form(s) that require UUID conversion.", uuidStringDocuments.size());
+    int total = 0;
+    int batchSize;
 
-    for (Document document : uuidStringDocuments) {
-      String originalId = document.getString(ID_FIELD);
-      log.info("Converting form {}.", originalId);
+    // Filter to only ObjectId forms, so that retries can skip migrated forms.
+    Query query = Query.query(Criteria.where(ID_FIELD).type(STRING))
+        .with(Sort.by(ID_FIELD))
+        .limit(1000);
 
-      UUID newId = UUID.fromString(originalId);
-      document.put(ID_FIELD, newId);
+    do {
+      List<Document> forms = mongoTemplate.find(query, Document.class, collectionName);
+      batchSize = forms.size();
+      total += batchSize;
+      log.debug("Found batch of {} form(s) that require UUID strings conversion.", batchSize);
 
-      log.info("Saving updated form {}.", newId);
-      mongoTemplate.insert(document, collectionName);
-      log.info("Saved updated form {}.", newId);
+      for (Document form : forms) {
+        migrateForm(form, collectionName);
+      }
+    } while (batchSize > 0);
 
-      deleteOriginalForm(originalId, collectionName);
-    }
+    log.info("Converted UUID strings for {} form(s) in collection {}.", total, collectionName);
   }
 
   /**
-   * Delete the original forms from the database.
+   * Migrate a single form from ObjectId to UUID string.
    *
-   * @param originalId     The original ID of the form to delete.
-   * @param collectionName The name of the collection to delete from.
+   * @param form           The form to migrate.
+   * @param collectionName The collection the form belongs to.
    */
-  private void deleteOriginalForm(String originalId, String collectionName) {
-    log.info("Deleting previous form {} from the database.", originalId);
-    Criteria originalFormCriteria = Criteria.where(ID_FIELD).is(originalId);
-    Query originalFormQuery = Query.query(originalFormCriteria);
-    DeleteResult result = mongoTemplate.remove(originalFormQuery, collectionName);
+  private void migrateForm(Document form, String collectionName) {
+    String originalId = form.getString(ID_FIELD);
+    log.info("Converting form {}.", originalId);
+
+    UUID newId = UUID.fromString(originalId);
+    Document newForm = new Document(form);
+    newForm.put(ID_FIELD, newId);
+
+    // Insert the updated form to the database.
+    mongoTemplate.insert(newForm, collectionName);
+
+    // Remove the original form.
+    DeleteResult result = mongoTemplate.remove(Query.query(Criteria.where(ID_FIELD).is(originalId)),
+        collectionName);
 
     if (result.getDeletedCount() != 1) {
       // Log an error, but do not fail the migration so that other forms can still be migrated.
       log.error("Unexpected delete count of {} for form ID {}.", result.getDeletedCount(),
           originalId);
-    } else {
-      log.info("Deleted previous form {} from the database.", originalId);
     }
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/config/filter/SignedDataFilterTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/config/filter/SignedDataFilterTest.java
@@ -312,8 +312,7 @@ class SignedDataFilterTest {
 
     filter.doFilterInternal(request, response, filterChain);
 
-    ArgumentCaptor<HttpServletRequest> requestCaptor = ArgumentCaptor.forClass(
-        HttpServletRequest.class);
+    ArgumentCaptor<HttpServletRequest> requestCaptor = ArgumentCaptor.captor();
     verify(filterChain).doFilter(requestCaptor.capture(), any());
 
     ServletInputStream inputStream = requestCaptor.getValue().getInputStream();

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertObjectIdsToUuidStringsTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertObjectIdsToUuidStringsTest.java
@@ -23,77 +23,49 @@ package uk.nhs.hee.tis.trainee.forms.migration;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.mongodb.client.result.DeleteResult;
-import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
-import java.util.function.Consumer;
 import org.bson.Document;
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.internal.verification.Times;
-import org.springframework.core.env.Environment;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.query.Query;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest.Builder;
-import uk.nhs.hee.tis.trainee.forms.dto.FormRPartADto;
-import uk.nhs.hee.tis.trainee.forms.dto.FormRPartBDto;
-import uk.nhs.hee.tis.trainee.forms.mapper.FormRPartAMapper;
-import uk.nhs.hee.tis.trainee.forms.mapper.FormRPartAMapperImpl;
-import uk.nhs.hee.tis.trainee.forms.mapper.FormRPartBMapper;
-import uk.nhs.hee.tis.trainee.forms.mapper.FormRPartBMapperImpl;
-import uk.nhs.hee.tis.trainee.forms.mapper.TemporalMapper;
 import uk.nhs.hee.tis.trainee.forms.model.AbstractForm;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartB;
-import uk.nhs.hee.tis.trainee.forms.service.FormRPartAService;
-import uk.nhs.hee.tis.trainee.forms.service.FormRPartBService;
 
 class ConvertObjectIdsToUuidStringsTest {
 
   private static final String ID_FIELD = "_id";
   private static final String TRAINEE_ID_FIELD = "traineeTisId";
-  private static final String BUCKET_NAME = "test-bucket";
   private static final String PART_A_COLLECTION_NAME = "part-a-collection";
   private static final String PART_B_COLLECTION_NAME = "part-b-collection";
   private ConvertObjectIdsToUuidStrings migration;
   private MongoTemplate template;
-  private S3Client s3;
-  private FormRPartAService partAService;
-  private FormRPartBService partBService;
 
   @BeforeEach
   void setUp() {
     template = mock(MongoTemplate.class);
-    s3 = mock(S3Client.class);
-    Environment env = mock(Environment.class);
-    when(env.getProperty("application.file-store.bucket")).thenReturn(BUCKET_NAME);
-
-    partAService = mock(FormRPartAService.class);
-    FormRPartAMapper partAMapper = new FormRPartAMapperImpl(
-        new TemporalMapper(ZoneId.of("Etc/UTC")));
-    partBService = mock(FormRPartBService.class);
-    FormRPartBMapper partBMapper = new FormRPartBMapperImpl(
-        new TemporalMapper(ZoneId.of("Etc/UTC")));
-    migration = new ConvertObjectIdsToUuidStrings(template, s3, env,
-        partAService, partAMapper,
-        partBService, partBMapper);
+    migration = new ConvertObjectIdsToUuidStrings(template);
 
     when(template.getCollectionName(FormRPartA.class)).thenReturn(PART_A_COLLECTION_NAME);
     when(template.getCollectionName(FormRPartB.class)).thenReturn(PART_B_COLLECTION_NAME);
@@ -113,98 +85,76 @@ class ConvertObjectIdsToUuidStringsTest {
 
   @Test
   void shouldNotFailWhenNoDocumentsToMigrate() {
-    when(template.findAll(eq(Document.class), any())).thenReturn(List.of());
+    when(template.find(any(), eq(Document.class), any())).thenReturn(List.of());
 
     assertDoesNotThrow(() -> migration.migrateCollections());
   }
 
-  @Test
-  void shouldOnlyIncludeObjectIdsInMigration() {
-    Document document1 = new Document();
-    document1.put(ID_FIELD, "not-uuid-1");
-
-    Document document2 = new Document();
-    String uuid = UUID.randomUUID().toString();
-    document2.put(ID_FIELD, uuid);
-
-    when(template.findAll(eq(Document.class), any())).thenReturn(List.of(document1, document2),
-        List.of());
-    when(template.remove(any(), any(Class.class))).thenReturn(DeleteResult.acknowledged(1));
-
+  @ParameterizedTest
+  @ValueSource(strings = {"part-a-collection", "part-b-collection"})
+  void shouldOnlyIncludeObjectIdsInMigration(String collectionName) {
     migration.migrateCollections();
 
-    verify(partAService).save(any());
-    verify(template).remove(any(), eq(FormRPartA.class));
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.captor();
+    verify(template).find(queryCaptor.capture(), eq(Document.class), eq(collectionName));
 
-    verifyNoInteractions(partBService);
-    verify(template, new Times(0)).remove(any(), eq(FormRPartB.class));
+    Query query = queryCaptor.getValue();
+    Document queryObject = query.getQueryObject();
+    List<?> idType = queryObject.getEmbedded(List.of(ID_FIELD, "$type"), List.class);
+    assertThat("Unexpected id type criteria size.", idType, hasSize(1));
+    assertThat("Unexpected id type criteria.", idType.get(0), is("objectId"));
   }
 
-  @Test
-  void shouldSaveFormRPartAsWithNewUuid() {
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+          part-a-collection | part-b-collection
+          part-b-collection | part-a-collection
+      """)
+  void shouldSaveFormRsWithNewUuid(String formCollection, String noActionCollection) {
     Document document1 = new Document();
-    document1.put(ID_FIELD, "not-uuid-1");
+    document1.put(ID_FIELD, ObjectId.get());
 
     Document document2 = new Document();
-    document2.put(ID_FIELD, "not-uuid-2");
+    document2.put(ID_FIELD, ObjectId.get());
 
-    when(template.findAll(Document.class, PART_A_COLLECTION_NAME)).thenReturn(
-        List.of(document1, document2));
-    when(template.remove(any(), eq(FormRPartA.class))).thenReturn(DeleteResult.acknowledged(1));
+    when(template.find(any(), eq(Document.class), eq(formCollection)))
+        .thenReturn(List.of(document1, document2))
+        .thenReturn(List.of());
+    when(template.remove(any(), eq(formCollection))).thenReturn(DeleteResult.acknowledged(1));
 
     migration.migrateCollections();
 
-    ArgumentCaptor<FormRPartADto> dtoCaptor = ArgumentCaptor.forClass(FormRPartADto.class);
-    verify(partAService, new Times(2)).save(dtoCaptor.capture());
-    verifyNoInteractions(partBService);
+    ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.captor();
+    verify(template, times(2)).insert(documentCaptor.capture(), eq(formCollection));
 
-    List<FormRPartADto> dtos = dtoCaptor.getAllValues();
-    assertThat("Unexpected DTO save count.", dtos.size(), is(2));
+    verify(template, never()).insert(any(), eq(noActionCollection));
+    verify(template, never()).remove(any(), eq(noActionCollection));
 
-    for (FormRPartADto dto : dtos) {
-      assertDoesNotThrow(() -> UUID.fromString(dto.getId()));
+    List<Document> documents = documentCaptor.getAllValues();
+    assertThat("Unexpected form save count.", documents.size(), is(2));
+
+    for (Document document : documents) {
+      assertDoesNotThrow(() -> UUID.fromString(document.getString(ID_FIELD)));
     }
   }
 
-  @Test
-  void shouldSaveFormRPartBsWithNewUuid() {
+  @ParameterizedTest
+  @ValueSource(strings = {"part-a-collection", "part-b-collection"})
+  void shouldDeleteOriginalForms(String collectionName) {
+    ObjectId id1 = ObjectId.get();
     Document document1 = new Document();
-    document1.put(ID_FIELD, "not-uuid-1");
+    document1.put(ID_FIELD, id1);
 
+    ObjectId id2 = ObjectId.get();
     Document document2 = new Document();
-    document2.put(ID_FIELD, "not-uuid-2");
+    document2.put(ID_FIELD, id2);
 
-    when(template.findAll(Document.class, PART_B_COLLECTION_NAME)).thenReturn(
-        List.of(document1, document2));
-    when(template.remove(any(), eq(FormRPartB.class))).thenReturn(DeleteResult.acknowledged(1));
+    when(template.find(any(), eq(Document.class), eq(collectionName)))
+        .thenReturn(List.of(document1, document2))
+        .thenReturn(List.of());
 
-    migration.migrateCollections();
-
-    ArgumentCaptor<FormRPartBDto> dtoCaptor = ArgumentCaptor.forClass(FormRPartBDto.class);
-    verify(partBService, new Times(2)).save(dtoCaptor.capture());
-    verifyNoInteractions(partAService);
-
-    List<FormRPartBDto> dtos = dtoCaptor.getAllValues();
-    assertThat("Unexpected DTO save count.", dtos.size(), is(2));
-
-    for (FormRPartBDto dto : dtos) {
-      assertDoesNotThrow(() -> UUID.fromString(dto.getId()));
-    }
-  }
-
-  @Test
-  void shouldDeleteOriginalFormRPartAsFromDatabase() {
-    Document document1 = new Document();
-    document1.put(ID_FIELD, "not-uuid-1");
-
-    Document document2 = new Document();
-    document2.put(ID_FIELD, "not-uuid-2");
-
-    when(template.findAll(Document.class, PART_A_COLLECTION_NAME)).thenReturn(
-        List.of(document1, document2));
-
-    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
-    when(template.remove(queryCaptor.capture(), any(Class.class))).thenReturn(
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.captor();
+    when(template.remove(queryCaptor.capture(), eq(collectionName))).thenReturn(
         DeleteResult.acknowledged(1));
 
     migration.migrateCollections();
@@ -213,167 +163,37 @@ class ConvertObjectIdsToUuidStringsTest {
     assertThat("Unexpected query count.", queries.size(), is(2));
 
     Document queryObject = queries.get(0).getQueryObject();
-    String id = queryObject.getString("_id");
-    assertThat("Unexpected ID requirement.", id, is("not-uuid-1"));
+    ObjectId id = queryObject.getObjectId("_id");
+    assertThat("Unexpected ID requirement.", id, is(id1));
 
     queryObject = queries.get(1).getQueryObject();
-    id = queryObject.getString("_id");
-    assertThat("Unexpected ID requirement.", id, is("not-uuid-2"));
-  }
-
-  @Test
-  void shouldDeleteOriginalFormRPartBsFromDatabase() {
-    Document document1 = new Document();
-    document1.put(ID_FIELD, "not-uuid-1");
-
-    Document document2 = new Document();
-    document2.put(ID_FIELD, "not-uuid-2");
-
-    when(template.findAll(eq(Document.class), eq(PART_B_COLLECTION_NAME))).thenReturn(
-        List.of(document1, document2));
-
-    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
-    when(template.remove(queryCaptor.capture(), any(Class.class))).thenReturn(
-        DeleteResult.acknowledged(1));
-
-    migration.migrateCollections();
-
-    List<Query> queries = queryCaptor.getAllValues();
-    assertThat("Unexpected query count.", queries.size(), is(2));
-
-    Document queryObject = queries.get(0).getQueryObject();
-    String id = queryObject.getString("_id");
-    assertThat("Unexpected ID requirement.", id, is("not-uuid-1"));
-
-    queryObject = queries.get(1).getQueryObject();
-    id = queryObject.getString("_id");
-    assertThat("Unexpected ID requirement.", id, is("not-uuid-2"));
+    id = queryObject.getObjectId("_id");
+    assertThat("Unexpected ID requirement.", id, is(id2));
   }
 
   @ParameterizedTest
   @ValueSource(ints = {0, 2})
-  void shouldNotFailMigrationWhenDeleteFromDatabaseFails(int deletedCount) {
+  void shouldNotFailMigrationWhenDeleteFails(int deletedCount) {
     Document document1 = new Document();
-    document1.put(ID_FIELD, "not-uuid-1");
+    document1.put(ID_FIELD, ObjectId.get());
 
     Document document2 = new Document();
-    document2.put(ID_FIELD, "not-uuid-2");
+    document2.put(ID_FIELD, ObjectId.get());
 
-    when(template.findAll(eq(Document.class), any())).thenReturn(List.of(document1),
-        List.of(document2));
-    when(template.remove(any(), any(Class.class))).thenReturn(
+    when(template.find(any(), eq(Document.class), any()))
+        .thenReturn(List.of(document1))
+        .thenReturn(List.of(document2))
+        .thenReturn(List.of());
+    when(template.remove(any(), anyString())).thenReturn(
         DeleteResult.acknowledged(deletedCount));
 
     assertDoesNotThrow(() -> migration.migrateCollections());
-    verify(template, new Times(2)).remove(any(), any(Class.class));
-  }
-
-  @Test
-  void shouldDeleteOriginalFormRPartAsFromS3() {
-    Document document1 = new Document();
-    document1.put(ID_FIELD, "not-uuid-1");
-    document1.put(TRAINEE_ID_FIELD, "trainee1");
-
-    Document document2 = new Document();
-    document2.put(ID_FIELD, "not-uuid-2");
-    document2.put(TRAINEE_ID_FIELD, "trainee2");
-
-    when(template.findAll(Document.class, PART_A_COLLECTION_NAME)).thenReturn(
-        List.of(document1, document2));
-
-    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
-    when(template.remove(queryCaptor.capture(), any(Class.class))).thenReturn(
-        DeleteResult.acknowledged(1));
-
-    migration.migrateCollections();
-
-    String keyTemplate = "%s/forms/%s/%s.json";
-
-    ArgumentCaptor<Consumer<Builder>> consumerCaptor = ArgumentCaptor.captor();
-    verify(s3, times(2)).deleteObject(consumerCaptor.capture());
-
-    List<Consumer<Builder>> consumers = consumerCaptor.getAllValues();
-
-    DeleteObjectRequest request1 = DeleteObjectRequest.builder()
-        .applyMutation(consumers.get(0))
-        .build();
-    assertThat("Unexpected bucket.", request1.bucket(), is(BUCKET_NAME));
-    assertThat("Unexpected key.", request1.key(),
-        is(String.format(keyTemplate, "trainee1", "formr-a", "not-uuid-1")));
-
-    DeleteObjectRequest request2 = DeleteObjectRequest.builder()
-        .applyMutation(consumers.get(1))
-        .build();
-    assertThat("Unexpected bucket.", request2.bucket(), is(BUCKET_NAME));
-    assertThat("Unexpected key.", request2.key(),
-        is(String.format(keyTemplate, "trainee2", "formr-a", "not-uuid-2")));
-  }
-
-  @Test
-  void shouldDeleteOriginalFormRPartBsFromS3() {
-    Document document1 = new Document();
-    document1.put(ID_FIELD, "not-uuid-1");
-    document1.put(TRAINEE_ID_FIELD, "trainee1");
-
-    Document document2 = new Document();
-    document2.put(ID_FIELD, "not-uuid-2");
-    document2.put(TRAINEE_ID_FIELD, "trainee2");
-
-    when(template.findAll(eq(Document.class), eq(PART_B_COLLECTION_NAME))).thenReturn(
-        List.of(document1, document2));
-
-    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
-    when(template.remove(queryCaptor.capture(), any(Class.class))).thenReturn(
-        DeleteResult.acknowledged(1));
-
-    migration.migrateCollections();
-
-    String keyTemplate = "%s/forms/%s/%s.json";
-
-    ArgumentCaptor<Consumer<Builder>> consumerCaptor = ArgumentCaptor.captor();
-    verify(s3, times(2)).deleteObject(consumerCaptor.capture());
-
-    List<Consumer<Builder>> consumers = consumerCaptor.getAllValues();
-
-    DeleteObjectRequest request1 = DeleteObjectRequest.builder()
-        .applyMutation(consumers.get(0))
-        .build();
-    assertThat("Unexpected bucket.", request1.bucket(), is(BUCKET_NAME));
-    assertThat("Unexpected key.", request1.key(),
-        is(String.format(keyTemplate, "trainee1", "formr-b", "not-uuid-1")));
-
-    DeleteObjectRequest request2 = DeleteObjectRequest.builder()
-        .applyMutation(consumers.get(1))
-        .build();
-    assertThat("Unexpected bucket.", request2.bucket(), is(BUCKET_NAME));
-    assertThat("Unexpected key.", request2.key(),
-        is(String.format(keyTemplate, "trainee2", "formr-b", "not-uuid-2")));
-  }
-
-  @Test
-  void shouldNotFailMigrationWhenDeleteFromS3Fails() {
-    Document document1 = new Document();
-    document1.put(ID_FIELD, "not-uuid-1");
-
-    Document document2 = new Document();
-    document2.put(ID_FIELD, "not-uuid-2");
-
-    when(template.findAll(eq(Document.class), any())).thenReturn(List.of(document1),
-        List.of(document2));
-    when(template.remove(any(), any(Class.class))).thenReturn(DeleteResult.acknowledged(1));
-
-    doThrow(RuntimeException.class).when(s3).deleteObject(any(Consumer.class));
-
-    assertDoesNotThrow(() -> migration.migrateCollections());
-    verify(s3, new Times(2)).deleteObject(any(Consumer.class));
+    verify(template, times(2)).remove(any(), anyString());
   }
 
   @Test
   void shouldNotAttemptRollback() {
     migration.rollback();
     verifyNoInteractions(template);
-    verifyNoInteractions(partAService);
-    verifyNoInteractions(partBService);
-    verifyNoInteractions(s3);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertUuidStringsToUuidObjectsTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/ConvertUuidStringsToUuidObjectsTest.java
@@ -23,10 +23,14 @@ package uk.nhs.hee.tis.trainee.forms.migration;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -38,9 +42,9 @@ import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.internal.verification.Times;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 import uk.nhs.hee.tis.trainee.forms.model.FormRPartA;
@@ -70,46 +74,50 @@ class ConvertUuidStringsToUuidObjectsTest {
 
   @Test
   void shouldNotFailWhenNoDocumentsToMigrate() {
-    when(template.findAll(eq(Document.class), any())).thenReturn(List.of());
+    when(template.find(any(), eq(Document.class), any())).thenReturn(List.of());
 
     assertDoesNotThrow(() -> migration.migrateCollections());
   }
 
-  @Test
-  void shouldOnlyIncludeUuidStringsInMigration() {
-    Document document1 = new Document();
-    document1.put(ID_FIELD, ID_STRING_1);
-
-    Document document2 = new Document();
-    document2.put(ID_FIELD, ID_UUID_2);
-
-    when(template.findAll(eq(Document.class), any())).thenReturn(List.of(document1, document2),
-        List.of());
-    when(template.remove(any(), any(String.class))).thenReturn(DeleteResult.acknowledged(1));
-
+  @ParameterizedTest
+  @ValueSource(strings = {"part-a-collection", "part-b-collection"})
+  void shouldOnlyIncludeUuidStringsInMigration(String collectionName) {
     migration.migrateCollections();
 
-    verify(template, new Times(1)).insert(any(Document.class), eq(PART_A_COLLECTION_NAME));
-    verify(template, new Times(1)).remove(any(), eq(PART_A_COLLECTION_NAME));
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.captor();
+    verify(template).find(queryCaptor.capture(), eq(Document.class), eq(collectionName));
+
+    Query query = queryCaptor.getValue();
+    Document queryObject = query.getQueryObject();
+    List<?> idType = queryObject.getEmbedded(List.of(ID_FIELD, "$type"), List.class);
+    assertThat("Unexpected id type criteria size.", idType, hasSize(1));
+    assertThat("Unexpected id type criteria.", idType.get(0), is("string"));
   }
 
-  @Test
-  void shouldSaveFormRPartAsWithNewUuid() {
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+          part-a-collection | part-b-collection
+          part-b-collection | part-a-collection
+      """)
+  void shouldSaveFormsWithNewUuid(String formCollection, String noActionCollection) {
     Document document1 = new Document();
     document1.put(ID_FIELD, ID_STRING_1);
 
     Document document2 = new Document();
     document2.put(ID_FIELD, ID_STRING_2);
 
-    when(template.findAll(Document.class, PART_A_COLLECTION_NAME)).thenReturn(
-        List.of(document1, document2));
-    when(template.remove(any(), eq(PART_A_COLLECTION_NAME))).thenReturn(
-        DeleteResult.acknowledged(1));
+    when(template.find(any(), eq(Document.class), eq(formCollection)))
+        .thenReturn(List.of(document1, document2))
+        .thenReturn(List.of());
+    when(template.remove(any(), eq(formCollection))).thenReturn(DeleteResult.acknowledged(1));
 
     migration.migrateCollections();
 
-    ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.forClass(Document.class);
-    verify(template, new Times(2)).insert(documentCaptor.capture(), eq(PART_A_COLLECTION_NAME));
+    ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.captor();
+    verify(template, times(2)).insert(documentCaptor.capture(), eq(formCollection));
+
+    verify(template, never()).insert(any(), eq(noActionCollection));
+    verify(template, never()).remove(any(), eq(noActionCollection));
 
     List<Document> documents = documentCaptor.getAllValues();
     assertThat("Unexpected document save count.", documents.size(), is(2));
@@ -117,72 +125,21 @@ class ConvertUuidStringsToUuidObjectsTest {
     assertThat("Unexpected document ID.", documents.get(1).get(ID_FIELD), is(ID_UUID_2));
   }
 
-  @Test
-  void shouldSaveFormRPartBsWithNewUuid() {
+  @ParameterizedTest
+  @ValueSource(strings = {"part-a-collection", "part-b-collection"})
+  void shouldDeleteOriginalForms(String collectionName) {
     Document document1 = new Document();
     document1.put(ID_FIELD, ID_STRING_1);
 
     Document document2 = new Document();
     document2.put(ID_FIELD, ID_STRING_2);
 
-    when(template.findAll(Document.class, PART_B_COLLECTION_NAME)).thenReturn(
-        List.of(document1, document2));
-    when(template.remove(any(), eq(PART_B_COLLECTION_NAME))).thenReturn(
-        DeleteResult.acknowledged(1));
+    when(template.find(any(), eq(Document.class), eq(collectionName)))
+        .thenReturn(List.of(document1, document2))
+        .thenReturn(List.of());
 
-    migration.migrateCollections();
-
-    ArgumentCaptor<Document> documentCaptor = ArgumentCaptor.forClass(Document.class);
-    verify(template, new Times(2)).insert(documentCaptor.capture(), eq(PART_B_COLLECTION_NAME));
-
-    List<Document> documents = documentCaptor.getAllValues();
-    assertThat("Unexpected document save count.", documents.size(), is(2));
-    assertThat("Unexpected document ID.", documents.get(0).get(ID_FIELD), is(ID_UUID_1));
-    assertThat("Unexpected document ID.", documents.get(1).get(ID_FIELD), is(ID_UUID_2));
-  }
-
-  @Test
-  void shouldDeleteOriginalFormRPartAsFromDatabase() {
-    Document document1 = new Document();
-    document1.put(ID_FIELD, ID_STRING_1);
-
-    Document document2 = new Document();
-    document2.put(ID_FIELD, ID_STRING_2);
-
-    when(template.findAll(Document.class, PART_A_COLLECTION_NAME)).thenReturn(
-        List.of(document1, document2));
-
-    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
-    when(template.remove(queryCaptor.capture(), any(String.class))).thenReturn(
-        DeleteResult.acknowledged(1));
-
-    migration.migrateCollections();
-
-    List<Query> queries = queryCaptor.getAllValues();
-    assertThat("Unexpected query count.", queries.size(), is(2));
-
-    Document queryObject = queries.get(0).getQueryObject();
-    String id = queryObject.getString("_id");
-    assertThat("Unexpected ID requirement.", id, is(ID_STRING_1));
-
-    queryObject = queries.get(1).getQueryObject();
-    id = queryObject.getString("_id");
-    assertThat("Unexpected ID requirement.", id, is(ID_STRING_2));
-  }
-
-  @Test
-  void shouldDeleteOriginalFormRPartBsFromDatabase() {
-    Document document1 = new Document();
-    document1.put(ID_FIELD, ID_STRING_1);
-
-    Document document2 = new Document();
-    document2.put(ID_FIELD, ID_STRING_2);
-
-    when(template.findAll(Document.class, PART_B_COLLECTION_NAME)).thenReturn(
-        List.of(document1, document2));
-
-    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
-    when(template.remove(queryCaptor.capture(), any(String.class))).thenReturn(
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.captor();
+    when(template.remove(queryCaptor.capture(), anyString())).thenReturn(
         DeleteResult.acknowledged(1));
 
     migration.migrateCollections();
@@ -201,20 +158,22 @@ class ConvertUuidStringsToUuidObjectsTest {
 
   @ParameterizedTest
   @ValueSource(ints = {0, 2})
-  void shouldNotFailMigrationWhenDeleteFromDatabaseFails(int deletedCount) {
+  void shouldNotFailMigrationWhenDeleteFails(int deletedCount) {
     Document document1 = new Document();
     document1.put(ID_FIELD, ID_STRING_1);
 
     Document document2 = new Document();
     document2.put(ID_FIELD, ID_STRING_2);
 
-    when(template.findAll(eq(Document.class), any())).thenReturn(List.of(document1),
-        List.of(document2));
-    when(template.remove(any(), any(String.class))).thenReturn(
+    when(template.find(any(), eq(Document.class), any()))
+        .thenReturn(List.of(document1))
+        .thenReturn(List.of(document2))
+        .thenReturn(List.of());
+    when(template.remove(any(), anyString())).thenReturn(
         DeleteResult.acknowledged(deletedCount));
 
     assertDoesNotThrow(() -> migration.migrateCollections());
-    verify(template, new Times(2)).remove(any(), any(String.class));
+    verify(template, times(2)).remove(any(), anyString());
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/DeletePilotFormsTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/DeletePilotFormsTest.java
@@ -60,7 +60,7 @@ class DeletePilotFormsTest {
   void shouldMigrateForms(Class<AbstractForm> formClass) {
     migration.migrate();
 
-    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.captor();
     verify(template).remove(queryCaptor.capture(), eq(formClass));
 
     Query query = queryCaptor.getValue();

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/DeleteTestFormTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/DeleteTestFormTest.java
@@ -54,7 +54,7 @@ class DeleteTestFormTest {
   void setUp() {
     template = mock(MongoTemplate.class);
     s3 = mock(S3Client.class);
-    queryCaptor = ArgumentCaptor.forClass(Query.class);
+    queryCaptor = ArgumentCaptor.captor();
     Environment env = mock(Environment.class);
     when(env.getProperty("application.file-store.bucket")).thenReturn(BUCKET_NAME);
     migration = new DeleteTestForm(template, s3, env);

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/FixLtftSubmissionDatesTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/FixLtftSubmissionDatesTest.java
@@ -74,7 +74,7 @@ class FixLtftSubmissionDatesTest {
 
     migration.migrate();
 
-    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.captor();
     verify(template).find(queryCaptor.capture(), eq(LtftForm.class));
 
     Query query = queryCaptor.getValue();
@@ -284,7 +284,7 @@ class FixLtftSubmissionDatesTest {
 
     migration.migrate();
 
-    ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+    ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.captor();
     verify(template).updateFirst(any(Query.class), updateCaptor.capture(), eq(LtftForm.class));
 
     Update update = updateCaptor.getValue();
@@ -348,7 +348,7 @@ class FixLtftSubmissionDatesTest {
 
     migration.migrate();
 
-    ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+    ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.captor();
     verify(template).updateFirst(any(Query.class), updateCaptor.capture(), eq(LtftForm.class));
 
     Update update = updateCaptor.getValue();
@@ -397,7 +397,7 @@ class FixLtftSubmissionDatesTest {
 
     migration.migrate();
 
-    ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+    ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.captor();
     verify(template).updateFirst(any(Query.class), updateCaptor.capture(), eq(LtftForm.class));
 
     Update update = updateCaptor.getValue();
@@ -572,7 +572,7 @@ class FixLtftSubmissionDatesTest {
 
     migration.migrate();
 
-    ArgumentCaptor<String> topicCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> topicCaptor = ArgumentCaptor.captor();
     verify(ltftService).publishUpdateNotification(
         any(),
         eq(null),

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/RecalculateTotalLeaveTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/RecalculateTotalLeaveTest.java
@@ -70,7 +70,7 @@ class RecalculateTotalLeaveTest {
   void shouldOnlyRecalculateDocumentsWithZeroTotalLeaveAndUnCalculatedLeave() {
     migration.migrate();
 
-    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.captor();
     verify(template).find(queryCaptor.capture(), eq(FormRPartB.class));
 
     Query query = queryCaptor.getValue();
@@ -110,7 +110,7 @@ class RecalculateTotalLeaveTest {
 
     migration.migrate();
 
-    ArgumentCaptor<FormRPartBDto> formCaptor = ArgumentCaptor.forClass(FormRPartBDto.class);
+    ArgumentCaptor<FormRPartBDto> formCaptor = ArgumentCaptor.captor();
     verify(service).save(formCaptor.capture());
 
     FormRPartBDto updatedForm = formCaptor.getValue();

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/SortWorkPlacementsTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/migration/SortWorkPlacementsTest.java
@@ -124,7 +124,7 @@ class SortWorkPlacementsTest {
     migration.migrate();
 
     //then
-    ArgumentCaptor<FormRPartBDto> formCaptor = ArgumentCaptor.forClass(FormRPartBDto.class);
+    ArgumentCaptor<FormRPartBDto> formCaptor = ArgumentCaptor.captor();
     verify(service).save(formCaptor.capture());
 
     FormRPartBDto updatedForm = formCaptor.getValue();
@@ -154,7 +154,7 @@ class SortWorkPlacementsTest {
     migration.migrate();
 
     //then
-    ArgumentCaptor<FormRPartBDto> formCaptor = ArgumentCaptor.forClass(FormRPartBDto.class);
+    ArgumentCaptor<FormRPartBDto> formCaptor = ArgumentCaptor.captor();
     verify(service).save(formCaptor.capture());
 
     FormRPartBDto updatedForm = formCaptor.getValue();

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartAServiceTest.java
@@ -616,7 +616,7 @@ class FormRPartAServiceTest {
 
     service.save(dto);
 
-    ArgumentCaptor<FormRPartADto> dtoCaptor = ArgumentCaptor.forClass(FormRPartADto.class);
+    ArgumentCaptor<FormRPartADto> dtoCaptor = ArgumentCaptor.captor();
     verify(eventBroadcastService).publishFormRPartAEvent(
         dtoCaptor.capture(), eq(Map.of("formType", "formr-a")), eq(FORM_R_PART_A_UPDATED_TOPIC));
 
@@ -724,7 +724,7 @@ class FormRPartAServiceTest {
 
     service.unsubmitFormRPartAById(DEFAULT_ID);
 
-    ArgumentCaptor<FormRPartADto> dtoCaptor = ArgumentCaptor.forClass(FormRPartADto.class);
+    ArgumentCaptor<FormRPartADto> dtoCaptor = ArgumentCaptor.captor();
     verify(eventBroadcastService).publishFormRPartAEvent(
         dtoCaptor.capture(), eq(Map.of("formType", "formr-a")), eq(FORM_R_PART_A_UPDATED_TOPIC));
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/FormRPartBServiceTest.java
@@ -663,7 +663,7 @@ class FormRPartBServiceTest {
 
     service.partialDeleteFormRPartBById(DEFAULT_ID);
 
-    ArgumentCaptor<FormRPartBDto> dtoCaptor = ArgumentCaptor.forClass(FormRPartBDto.class);
+    ArgumentCaptor<FormRPartBDto> dtoCaptor = ArgumentCaptor.captor();
     verify(eventBroadcastService).publishFormRPartBEvent(
         dtoCaptor.capture(), eq(Map.of("formType", "formr-b")), eq(FORM_R_PART_B_UPDATED_TOPIC));
 
@@ -717,7 +717,7 @@ class FormRPartBServiceTest {
 
     service.save(dto);
 
-    ArgumentCaptor<FormRPartBDto> dtoCaptor = ArgumentCaptor.forClass(FormRPartBDto.class);
+    ArgumentCaptor<FormRPartBDto> dtoCaptor = ArgumentCaptor.captor();
     verify(eventBroadcastService).publishFormRPartBEvent(
         dtoCaptor.capture(), eq(Map.of("formType", "formr-b")), eq(FORM_R_PART_B_UPDATED_TOPIC));
 
@@ -816,7 +816,7 @@ class FormRPartBServiceTest {
 
     service.unsubmitFormRPartBById(DEFAULT_ID);
 
-    ArgumentCaptor<FormRPartBDto> dtoCaptor = ArgumentCaptor.forClass(FormRPartBDto.class);
+    ArgumentCaptor<FormRPartBDto> dtoCaptor = ArgumentCaptor.captor();
     verify(eventBroadcastService).publishFormRPartBEvent(
         dtoCaptor.capture(), eq(Map.of("formType", "formr-b")), eq(FORM_R_PART_B_UPDATED_TOPIC));
 


### PR DESCRIPTION
There are two migrations ran on FormR to migrate from ObjectId to UUID for the ID field.
Since the Form-R refactoring these required some refactoring to bring them back in line with up-to-date expectations.

 1. Remove the S3 updates as S3 form mirroring has been removed.
 2. Switch service usage to raw Document to avoid the migration applying a `modifiedBy` to each form, which requires an unavailable Identity/claims.

NO-TICKET