### PR TITLE
Feat/ltft admin review stage list endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,80 @@
+# AGENTS.md
+
+## Project Overview
+
+Spring Boot microservice managing NHS trainee forms (Form R Part A/B, LTFT). Uses MongoDB for persistence, AWS S3 for file storage, SNS/SQS for event-driven communication, and Mongock for database migrations.
+
+**Base package:** `uk.nhs.hee.tis.trainee.forms`  
+**Context path:** `/forms` (port 8207)
+
+## Architecture
+
+Layered structure within a single package root:
+
+- `api/` — REST controllers (`*Resource.java`), annotated with `@XRayEnabled` for AWS X-Ray tracing
+- `service/` — Business logic; form services extend `AbstractAuditedFormService` for lifecycle/revision tracking
+- `repository/` — Spring Data MongoDB repositories
+- `model/` — MongoDB `@Document` entities; forms extend `AbstractAuditedForm` (status history, revisions, timestamps)
+- `dto/` — Data transfer objects for API layer
+- `mapper/` — MapStruct interfaces (use `componentModel = SPRING`, `injectionStrategy = CONSTRUCTOR`)
+- `event/` — `@SqsListener` classes consuming AWS SQS messages (e.g., `ProfileMoveListener`, `FormEventListener`)
+- `migration/` — Mongock `@ChangeUnit` classes for schema migrations
+- `config/` — Spring configuration classes
+- `api/validation/` — Custom validators per form type (e.g., `FormRPartAValidator`)
+
+### Key Patterns
+
+- **Admin vs Trainee controllers**: `Admin*Resource` endpoints for admin operations; regular `*Resource` for trainee-facing APIs
+- **Event broadcasting**: Services publish to SNS topics (formr-updated, ltft-status-updated, etc.); listeners consume from SQS queues
+- **Audited forms**: All form entities track status history and revisions via `AbstractAuditedForm`; mappers translate between `status.current.state` and flat DTO `lifecycleState`
+- **Submission history**: Separate `*SubmissionHistory` documents and repositories for lightweight queries
+
+## Build & Test Commands
+
+```shell
+# Unit tests (with JaCoCo coverage)
+./gradlew test
+
+# Integration tests (requires Docker for Testcontainers)
+./gradlew integrationTest
+
+# Full check (unit + integration + checkstyle)
+./gradlew check
+
+# Run locally
+./gradlew bootRun
+```
+
+Integration tests use Testcontainers (`@Testcontainers`) with `@ServiceConnection` for MongoDB and LocalStack. The `spring.profiles.active=test` profile is set automatically. Mongock migrations are disabled in tests (`mongock.enabled: false`).
+
+## Conventions
+
+- **Java 17** with Adoptium toolchain
+- **Lombok** for boilerplate (getters, setters, builders, `@Slf4j`)
+- **Google Checkstyle** enforced via Gradle checkstyle plugin
+- **MapStruct mappers** are interfaces extending `FormMapper<Entity, Dto>` and optionally `SubmissionHistoryMapper`
+- **MIT License header** required in all source files
+- **Lifecycle states** defined in `dto/enumeration/LifecycleState`
+- Feature flags configured via `features.*` properties in `application.yml`
+
+## Key Configuration
+
+| Property path | Purpose |
+|---|---|
+| `application.aws.sns.*` | SNS topic ARNs for event publishing |
+| `application.aws.sqs.*` | SQS queue URLs for event consumption |
+| `application.file-store.bucket` | S3 bucket for form document storage |
+| `application.signature.secret-key` | HMAC key for signed data validation |
+| `application.review-workflows` | Per-DBC multi-stage review configuration |
+
+## Adding a New Form Type
+
+1. Create entity in `model/` extending `AbstractAuditedForm`
+2. Create DTO in `dto/`
+3. Create MapStruct mapper in `mapper/` extending `FormMapper`
+4. Create repository in `repository/`
+5. Create service in `service/` extending `AbstractAuditedFormService`
+6. Create controller in `api/` with `@XRayEnabled`
+7. Add validator in `api/validation/` if needed
+8. Add SNS topic config in `application.yml` if publishing events
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.71.2"
+version = "0.72.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
@@ -870,6 +870,67 @@ class AdminLtftResourceIntegrationTest {
         .andExpect(jsonPath("$.content[0].personalDetails.id", is("trainee id to find")));
   }
 
+  @Test
+  void shouldCountOnlyLtftsWithMatchingReviewStageFilter() throws Exception {
+    template.insert(createSubmittedFormWithReviewStage(DBC_1, 0, "Stage One"));
+    template.insert(createSubmittedFormWithReviewStage(DBC_1, 1, "Stage Two"));
+    template.insert(createSubmittedFormWithReviewStage(DBC_1, 0, "Stage One"));
+    template.insert(createSubmittedFormWithReviewStage(DBC_1, 2, "Stage Three"));
+
+    mockMvc.perform(get("/api/admin/ltft/count")
+            .with(TestJwtUtil.createAdminToken(List.of(DBC_1), REQUIRED_ROLES))
+            .param("reviewStage", "Stage One"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.TEXT_PLAIN))
+        .andExpect(content().string("2"));
+  }
+
+  @Test
+  void shouldCountLtftsWithMultipleReviewStageFilters() throws Exception {
+    template.insert(createSubmittedFormWithReviewStage(DBC_1, 0, "Stage One"));
+    template.insert(createSubmittedFormWithReviewStage(DBC_1, 1, "Stage Two"));
+    template.insert(createSubmittedFormWithReviewStage(DBC_1, 2, "Stage Three"));
+
+    mockMvc.perform(get("/api/admin/ltft/count")
+            .with(TestJwtUtil.createAdminToken(List.of(DBC_1), REQUIRED_ROLES))
+            .param("reviewStage", "Stage One,Stage Three"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.TEXT_PLAIN))
+        .andExpect(content().string("2"));
+  }
+
+  @Test
+  void shouldReturnSummariesWithMatchingReviewStageFilter() throws Exception {
+    LtftForm stageOneForm = createSubmittedFormWithReviewStage(DBC_1, 0, "Stage One");
+    template.insert(stageOneForm);
+    template.insert(createSubmittedFormWithReviewStage(DBC_1, 1, "Stage Two"));
+    template.insert(createSubmittedFormWithReviewStage(DBC_1, 2, "Stage Three"));
+
+    mockMvc.perform(get("/api/admin/ltft")
+            .with(TestJwtUtil.createAdminToken(List.of(DBC_1), REQUIRED_ROLES))
+            .param("reviewStage", "Stage One"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.content[0].id", is(stageOneForm.getId().toString())));
+  }
+
+  @Test
+  void shouldReturnSummariesWithMultipleReviewStageFilters() throws Exception {
+    template.insert(createSubmittedFormWithReviewStage(DBC_1, 0, "Stage One"));
+    template.insert(createSubmittedFormWithReviewStage(DBC_1, 1, "Stage Two"));
+    template.insert(createSubmittedFormWithReviewStage(DBC_1, 2, "Stage Three"));
+
+    mockMvc.perform(get("/api/admin/ltft")
+            .with(TestJwtUtil.createAdminToken(List.of(DBC_1), REQUIRED_ROLES))
+            .param("reviewStage", "Stage One,Stage Two"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content", hasSize(2)));
+  }
+
   @ParameterizedTest
   @ValueSource(ints = {0, 1, 2})
   void shouldPageLtftSummariesWhenTooManyResults(int pageNumber) throws Exception {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.trainee.forms.api;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
@@ -121,6 +122,7 @@ class AdminLtftResourceIntegrationTest {
   // DBCs matching review-workflow config in application-test.yml (test-specific)
   private static final String DBC_THREE_STAGES = "TEST-DBC-3-STAGES";
   private static final String DBC_ONE_STAGE = "TEST-DBC-1-STAGE";
+  private static final String DBC_DISABLED = "TEST-DBC-DISABLED";
 
   @Container
   @ServiceConnection
@@ -1944,6 +1946,115 @@ class AdminLtftResourceIntegrationTest {
         .andExpect(jsonPath("$.status.current.detail.message", is("All checks passed.")))
         .andExpect(jsonPath("$.status.current.modifiedBy.name", is("Ad Min")))
         .andExpect(jsonPath("$.status.current.modifiedBy.email", is("ad.min@example.com")));
+  }
+
+  // -- GET /review-stages --
+
+  @Test
+  void shouldReturnForbiddenGettingReviewStagesWhenNoToken() throws Exception {
+    mockMvc.perform(get("/api/admin/ltft/review-stages")
+            .contentType(APPLICATION_JSON)
+            .content("[\"DBC-1\"]"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void shouldReturnForbiddenGettingReviewStagesWhenNoGroups() throws Exception {
+    mockMvc.perform(get("/api/admin/ltft/review-stages")
+            .with(TestJwtUtil.createAdminToken(List.of(), REQUIRED_ROLES))
+            .contentType(APPLICATION_JSON)
+            .content("[\"DBC-1\"]"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void shouldReturnEmptyReviewStagesWhenDbcsHaveNoConfiguredWorkflow() throws Exception {
+    mockMvc.perform(get("/api/admin/ltft/review-stages")
+            .with(TestJwtUtil.createAdminToken(List.of(DBC_1), REQUIRED_ROLES))
+            .contentType(APPLICATION_JSON)
+            .content("[\"" + DBC_1 + "\"]"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(0)));
+  }
+
+  @Test
+  void shouldReturnEnabledReviewStageLabelsForSingleDbc() throws Exception {
+    mockMvc.perform(get("/api/admin/ltft/review-stages")
+            .with(TestJwtUtil.createAdminToken(List.of(DBC_THREE_STAGES), REQUIRED_ROLES))
+            .contentType(APPLICATION_JSON)
+            .content("[\"" + DBC_THREE_STAGES + "\"]"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(3)))
+        .andExpect(jsonPath("$", containsInAnyOrder("Stage One", "Stage Two", "Stage Three")));
+  }
+
+  @Test
+  void shouldReturnDeduplicatedEnabledLabelsAcrossMultipleDbcs() throws Exception {
+    // DBC_THREE_STAGES has Stage One, Stage Two, Stage Three; DBC_ONE_STAGE has Single Review
+    mockMvc.perform(get("/api/admin/ltft/review-stages")
+            .with(TestJwtUtil.createAdminToken(
+                List.of(DBC_THREE_STAGES, DBC_ONE_STAGE), REQUIRED_ROLES))
+            .contentType(APPLICATION_JSON)
+            .content("[\"" + DBC_THREE_STAGES + "\",\"" + DBC_ONE_STAGE + "\"]"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(4)))
+        .andExpect(jsonPath("$", containsInAnyOrder(
+            "Stage One", "Stage Two", "Stage Three", "Single Review")));
+  }
+
+  @Test
+  void shouldNotIncludeDisabledStageLabelsWhenNoFormsExistInThem() throws Exception {
+    // DBC_DISABLED has one stage "Disabled Stage" with enabled=false, no forms exist
+    mockMvc.perform(get("/api/admin/ltft/review-stages")
+            .with(TestJwtUtil.createAdminToken(List.of(DBC_DISABLED), REQUIRED_ROLES))
+            .contentType(APPLICATION_JSON)
+            .content("[\"" + DBC_DISABLED + "\"]"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(0)));
+  }
+
+  @Test
+  void shouldIncludeDisabledStageLabelsWhenFormsExistInThem() throws Exception {
+    // Create a form that is SUBMITTED and in the disabled review stage for DBC_DISABLED
+    LtftForm form = createSubmittedFormWithReviewStage(DBC_DISABLED, 0, "Disabled Stage");
+    template.insert(form);
+
+    mockMvc.perform(get("/api/admin/ltft/review-stages")
+            .with(TestJwtUtil.createAdminToken(List.of(DBC_DISABLED), REQUIRED_ROLES))
+            .contentType(APPLICATION_JSON)
+            .content("[\"" + DBC_DISABLED + "\"]"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0]", is("Disabled Stage")));
+  }
+
+  @Test
+  void shouldIncludeBothEnabledAndInUseDisabledLabelsAcrossDbcs() throws Exception {
+    // Create a form in the disabled stage for DBC_DISABLED
+    LtftForm form = createSubmittedFormWithReviewStage(DBC_DISABLED, 0, "Disabled Stage");
+    template.insert(form);
+
+    // Request for DBC_ONE_STAGE (enabled: Single Review) + DBC_DISABLED (disabled: Disabled Stage)
+    mockMvc.perform(get("/api/admin/ltft/review-stages")
+            .with(TestJwtUtil.createAdminToken(
+                List.of(DBC_ONE_STAGE, DBC_DISABLED), REQUIRED_ROLES))
+            .contentType(APPLICATION_JSON)
+            .content("[\"" + DBC_ONE_STAGE + "\",\"" + DBC_DISABLED + "\"]"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(2)))
+        .andExpect(jsonPath("$", containsInAnyOrder("Single Review", "Disabled Stage")));
   }
 
   /**

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
@@ -2137,6 +2137,21 @@ class AdminLtftResourceIntegrationTest {
             "Single Review", "Review complete", "Disabled Stage")));
   }
 
+  @Test
+  void shouldFilterOutDbcsNotInAdminGroups() throws Exception {
+    // Admin token only has DBC_ONE_STAGE, but request body includes DBC_THREE_STAGES too
+    mockMvc.perform(get("/api/admin/ltft/review-stages")
+            .with(TestJwtUtil.createAdminToken(List.of(DBC_ONE_STAGE), REQUIRED_ROLES))
+            .contentType(APPLICATION_JSON)
+            .content("[\"" + DBC_ONE_STAGE + "\",\"" + DBC_THREE_STAGES + "\"]"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        // Only DBC_ONE_STAGE stages should be returned (Single Review + Review complete)
+        .andExpect(jsonPath("$", hasSize(2)))
+        .andExpect(jsonPath("$", containsInAnyOrder("Single Review", "Review complete")));
+  }
+
   /**
    * Create a form with the given details, other fields will get sensible defaults.
    *

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
@@ -724,6 +724,7 @@ class AdminLtftResourceIntegrationTest {
         .andExpect(jsonPath("$.content[0].tpd.email", is("tpd@example.com")))
         .andExpect(jsonPath("$.content[0].tpd.emailStatus", is("VALID")))
         .andExpect(jsonPath("$.content[0].status", is(SUBMITTED.name())))
+        .andExpect(jsonPath("$.content[0].reviewStage", nullValue()))
         .andExpect(jsonPath("$.content[0].assignedAdmin.name", is("Ad Min")))
         .andExpect(jsonPath("$.content[0].assignedAdmin.email", is("ad.min@example.com")))
         .andExpect(jsonPath("$.content[0].assignedAdmin.role").doesNotExist())
@@ -732,6 +733,22 @@ class AdminLtftResourceIntegrationTest {
         .andExpect(jsonPath("$.page.number", is(0)))
         .andExpect(jsonPath("$.page.totalElements", is(1)))
         .andExpect(jsonPath("$.page.totalPages", is(1)));
+  }
+
+  @Test
+  void shouldReturnReviewStageLabelInSummaryWhenFormHasReviewStage() throws Exception {
+    LtftForm form = createSubmittedFormWithReviewStage(DBC_1, 1, "Manager Review");
+    template.insert(form);
+
+    mockMvc.perform(get("/api/admin/ltft")
+            .with(TestJwtUtil.createAdminToken(List.of(DBC_1), REQUIRED_ROLES)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.content[0].id", is(form.getId().toString())))
+        .andExpect(jsonPath("$.content[0].status", is(SUBMITTED.name())))
+        .andExpect(jsonPath("$.content[0].reviewStage", is("Manager Review")));
   }
 
   @ParameterizedTest

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
@@ -2031,8 +2031,7 @@ class AdminLtftResourceIntegrationTest {
   @Test
   void shouldReturnForbiddenGettingReviewStagesWhenNoToken() throws Exception {
     mockMvc.perform(get("/api/admin/ltft/review-stages")
-            .contentType(APPLICATION_JSON)
-            .content("[\"DBC-1\"]"))
+            .param("dbcs", "DBC-1"))
         .andExpect(status().isForbidden());
   }
 
@@ -2040,8 +2039,7 @@ class AdminLtftResourceIntegrationTest {
   void shouldReturnForbiddenGettingReviewStagesWhenNoGroups() throws Exception {
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(List.of(), REQUIRED_ROLES))
-            .contentType(APPLICATION_JSON)
-            .content("[\"DBC-1\"]"))
+            .param("dbcs", "DBC-1"))
         .andExpect(status().isForbidden());
   }
 
@@ -2049,8 +2047,7 @@ class AdminLtftResourceIntegrationTest {
   void shouldReturnEmptyReviewStagesWhenDbcsHaveNoConfiguredWorkflow() throws Exception {
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(List.of(DBC_1), REQUIRED_ROLES))
-            .contentType(APPLICATION_JSON)
-            .content("[\"" + DBC_1 + "\"]"))
+            .param("dbcs", DBC_1))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2061,8 +2058,7 @@ class AdminLtftResourceIntegrationTest {
   void shouldReturnEnabledReviewStageLabelsForSingleDbc() throws Exception {
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(List.of(DBC_THREE_STAGES), REQUIRED_ROLES))
-            .contentType(APPLICATION_JSON)
-            .content("[\"" + DBC_THREE_STAGES + "\"]"))
+            .param("dbcs", DBC_THREE_STAGES))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2077,8 +2073,7 @@ class AdminLtftResourceIntegrationTest {
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(
                 List.of(DBC_THREE_STAGES, DBC_ONE_STAGE), REQUIRED_ROLES))
-            .contentType(APPLICATION_JSON)
-            .content("[\"" + DBC_THREE_STAGES + "\",\"" + DBC_ONE_STAGE + "\"]"))
+            .param("dbcs", DBC_THREE_STAGES, DBC_ONE_STAGE))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2092,8 +2087,7 @@ class AdminLtftResourceIntegrationTest {
     // DBC_DISABLED has one stage "Disabled Stage" with enabled=false, no forms exist
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(List.of(DBC_DISABLED), REQUIRED_ROLES))
-            .contentType(APPLICATION_JSON)
-            .content("[\"" + DBC_DISABLED + "\"]"))
+            .param("dbcs", DBC_DISABLED))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2108,8 +2102,7 @@ class AdminLtftResourceIntegrationTest {
 
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(List.of(DBC_DISABLED), REQUIRED_ROLES))
-            .contentType(APPLICATION_JSON)
-            .content("[\"" + DBC_DISABLED + "\"]"))
+            .param("dbcs", DBC_DISABLED))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2127,8 +2120,7 @@ class AdminLtftResourceIntegrationTest {
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(
                 List.of(DBC_ONE_STAGE, DBC_DISABLED), REQUIRED_ROLES))
-            .contentType(APPLICATION_JSON)
-            .content("[\"" + DBC_ONE_STAGE + "\",\"" + DBC_DISABLED + "\"]"))
+            .param("dbcs", DBC_ONE_STAGE, DBC_DISABLED))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2139,11 +2131,10 @@ class AdminLtftResourceIntegrationTest {
 
   @Test
   void shouldFilterOutDbcsNotInAdminGroups() throws Exception {
-    // Admin token only has DBC_ONE_STAGE, but request body includes DBC_THREE_STAGES too
+    // Admin token only has DBC_ONE_STAGE, but request includes DBC_THREE_STAGES too
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(List.of(DBC_ONE_STAGE), REQUIRED_ROLES))
-            .contentType(APPLICATION_JSON)
-            .content("[\"" + DBC_ONE_STAGE + "\",\"" + DBC_THREE_STAGES + "\"]"))
+            .param("dbcs", DBC_ONE_STAGE, DBC_THREE_STAGES))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
@@ -1988,8 +1988,9 @@ class AdminLtftResourceIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
-        .andExpect(jsonPath("$", hasSize(3)))
-        .andExpect(jsonPath("$", containsInAnyOrder("Stage One", "Stage Two", "Stage Three")));
+        .andExpect(jsonPath("$", hasSize(4)))
+        .andExpect(jsonPath("$", containsInAnyOrder(
+            "Stage One", "Stage Two", "Stage Three", "Review complete")));
   }
 
   @Test
@@ -2003,9 +2004,9 @@ class AdminLtftResourceIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
-        .andExpect(jsonPath("$", hasSize(4)))
+        .andExpect(jsonPath("$", hasSize(5)))
         .andExpect(jsonPath("$", containsInAnyOrder(
-            "Stage One", "Stage Two", "Stage Three", "Single Review")));
+            "Stage One", "Stage Two", "Stage Three", "Single Review", "Review complete")));
   }
 
   @Test
@@ -2053,8 +2054,9 @@ class AdminLtftResourceIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
-        .andExpect(jsonPath("$", hasSize(2)))
-        .andExpect(jsonPath("$", containsInAnyOrder("Single Review", "Disabled Stage")));
+        .andExpect(jsonPath("$", hasSize(3)))
+        .andExpect(jsonPath("$", containsInAnyOrder(
+            "Single Review", "Review complete", "Disabled Stage")));
   }
 
   /**

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
@@ -2030,24 +2030,21 @@ class AdminLtftResourceIntegrationTest {
 
   @Test
   void shouldReturnForbiddenGettingReviewStagesWhenNoToken() throws Exception {
-    mockMvc.perform(get("/api/admin/ltft/review-stages")
-            .param("dbc", "DBC-1"))
+    mockMvc.perform(get("/api/admin/ltft/review-stages"))
         .andExpect(status().isForbidden());
   }
 
   @Test
   void shouldReturnForbiddenGettingReviewStagesWhenNoGroups() throws Exception {
     mockMvc.perform(get("/api/admin/ltft/review-stages")
-            .with(TestJwtUtil.createAdminToken(List.of(), REQUIRED_ROLES))
-            .param("dbc", "DBC-1"))
+            .with(TestJwtUtil.createAdminToken(List.of(), REQUIRED_ROLES)))
         .andExpect(status().isForbidden());
   }
 
   @Test
   void shouldReturnEmptyReviewStagesWhenDbcsHaveNoConfiguredWorkflow() throws Exception {
     mockMvc.perform(get("/api/admin/ltft/review-stages")
-            .with(TestJwtUtil.createAdminToken(List.of(DBC_1), REQUIRED_ROLES))
-            .param("dbc", DBC_1))
+            .with(TestJwtUtil.createAdminToken(List.of(DBC_1), REQUIRED_ROLES)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2057,8 +2054,7 @@ class AdminLtftResourceIntegrationTest {
   @Test
   void shouldReturnEnabledReviewStageLabelsForSingleDbc() throws Exception {
     mockMvc.perform(get("/api/admin/ltft/review-stages")
-            .with(TestJwtUtil.createAdminToken(List.of(DBC_THREE_STAGES), REQUIRED_ROLES))
-            .param("dbc", DBC_THREE_STAGES))
+            .with(TestJwtUtil.createAdminToken(List.of(DBC_THREE_STAGES), REQUIRED_ROLES)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2072,8 +2068,7 @@ class AdminLtftResourceIntegrationTest {
     // DBC_THREE_STAGES has Stage One, Stage Two, Stage Three; DBC_ONE_STAGE has Single Review
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(
-                List.of(DBC_THREE_STAGES, DBC_ONE_STAGE), REQUIRED_ROLES))
-            .param("dbc", DBC_THREE_STAGES, DBC_ONE_STAGE))
+                List.of(DBC_THREE_STAGES, DBC_ONE_STAGE), REQUIRED_ROLES)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2086,8 +2081,7 @@ class AdminLtftResourceIntegrationTest {
   void shouldNotIncludeDisabledStageLabelsWhenNoFormsExistInThem() throws Exception {
     // DBC_DISABLED has one stage "Disabled Stage" with enabled=false, no forms exist
     mockMvc.perform(get("/api/admin/ltft/review-stages")
-            .with(TestJwtUtil.createAdminToken(List.of(DBC_DISABLED), REQUIRED_ROLES))
-            .param("dbc", DBC_DISABLED))
+            .with(TestJwtUtil.createAdminToken(List.of(DBC_DISABLED), REQUIRED_ROLES)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2101,8 +2095,7 @@ class AdminLtftResourceIntegrationTest {
     template.insert(form);
 
     mockMvc.perform(get("/api/admin/ltft/review-stages")
-            .with(TestJwtUtil.createAdminToken(List.of(DBC_DISABLED), REQUIRED_ROLES))
-            .param("dbc", DBC_DISABLED))
+            .with(TestJwtUtil.createAdminToken(List.of(DBC_DISABLED), REQUIRED_ROLES)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2116,11 +2109,10 @@ class AdminLtftResourceIntegrationTest {
     LtftForm form = createSubmittedFormWithReviewStage(DBC_DISABLED, 0, "Disabled Stage");
     template.insert(form);
 
-    // Request for DBC_ONE_STAGE (enabled: Single Review) + DBC_DISABLED (disabled: Disabled Stage)
+    // Admin token has DBC_ONE_STAGE (enabled: Single Review) + DBC_DISABLED (disabled: Disabled Stage)
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(
-                List.of(DBC_ONE_STAGE, DBC_DISABLED), REQUIRED_ROLES))
-            .param("dbc", DBC_ONE_STAGE, DBC_DISABLED))
+                List.of(DBC_ONE_STAGE, DBC_DISABLED), REQUIRED_ROLES)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2130,15 +2122,13 @@ class AdminLtftResourceIntegrationTest {
   }
 
   @Test
-  void shouldFilterOutDbcsNotInAdminGroups() throws Exception {
-    // Admin token only has DBC_ONE_STAGE, but request includes DBC_THREE_STAGES too
+  void shouldOnlyReturnStagesForAdminGroups() throws Exception {
+    // Admin token only has DBC_ONE_STAGE, so only its stages should be returned
     mockMvc.perform(get("/api/admin/ltft/review-stages")
-            .with(TestJwtUtil.createAdminToken(List.of(DBC_ONE_STAGE), REQUIRED_ROLES))
-            .param("dbc", DBC_ONE_STAGE, DBC_THREE_STAGES))
+            .with(TestJwtUtil.createAdminToken(List.of(DBC_ONE_STAGE), REQUIRED_ROLES)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
-        // Only DBC_ONE_STAGE stages should be returned (Single Review + Review complete)
         .andExpect(jsonPath("$", hasSize(2)))
         .andExpect(jsonPath("$", containsInAnyOrder("Single Review", "Review complete")));
   }

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceIntegrationTest.java
@@ -2031,7 +2031,7 @@ class AdminLtftResourceIntegrationTest {
   @Test
   void shouldReturnForbiddenGettingReviewStagesWhenNoToken() throws Exception {
     mockMvc.perform(get("/api/admin/ltft/review-stages")
-            .param("dbcs", "DBC-1"))
+            .param("dbc", "DBC-1"))
         .andExpect(status().isForbidden());
   }
 
@@ -2039,7 +2039,7 @@ class AdminLtftResourceIntegrationTest {
   void shouldReturnForbiddenGettingReviewStagesWhenNoGroups() throws Exception {
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(List.of(), REQUIRED_ROLES))
-            .param("dbcs", "DBC-1"))
+            .param("dbc", "DBC-1"))
         .andExpect(status().isForbidden());
   }
 
@@ -2047,7 +2047,7 @@ class AdminLtftResourceIntegrationTest {
   void shouldReturnEmptyReviewStagesWhenDbcsHaveNoConfiguredWorkflow() throws Exception {
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(List.of(DBC_1), REQUIRED_ROLES))
-            .param("dbcs", DBC_1))
+            .param("dbc", DBC_1))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2058,7 +2058,7 @@ class AdminLtftResourceIntegrationTest {
   void shouldReturnEnabledReviewStageLabelsForSingleDbc() throws Exception {
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(List.of(DBC_THREE_STAGES), REQUIRED_ROLES))
-            .param("dbcs", DBC_THREE_STAGES))
+            .param("dbc", DBC_THREE_STAGES))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2073,7 +2073,7 @@ class AdminLtftResourceIntegrationTest {
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(
                 List.of(DBC_THREE_STAGES, DBC_ONE_STAGE), REQUIRED_ROLES))
-            .param("dbcs", DBC_THREE_STAGES, DBC_ONE_STAGE))
+            .param("dbc", DBC_THREE_STAGES, DBC_ONE_STAGE))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2087,7 +2087,7 @@ class AdminLtftResourceIntegrationTest {
     // DBC_DISABLED has one stage "Disabled Stage" with enabled=false, no forms exist
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(List.of(DBC_DISABLED), REQUIRED_ROLES))
-            .param("dbcs", DBC_DISABLED))
+            .param("dbc", DBC_DISABLED))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2102,7 +2102,7 @@ class AdminLtftResourceIntegrationTest {
 
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(List.of(DBC_DISABLED), REQUIRED_ROLES))
-            .param("dbcs", DBC_DISABLED))
+            .param("dbc", DBC_DISABLED))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2120,7 +2120,7 @@ class AdminLtftResourceIntegrationTest {
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(
                 List.of(DBC_ONE_STAGE, DBC_DISABLED), REQUIRED_ROLES))
-            .param("dbcs", DBC_ONE_STAGE, DBC_DISABLED))
+            .param("dbc", DBC_ONE_STAGE, DBC_DISABLED))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
@@ -2134,7 +2134,7 @@ class AdminLtftResourceIntegrationTest {
     // Admin token only has DBC_ONE_STAGE, but request includes DBC_THREE_STAGES too
     mockMvc.perform(get("/api/admin/ltft/review-stages")
             .with(TestJwtUtil.createAdminToken(List.of(DBC_ONE_STAGE), REQUIRED_ROLES))
-            .param("dbcs", DBC_ONE_STAGE, DBC_THREE_STAGES))
+            .param("dbc", DBC_ONE_STAGE, DBC_THREE_STAGES))
         .andExpect(status().isOk())
         .andExpect(content().contentType(APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
@@ -33,7 +33,6 @@ import jakarta.validation.Valid;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -164,15 +163,14 @@ public class AdminLtftResource {
   }
 
   /**
-   * Get a deduplicated set of review stage labels for the given DBCs. Includes all enabled stages
-   * plus any disabled stages that currently have LTFT forms in them.
+   * Get a deduplicated set of review stage labels for the admin's local office DBCs. Includes all
+   * enabled stages plus any disabled stages that currently have LTFT forms in them.
    *
-   * @param dbc The list of designated body codes to retrieve review stages for.
    * @return A set of deduplicated review stage labels.
    */
   @GetMapping("/review-stages")
-  ResponseEntity<Set<String>> getReviewStages(@RequestParam List<String> dbc) {
-    Set<String> stages = service.getReviewStageLabels(dbc);
+  ResponseEntity<Set<String>> getReviewStages() {
+    Set<String> stages = service.getReviewStageLabels();
     return ResponseEntity.ok(stages);
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
@@ -164,11 +164,11 @@ public class AdminLtftResource {
   }
 
   /**
-   * Get a deduplicated list of review stage labels for the given DBCs. Includes all enabled stages
+   * Get a deduplicated set of review stage labels for the given DBCs. Includes all enabled stages
    * plus any disabled stages that currently have LTFT forms in them.
    *
    * @param dbcs The list of designated body codes to retrieve review stages for.
-   * @return An array of deduplicated review stage labels.
+   * @return A set of deduplicated review stage labels.
    */
   @GetMapping("/review-stages")
   ResponseEntity<Set<String>> getReviewStages(@RequestBody List<String> dbcs) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
@@ -171,7 +171,7 @@ public class AdminLtftResource {
    * @return A set of deduplicated review stage labels.
    */
   @GetMapping("/review-stages")
-  ResponseEntity<Set<String>> getReviewStages(@RequestBody List<String> dbcs) {
+  ResponseEntity<Set<String>> getReviewStages(@RequestParam List<String> dbcs) {
     Set<String> stages = service.getReviewStageLabels(dbcs);
     return ResponseEntity.ok(stages);
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
@@ -167,12 +167,12 @@ public class AdminLtftResource {
    * Get a deduplicated set of review stage labels for the given DBCs. Includes all enabled stages
    * plus any disabled stages that currently have LTFT forms in them.
    *
-   * @param dbcs The list of designated body codes to retrieve review stages for.
+   * @param dbc The list of designated body codes to retrieve review stages for.
    * @return A set of deduplicated review stage labels.
    */
   @GetMapping("/review-stages")
-  ResponseEntity<Set<String>> getReviewStages(@RequestParam List<String> dbcs) {
-    Set<String> stages = service.getReviewStageLabels(dbcs);
+  ResponseEntity<Set<String>> getReviewStages(@RequestParam List<String> dbc) {
+    Set<String> stages = service.getReviewStageLabels(dbc);
     return ResponseEntity.ok(stages);
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResource.java
@@ -33,6 +33,7 @@ import jakarta.validation.Valid;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -160,6 +161,19 @@ public class AdminLtftResource {
     }
 
     return ResponseEntity.notFound().build();
+  }
+
+  /**
+   * Get a deduplicated list of review stage labels for the given DBCs. Includes all enabled stages
+   * plus any disabled stages that currently have LTFT forms in them.
+   *
+   * @param dbcs The list of designated body codes to retrieve review stages for.
+   * @return An array of deduplicated review stage labels.
+   */
+  @GetMapping("/review-stages")
+  ResponseEntity<Set<String>> getReviewStages(@RequestBody List<String> dbcs) {
+    Set<String> stages = service.getReviewStageLabels(dbcs);
+    return ResponseEntity.ok(stages);
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftAdminSummaryDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftAdminSummaryDto.java
@@ -41,6 +41,7 @@ import uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState;
  * @param shortNotice       Whether the LTFT application was submitted at short notice.
  * @param tpd               The details of the notification sent to the TPD.
  * @param status            The current status of the LTFT application.
+ * @param reviewStage       The current review stage label, or null if no review stage is active.
  * @param assignedAdmin     The admin assigned to process the LTFT application.
  */
 @Builder
@@ -57,6 +58,7 @@ public record LtftAdminSummaryDto(
     Boolean shortNotice,
     LtftAdminNotificationDto tpd,
     LifecycleState status,
+    String reviewStage,
     PersonDto assignedAdmin) {
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/mapper/LtftMapper.java
@@ -90,6 +90,7 @@ public abstract class LtftMapper implements FormMapper<LtftForm, LtftFormDto>,
   @Mapping(target = "tpd.email", source = "content.discussions.tpdEmail")
   @Mapping(target = "tpd.emailStatus", source = "content.tpdEmailValidity")
   @Mapping(target = "status", source = "status.current.state")
+  @Mapping(target = "reviewStage", source = "status.current.reviewStage.label")
   @Mapping(target = "assignedAdmin.name", source = "status.current.assignedAdmin.name")
   @Mapping(target = "assignedAdmin.email", source = "status.current.assignedAdmin.email")
   @Mapping(target = "assignedAdmin.role", ignore = true)

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.trainee.forms.repository;
 
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -102,6 +103,19 @@ public interface LtftFormRepository extends BaseAuditedFormRepository<LtftForm> 
    */
   Optional<LtftForm> findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(UUID id,
       Set<String> dbcs);
+
+  /**
+   * Find LTFT forms that are in the SUBMITTED state with one of the given DBCs and one of the
+   * given review stage labels.
+   *
+   * @param state  The lifecycle state to filter by.
+   * @param dbcs   The designated body codes to include in the search.
+   * @param labels The review stage labels to filter by.
+   * @return The found LTFT forms, empty if none found.
+   */
+  List<LtftForm>
+      findByStatus_Current_StateAndContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
+          LifecycleState state, Collection<String> dbcs, Collection<String> labels);
 
   /**
    * Delete the LTFT form with the given id.

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/repository/LtftFormRepository.java
@@ -105,17 +105,15 @@ public interface LtftFormRepository extends BaseAuditedFormRepository<LtftForm> 
       Set<String> dbcs);
 
   /**
-   * Find LTFT forms that are in the SUBMITTED state with one of the given DBCs and one of the
-   * given review stage labels.
+   * Find LTFT forms in one of the given DBCs and one of the given review stage labels.
    *
-   * @param state  The lifecycle state to filter by.
    * @param dbcs   The designated body codes to include in the search.
    * @param labels The review stage labels to filter by.
    * @return The found LTFT forms, empty if none found.
    */
   List<LtftForm>
-      findByStatus_Current_StateAndContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
-          LifecycleState state, Collection<String> dbcs, Collection<String> labels);
+      findByContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
+          Collection<String> dbcs, Collection<String> labels);
 
   /**
    * Delete the LTFT form with the given id.

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -38,6 +38,8 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -658,6 +660,38 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
     }
 
     return Optional.of(reviewStageService.getWorkflowDto(optForm.get()));
+  }
+
+  /**
+   * Get a deduplicated set of review stage labels relevant to the given DBCs.
+   *
+   * <p>This includes all <em>enabled</em> configured stages plus any <em>disabled</em> stages
+   * that currently have LTFT forms in them (i.e. forms that entered the stage before it was
+   * disabled).
+   *
+   * @param dbcs The designated body codes to retrieve review stages for.
+   * @return A set of deduplicated review stage labels.
+   */
+  public Set<String> getReviewStageLabels(Collection<String> dbcs) {
+    log.info("Getting review stage labels for DBCs {}", dbcs);
+    Set<String> labels = new LinkedHashSet<>(reviewStageService.getEnabledStageLabels(dbcs));
+
+    Set<String> disabledLabels = new LinkedHashSet<>(
+        reviewStageService.getDisabledStageLabels(dbcs));
+    // Remove labels already present from the enabled set to avoid unnecessary queries.
+    disabledLabels.removeAll(labels);
+
+    if (!disabledLabels.isEmpty()) {
+      List<LtftForm> forms = ltftFormRepository
+          .findByStatus_Current_StateAndContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
+              SUBMITTED, dbcs, disabledLabels);
+      forms.stream()
+          .map(f -> f.getStatus().current().reviewStage().label())
+          .forEach(labels::add);
+    }
+
+    log.info("Found {} review stage labels for DBCs {}: {}", labels.size(), dbcs, labels);
+    return labels;
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -665,7 +665,8 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
   /**
    * Get a deduplicated set of review stage labels relevant to the given DBCs.
    *
-   * <p>This includes all <em>enabled</em> configured stages plus any <em>disabled</em> stages
+   * <p>This includes all <em>enabled</em> configured stages, the implicit "Review complete"
+   * terminal stage (when at least one enabled stage exists), plus any <em>disabled</em> stages
    * that currently have LTFT forms in them (i.e. forms that entered the stage before it was
    * disabled).
    *
@@ -675,6 +676,11 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
   public Set<String> getReviewStageLabels(Collection<String> dbcs) {
     log.info("Getting review stage labels for DBCs {}", dbcs);
     Set<String> labels = new LinkedHashSet<>(reviewStageService.getEnabledStageLabels(dbcs));
+
+    // Include the implicit terminal stage when at least one enabled stage exists.
+    if (!labels.isEmpty()) {
+      labels.add(ReviewStageService.TERMINAL_STAGE_LABEL);
+    }
 
     Set<String> disabledLabels = new LinkedHashSet<>(
         reviewStageService.getDisabledStageLabels(dbcs));

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -674,8 +674,13 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
    * @return A set of deduplicated review stage labels.
    */
   public Set<String> getReviewStageLabels(Collection<String> dbcs) {
-    log.info("Getting review stage labels for DBCs {}", dbcs);
-    Set<String> labels = new LinkedHashSet<>(reviewStageService.getEnabledStageLabels(dbcs));
+    // Filter to only include DBCs that the admin has access to.
+    List<String> filteredDbcs = dbcs.stream()
+        .filter(dbc -> adminIdentity.getGroups().contains(dbc))
+        .toList();
+    log.info("Getting review stage labels for DBCs {} (filtered from {})", filteredDbcs, dbcs);
+    Set<String> labels = new LinkedHashSet<>(
+        reviewStageService.getEnabledStageLabels(filteredDbcs));
 
     // Include the implicit terminal stage when at least one enabled stage exists.
     if (!labels.isEmpty()) {
@@ -683,20 +688,20 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
     }
 
     Set<String> disabledLabels = new LinkedHashSet<>(
-        reviewStageService.getDisabledStageLabels(dbcs));
+        reviewStageService.getDisabledStageLabels(filteredDbcs));
     // Remove labels already present from the enabled set to avoid unnecessary queries.
     disabledLabels.removeAll(labels);
 
     if (!disabledLabels.isEmpty()) {
       List<LtftForm> forms = ltftFormRepository
-          .findByStatus_Current_StateAndContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
-              SUBMITTED, dbcs, disabledLabels);
+          .findByContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
+              filteredDbcs, disabledLabels);
       forms.stream()
           .map(f -> f.getStatus().current().reviewStage().label())
           .forEach(labels::add);
     }
 
-    log.info("Found {} review stage labels for DBCs {}: {}", labels.size(), dbcs, labels);
+    log.info("Found {} review stage labels for DBCs {}: {}", labels.size(), filteredDbcs, labels);
     return labels;
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -38,7 +38,6 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
 import java.util.AbstractMap.SimpleEntry;
-import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -663,22 +662,18 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
   }
 
   /**
-   * Get a deduplicated set of review stage labels relevant to the given DBCs.
+   * Get a deduplicated set of review stage labels relevant to the user's group DBCs.
    *
    * <p>This includes all <em>enabled</em> configured stages, the implicit "Review complete"
    * terminal stage (when at least one enabled stage exists), plus any <em>disabled</em> stages
    * that currently have LTFT forms in them (i.e. forms that entered the stage before it was
    * disabled).
    *
-   * @param dbcs The designated body codes to retrieve review stages for.
    * @return A set of deduplicated review stage labels.
    */
-  public Set<String> getReviewStageLabels(Collection<String> dbcs) {
-    // Filter to only include DBCs that the admin has access to.
-    List<String> filteredDbcs = dbcs.stream()
-        .filter(dbc -> adminIdentity.getGroups().contains(dbc))
-        .toList();
-    log.info("Getting review stage labels for DBCs {} (filtered from {})", filteredDbcs, dbcs);
+  public Set<String> getReviewStageLabels() {
+    List<String> filteredDbcs = adminIdentity.getGroups().stream().toList();
+    log.info("Getting review stage labels for DBCs {}", filteredDbcs);
     Set<String> labels = new LinkedHashSet<>(
         reviewStageService.getEnabledStageLabels(filteredDbcs));
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -1021,6 +1021,7 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
             case "personalDetails.gmcNumber" -> "content.personalDetails.gmcNumber";
             case "personalDetails.surname" -> "content.personalDetails.surname";
             case "programmeName" -> "content.programmeMembership.name";
+            case "reviewStage" -> "status.current.reviewStage.label";
             case "status" -> FORM_ATTRIBUTE_FORM_STATUS;
             case "traineeId" -> "traineeTisId";
             default -> null;

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
@@ -26,8 +26,11 @@ import static uk.nhs.hee.tis.trainee.forms.dto.enumeration.LifecycleState.UNSUBM
 
 import jakarta.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.forms.config.ReviewWorkflowProperties;
@@ -271,6 +274,42 @@ public class ReviewStageService {
     }
     return atTerminalStage;
   }
+
+ /**
+ * Collect the labels of all <em>enabled</em> review stages across the given DBCs.
+ *
+ * @param dbcs The designated body codes to inspect.
+ * @return A deduplicated set of enabled stage labels.
+ */
+public Set<String> getEnabledStageLabels(Collection<String> dbcs) {
+  return getStageLabels(dbcs, true);
+}
+
+/**
+ * Collect the labels of all <em>disabled</em> review stages across the given DBCs.
+ *
+ * @param dbcs The designated body codes to inspect.
+ * @return A deduplicated set of disabled stage labels.
+ */
+public Set<String> getDisabledStageLabels(Collection<String> dbcs) {
+  return getStageLabels(dbcs, false);
+}
+
+  /**
+   * Collect the labels of all review stages across the given DBCs matching the given
+   * enabled/disabled status.
+   *
+   * @param dbcs    The designated body codes to inspect.
+   * @param enabled The enabled/disabled status.
+   * @return A deduplicated set of matched stage labels.
+   */
+  private Set<String> getStageLabels(Collection<String> dbcs, boolean enabled) {
+  return dbcs.stream()
+      .flatMap(dbc -> getConfiguredStages(dbc).stream())
+      .filter(stage -> stage.enabled() == enabled)
+      .map(StateStage::label)
+      .collect(Collectors.toSet());
+}
 
   /**
    * Return the configured review-workflow stages for the given DBC code, or an empty list if no

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
@@ -275,25 +275,25 @@ public class ReviewStageService {
     return atTerminalStage;
   }
 
- /**
- * Collect the labels of all <em>enabled</em> review stages across the given DBCs.
- *
- * @param dbcs The designated body codes to inspect.
- * @return A deduplicated set of enabled stage labels.
- */
-public Set<String> getEnabledStageLabels(Collection<String> dbcs) {
-  return getStageLabels(dbcs, true);
-}
+  /**
+   * Collect the labels of all <em>enabled</em> review stages across the given DBCs.
+   *
+   * @param dbcs The designated body codes to inspect.
+   * @return A deduplicated set of enabled stage labels.
+   */
+  public Set<String> getEnabledStageLabels(Collection<String> dbcs) {
+    return getStageLabels(dbcs, true);
+  }
 
-/**
- * Collect the labels of all <em>disabled</em> review stages across the given DBCs.
- *
- * @param dbcs The designated body codes to inspect.
- * @return A deduplicated set of disabled stage labels.
- */
-public Set<String> getDisabledStageLabels(Collection<String> dbcs) {
-  return getStageLabels(dbcs, false);
-}
+  /**
+   * Collect the labels of all <em>disabled</em> review stages across the given DBCs.
+   *
+   * @param dbcs The designated body codes to inspect.
+   * @return A deduplicated set of disabled stage labels.
+   */
+  public Set<String> getDisabledStageLabels(Collection<String> dbcs) {
+    return getStageLabels(dbcs, false);
+  }
 
   /**
    * Collect the labels of all review stages across the given DBCs matching the given

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
@@ -44,18 +44,19 @@ import uk.nhs.hee.tis.trainee.forms.model.ReviewStageStatus;
  * A service for managing review stage transitions on LTFT forms.
  *
  * <p>Rules enforced:
+ *
  * <ul>
  *   <li>On entering SUBMITTED: set the review stage to the first <em>enabled</em> configured stage
- *       for the form's DBC, or null if no enabled stages are configured.</li>
- *   <li>On leaving SUBMITTED for any reason: clear the review stage to null.</li>
- *   <li>On re-entering SUBMITTED after UNSUBMITTED: restart from the first enabled stage.</li>
- *   <li>Any review stage may UNSUBMIT a form.</li>
- *   <li>A disabled review stage may be advanced or exited as if it were enabled.</li>
- *   <li>Advancing always moves to the next <em>enabled</em> stage, skipping disabled ones.</li>
+ *       for the form's DBC, or null if no enabled stages are configured.
+ *   <li>On leaving SUBMITTED for any reason: clear the review stage to null.
+ *   <li>On re-entering SUBMITTED after UNSUBMITTED: restart from the first enabled stage.
+ *   <li>Any review stage may UNSUBMIT a form.
+ *   <li>A disabled review stage may be advanced or exited as if it were enabled.
+ *   <li>Advancing always moves to the next <em>enabled</em> stage, skipping disabled ones.
  *   <li>Only the <em>effective</em> final stage (the stage after which no further enabled stages
- *       exist) may approve, reject, or otherwise terminate a form.</li>
+ *       exist) may approve, reject, or otherwise terminate a form.
  *   <li>If no enabled stages are configured for a DBC, that DBC is treated as having no review
- *       workflow at all.</li>
+ *       workflow at all.
  * </ul>
  */
 @Slf4j
@@ -84,8 +85,8 @@ public class ReviewStageService {
    * configured stage is enabled, an implicit terminal "Review complete" stage is appended.
    *
    * <p>The {@code currentStage} field is the zero-based index of the form's current review stage
-   * within the returned {@code stages} list, or {@code null} if the form is not SUBMITTED or has
-   * no active review stage.
+   * within the returned {@code stages} list, or {@code null} if the form is not SUBMITTED or has no
+   * active review stage.
    *
    * @param form The form to inspect.
    * @return The workflow DTO describing the visible stages and the form's current position.
@@ -95,11 +96,12 @@ public class ReviewStageService {
     List<StateStage> allStages = getConfiguredStages(dbc);
 
     ReviewStageStatus currentReviewStage = getCurrentReviewStage(form);
-    boolean isSubmitted = form.getStatus() != null
-        && form.getStatus().current() != null
-        && form.getStatus().current().state() == SUBMITTED;
-    Integer currentAbsoluteIndex = (isSubmitted && currentReviewStage != null)
-        ? currentReviewStage.index() : null;
+    boolean isSubmitted =
+        form.getStatus() != null
+            && form.getStatus().current() != null
+            && form.getStatus().current().state() == SUBMITTED;
+    Integer currentAbsoluteIndex =
+        (isSubmitted && currentReviewStage != null) ? currentReviewStage.index() : null;
 
     List<String> visibleLabels = new ArrayList<>();
     Integer currentVisiblePosition = null;
@@ -134,13 +136,13 @@ public class ReviewStageService {
    * no enabled stages are configured (or no workflow exists) {@code null} is returned, indicating
    * the form should behave as if no review workflow is in place.
    *
-   * @param form        The form being transitioned.
+   * @param form The form being transitioned.
    * @param targetState The lifecycle state being transitioned to.
    * @return The review stage to record, or {@code null} if the stage should be cleared.
    */
   @Nullable
-  public ReviewStageStatus resolveReviewStageForTransition(LtftForm form,
-      LifecycleState targetState) {
+  public ReviewStageStatus resolveReviewStageForTransition(
+      LtftForm form, LifecycleState targetState) {
     if (targetState != SUBMITTED) {
       // Leaving SUBMITTED for any reason (APPROVED, REJECTED, UNSUBMITTED, WITHDRAWN) clears stage.
       return null;
@@ -157,11 +159,14 @@ public class ReviewStageService {
 
     Optional<ReviewStageStatus> firstEnabled = nextEnabledStageAfter(stages, -1);
     if (firstEnabled.isPresent()) {
-      log.debug("Resolving first enabled review stage for DBC '{}': index={}, label='{}'.",
-          dbc, firstEnabled.get().index(), firstEnabled.get().label());
+      log.debug(
+          "Resolving first enabled review stage for DBC '{}': index={}, label='{}'.",
+          dbc,
+          firstEnabled.get().index(),
+          firstEnabled.get().label());
     } else {
-      log.debug("No enabled review stages configured for DBC '{}'; setting review stage to null.",
-          dbc);
+      log.debug(
+          "No enabled review stages configured for DBC '{}'; setting review stage to null.", dbc);
     }
     return firstEnabled.orElse(null);
   }
@@ -170,17 +175,17 @@ public class ReviewStageService {
    * Resolve the next {@link ReviewStageStatus} when an admin advances the review of a form.
    *
    * <p>Disabled stages are skipped: the next <em>enabled</em> stage after the current index is
-   * returned. If no enabled stage exists after the current index (i.e. the form is at the
-   * effective final configured stage), the implicit terminal "Review complete" stage is returned,
-   * allowing the admin to record a reason before transitioning to a terminal lifecycle state.
+   * returned. If no enabled stage exists after the current index (i.e. the form is at the effective
+   * final configured stage), the implicit terminal "Review complete" stage is returned, allowing
+   * the admin to record a reason before transitioning to a terminal lifecycle state.
    *
    * <p>If the form is already at the terminal stage, {@link Optional#empty()} is returned to
    * indicate that no further advancement is possible. Transitioning to APPROVED must be performed
    * separately via the normal status-update path.
    *
    * @param form The form whose review is being advanced.
-   * @return The next review stage (including the implicit terminal stage), or empty if the form
-   *     is already at the terminal stage.
+   * @return The next review stage (including the implicit terminal stage), or empty if the form is
+   *     already at the terminal stage.
    */
   public Optional<ReviewStageStatus> resolveAdvance(LtftForm form) {
     String dbc = getDesignatedBodyCode(form);
@@ -194,7 +199,8 @@ public class ReviewStageService {
 
     ReviewStageStatus current = getCurrentReviewStage(form);
     if (current == null) {
-      log.warn("Form {} has a review workflow but no current review stage; cannot advance.",
+      log.warn(
+          "Form {} has a review workflow but no current review stage; cannot advance.",
           form.getId());
       return Optional.empty();
     }
@@ -204,37 +210,43 @@ public class ReviewStageService {
     // Already at the terminal stage — no further advancement is possible.
     // Note, not stages.size() - 1, as the terminal stage is not part of the configured stages list.
     if (currentIndex == stages.size()) {
-      log.debug("Form {} is already at the terminal review stage; no advancement possible.",
+      log.debug(
+          "Form {} is already at the terminal review stage; no advancement possible.",
           form.getId());
       return Optional.empty();
     }
 
     Optional<ReviewStageStatus> next = nextEnabledStageAfter(stages, currentIndex);
     if (next.isPresent()) {
-      log.debug("Advancing form {} from review stage index {} to {} ('{}').",
-          form.getId(), currentIndex, next.get().index(), next.get().label());
+      log.debug(
+          "Advancing form {} from review stage index {} to {} ('{}').",
+          form.getId(),
+          currentIndex,
+          next.get().index(),
+          next.get().label());
       return next;
     }
 
     // At the effective final configured stage — advance to the implicit terminal stage.
-    log.debug("Advancing form {} from final configured stage (index {}) to terminal stage.",
-        form.getId(), currentIndex);
+    log.debug(
+        "Advancing form {} from final configured stage (index {}) to terminal stage.",
+        form.getId(),
+        currentIndex);
     return Optional.of(new ReviewStageStatus(stages.size(), TERMINAL_STAGE_LABEL));
   }
 
-
   /**
-   * Determine whether the form's current review stage permits a transition to the given
-   * lifecycle state.
+   * Determine whether the form's current review stage permits a transition to the given lifecycle
+   * state.
    *
-   * <p>UNSUBMITTED is always permitted from any review stage. All other lifecycle states
-   * (APPROVED, REJECTED, WITHDRAWN) require the form to be at the implicit terminal stage,
-   * i.e. past all configured stages.
+   * <p>UNSUBMITTED is always permitted from any review stage. All other lifecycle states (APPROVED,
+   * REJECTED, WITHDRAWN) require the form to be at the implicit terminal stage, i.e. past all
+   * configured stages.
    *
-   * <p>If no workflow is configured for the form's DBC, or all configured stages are disabled,
-   * the transition is always permitted.
+   * <p>If no workflow is configured for the form's DBC, or all configured stages are disabled, the
+   * transition is always permitted.
    *
-   * @param form        The form to check.
+   * @param form The form to check.
    * @param targetState The lifecycle state the form is being transitioned to.
    * @return {@code true} if the transition is permitted, {@code false} otherwise.
    */
@@ -259,8 +271,11 @@ public class ReviewStageService {
 
     ReviewStageStatus currentReviewStage = getCurrentReviewStage(form);
     if (currentReviewStage == null) {
-      log.debug("Form {} has no review stage; treating as pre-workflow form — allowing transition "
-          + "to {}.", form.getId(), targetState);
+      log.debug(
+          "Form {} has no review stage; treating as pre-workflow form — allowing transition "
+              + "to {}.",
+          form.getId(),
+          targetState);
       return true;
     }
 
@@ -268,9 +283,12 @@ public class ReviewStageService {
     // terminal stage, i.e. after all configured review stages have been completed.
     boolean atTerminalStage = currentReviewStage.index() >= stages.size();
     if (!atTerminalStage) {
-      log.warn("Form {} is at review stage index {} but attempted to transition to {}; "
+      log.warn(
+          "Form {} is at review stage index {} but attempted to transition to {}; "
               + "the form must be advanced to the terminal stage first.",
-          form.getId(), currentReviewStage.index(), targetState);
+          form.getId(),
+          currentReviewStage.index(),
+          targetState);
     }
     return atTerminalStage;
   }
@@ -299,17 +317,17 @@ public class ReviewStageService {
    * Collect the labels of all review stages across the given DBCs matching the given
    * enabled/disabled status.
    *
-   * @param dbcs    The designated body codes to inspect.
+   * @param dbcs The designated body codes to inspect.
    * @param enabled The enabled/disabled status.
    * @return A deduplicated set of matched stage labels.
    */
   private Set<String> getStageLabels(Collection<String> dbcs, boolean enabled) {
-  return dbcs.stream()
-      .flatMap(dbc -> getConfiguredStages(dbc).stream())
-      .filter(stage -> stage.enabled() == enabled)
-      .map(StateStage::label)
-      .collect(Collectors.toSet());
-}
+    return dbcs.stream()
+        .flatMap(dbc -> getConfiguredStages(dbc).stream())
+        .filter(stage -> stage.enabled() == enabled)
+        .map(StateStage::label)
+        .collect(Collectors.toSet());
+  }
 
   /**
    * Return the configured review-workflow stages for the given DBC code, or an empty list if no
@@ -342,17 +360,17 @@ public class ReviewStageService {
   }
 
   /**
-   * Find the next enabled stage in {@code stages} whose index is strictly greater than
-   * {@code fromIndex}.
+   * Find the next enabled stage in {@code stages} whose index is strictly greater than {@code
+   * fromIndex}.
    *
    * <p>Pass {@code -1} as {@code fromIndex} to find the very first enabled stage.
    *
-   * @param stages    The ordered list of configured stages.
+   * @param stages The ordered list of configured stages.
    * @param fromIndex The index to start searching <em>after</em> (exclusive).
    * @return The first enabled stage found, or empty if none exists.
    */
-  private Optional<ReviewStageStatus> nextEnabledStageAfter(List<StateStage> stages,
-      int fromIndex) {
+  private Optional<ReviewStageStatus> nextEnabledStageAfter(
+      List<StateStage> stages, int fromIndex) {
     for (int i = fromIndex + 1; i < stages.size(); i++) {
       if (stages.get(i).enabled()) {
         return Optional.of(new ReviewStageStatus(i, stages.get(i).label()));

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
@@ -588,23 +588,23 @@ class AdminLtftResourceTest {
 
   @Test
   void shouldReturnReviewStageLabelsForDbcs() {
-    List<String> dbcs = List.of("DBC-1", "DBC-2");
+    List<String> dbc = List.of("DBC-1", "DBC-2");
     Set<String> expectedLabels = Set.of("Triage", "Review", "Approval");
-    when(service.getReviewStageLabels(dbcs)).thenReturn(expectedLabels);
+    when(service.getReviewStageLabels(dbc)).thenReturn(expectedLabels);
 
-    ResponseEntity<Set<String>> response = controller.getReviewStages(dbcs);
+    ResponseEntity<Set<String>> response = controller.getReviewStages(dbc);
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
     assertThat("Unexpected response body.", response.getBody(), is(expectedLabels));
-    verify(service).getReviewStageLabels(dbcs);
+    verify(service).getReviewStageLabels(dbc);
   }
 
   @Test
   void shouldReturnEmptyReviewStageLabelsWhenNoStagesConfigured() {
-    List<String> dbcs = List.of("DBC-1");
-    when(service.getReviewStageLabels(dbcs)).thenReturn(Set.of());
+    List<String> dbc = List.of("DBC-1");
+    when(service.getReviewStageLabels(dbc)).thenReturn(Set.of());
 
-    ResponseEntity<Set<String>> response = controller.getReviewStages(dbcs);
+    ResponseEntity<Set<String>> response = controller.getReviewStages(dbc);
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
     assertThat("Unexpected response body size.", response.getBody(), hasSize(0));

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
@@ -588,23 +588,21 @@ class AdminLtftResourceTest {
 
   @Test
   void shouldReturnReviewStageLabelsForDbcs() {
-    List<String> dbc = List.of("DBC-1", "DBC-2");
     Set<String> expectedLabels = Set.of("Triage", "Review", "Approval");
-    when(service.getReviewStageLabels(dbc)).thenReturn(expectedLabels);
+    when(service.getReviewStageLabels()).thenReturn(expectedLabels);
 
-    ResponseEntity<Set<String>> response = controller.getReviewStages(dbc);
+    ResponseEntity<Set<String>> response = controller.getReviewStages();
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
     assertThat("Unexpected response body.", response.getBody(), is(expectedLabels));
-    verify(service).getReviewStageLabels(dbc);
+    verify(service).getReviewStageLabels();
   }
 
   @Test
   void shouldReturnEmptyReviewStageLabelsWhenNoStagesConfigured() {
-    List<String> dbc = List.of("DBC-1");
-    when(service.getReviewStageLabels(dbc)).thenReturn(Set.of());
+    when(service.getReviewStageLabels()).thenReturn(Set.of());
 
-    ResponseEntity<Set<String>> response = controller.getReviewStages(dbc);
+    ResponseEntity<Set<String>> response = controller.getReviewStages();
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
     assertThat("Unexpected response body size.", response.getBody(), hasSize(0));

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/api/AdminLtftResourceTest.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -583,5 +584,29 @@ class AdminLtftResourceTest {
     assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
     assertThat("Unexpected response body.", response.getBody(), sameInstance(dto));
     verify(service).advanceReviewStage(id, detail);
+  }
+
+  @Test
+  void shouldReturnReviewStageLabelsForDbcs() {
+    List<String> dbcs = List.of("DBC-1", "DBC-2");
+    Set<String> expectedLabels = Set.of("Triage", "Review", "Approval");
+    when(service.getReviewStageLabels(dbcs)).thenReturn(expectedLabels);
+
+    ResponseEntity<Set<String>> response = controller.getReviewStages(dbcs);
+
+    assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
+    assertThat("Unexpected response body.", response.getBody(), is(expectedLabels));
+    verify(service).getReviewStageLabels(dbcs);
+  }
+
+  @Test
+  void shouldReturnEmptyReviewStageLabelsWhenNoStagesConfigured() {
+    List<String> dbcs = List.of("DBC-1");
+    when(service.getReviewStageLabels(dbcs)).thenReturn(Set.of());
+
+    ResponseEntity<Set<String>> response = controller.getReviewStages(dbcs);
+
+    assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
+    assertThat("Unexpected response body size.", response.getBody(), hasSize(0));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -385,6 +385,7 @@ class LtftServiceTest {
       personalDetails.gmcNumber | content.personalDetails.gmcNumber
       personalDetails.surname | content.personalDetails.surname
       programmeName | content.programmeMembership.name
+      reviewStage | status.current.reviewStage.label
       status | status.current.state
       traineeId | traineeTisId
       """)
@@ -412,6 +413,7 @@ class LtftServiceTest {
       personalDetails.gmcNumber | content.personalDetails.gmcNumber
       personalDetails.surname | content.personalDetails.surname
       programmeName | content.programmeMembership.name
+      reviewStage | status.current.reviewStage.label
       status | status.current.state
       traineeId | traineeTisId
       """)
@@ -603,6 +605,7 @@ class LtftServiceTest {
       personalDetails.gmcNumber | content.personalDetails.gmcNumber
       personalDetails.surname | content.personalDetails.surname
       programmeName | content.programmeMembership.name
+      reviewStage | status.current.reviewStage.label
       status | status.current.state
       traineeId | traineeTisId
       """)
@@ -633,6 +636,7 @@ class LtftServiceTest {
       personalDetails.gmcNumber | content.personalDetails.gmcNumber
       personalDetails.surname | content.personalDetails.surname
       programmeName | content.programmeMembership.name
+      reviewStage | status.current.reviewStage.label
       status | status.current.state
       traineeId | traineeTisId
       """)

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -2156,6 +2156,87 @@ class LtftServiceTest {
   }
 
   @Test
+  void shouldReturnEnabledStageLabelsFromReviewStageService() {
+    Set<String> enabledLabels = Set.of("Triage", "Review");
+    List<String> dbcs = List.of("DBC-1", "DBC-2");
+    when(reviewStageService.getEnabledStageLabels(dbcs)).thenReturn(enabledLabels);
+    when(reviewStageService.getDisabledStageLabels(dbcs)).thenReturn(Set.of());
+
+    Set<String> result = service.getReviewStageLabels(dbcs);
+
+    assertThat("Unexpected number of labels.", result, hasSize(2));
+    assertThat("Expected Triage label.", result, hasItem("Triage"));
+    assertThat("Expected Review label.", result, hasItem("Review"));
+  }
+
+  @Test
+  void shouldReturnEmptyLabelsWhenNoStagesConfigured() {
+    List<String> dbcs = List.of("DBC-1");
+    when(reviewStageService.getEnabledStageLabels(dbcs)).thenReturn(Set.of());
+    when(reviewStageService.getDisabledStageLabels(dbcs)).thenReturn(Set.of());
+
+    Set<String> result = service.getReviewStageLabels(dbcs);
+
+    assertThat("Expected empty labels.", result, hasSize(0));
+  }
+
+  @Test
+  void shouldIncludeDisabledStageLabelsWhenFormsExistInThem() {
+    List<String> dbcs = List.of("DBC-1");
+    when(reviewStageService.getEnabledStageLabels(dbcs)).thenReturn(Set.of("Triage"));
+    when(reviewStageService.getDisabledStageLabels(dbcs)).thenReturn(Set.of("Disabled Stage"));
+
+    LtftForm form = new LtftForm();
+    form.setStatus(Status.builder()
+        .current(StatusInfo.builder()
+            .state(SUBMITTED)
+            .reviewStage(new ReviewStageStatus(1, "Disabled Stage"))
+            .build())
+        .build());
+    when(repository
+        .findByStatus_Current_StateAndContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
+            eq(SUBMITTED), eq(dbcs), any()))
+        .thenReturn(List.of(form));
+
+    Set<String> result = service.getReviewStageLabels(dbcs);
+
+    assertThat("Expected enabled and disabled labels.", result, hasSize(2));
+    assertThat("Expected Triage label.", result, hasItem("Triage"));
+    assertThat("Expected Disabled Stage label.", result, hasItem("Disabled Stage"));
+  }
+
+  @Test
+  void shouldNotQueryForDisabledStagesWhenNoneConfigured() {
+    List<String> dbcs = List.of("DBC-1");
+    when(reviewStageService.getEnabledStageLabels(dbcs)).thenReturn(Set.of("Triage"));
+    when(reviewStageService.getDisabledStageLabels(dbcs)).thenReturn(Set.of());
+
+    Set<String> result = service.getReviewStageLabels(dbcs);
+
+    verify(repository, never())
+        .findByStatus_Current_StateAndContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
+            any(), any(), any());
+    assertThat("Expected only enabled labels.", result, hasSize(1));
+  }
+
+  @Test
+  void shouldNotQueryForDisabledStagesAlreadyInEnabledSet() {
+    List<String> dbcs = List.of("DBC-1", "DBC-2");
+    // "Triage" is enabled for one DBC and disabled for another
+    when(reviewStageService.getEnabledStageLabels(dbcs)).thenReturn(Set.of("Triage", "Review"));
+    when(reviewStageService.getDisabledStageLabels(dbcs))
+        .thenReturn(new java.util.HashSet<>(Set.of("Triage")));
+
+    Set<String> result = service.getReviewStageLabels(dbcs);
+
+    // Should not query because the disabled label "Triage" is already in the enabled set
+    verify(repository, never())
+        .findByStatus_Current_StateAndContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
+            any(), any(), any());
+    assertThat("Expected only enabled labels.", result, hasSize(2));
+  }
+
+  @Test
   void shouldLookUpFormByIdWhenAdvancingReviewStage()
       throws MethodArgumentNotValidException {
     when(repository.findByIdAndContent_ProgrammeMembership_DesignatedBodyCodeIn(

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -2162,12 +2162,11 @@ class LtftServiceTest {
   @Test
   void shouldReturnEnabledStageLabelsAndTerminalStageFromReviewStageService() {
     Set<String> enabledLabels = Set.of("Triage", "Review");
-    List<String> dbcs = List.of(ADMIN_GROUP, "DBC-2");
-    List<String> filteredDbcs = List.of(ADMIN_GROUP);
-    when(reviewStageService.getEnabledStageLabels(filteredDbcs)).thenReturn(enabledLabels);
-    when(reviewStageService.getDisabledStageLabels(filteredDbcs)).thenReturn(Set.of());
+    List<String> adminDbcs = List.of(ADMIN_GROUP);
+    when(reviewStageService.getEnabledStageLabels(adminDbcs)).thenReturn(enabledLabels);
+    when(reviewStageService.getDisabledStageLabels(adminDbcs)).thenReturn(Set.of());
 
-    Set<String> result = service.getReviewStageLabels(dbcs);
+    Set<String> result = service.getReviewStageLabels();
 
     assertThat("Unexpected number of labels.", result, hasSize(3));
     assertThat("Expected Triage label.", result, hasItem("Triage"));
@@ -2177,20 +2176,20 @@ class LtftServiceTest {
 
   @Test
   void shouldNotIncludeTerminalStageWhenNoEnabledStagesExist() {
-    List<String> dbcs = List.of(ADMIN_GROUP);
-    when(reviewStageService.getEnabledStageLabels(dbcs)).thenReturn(Set.of());
-    when(reviewStageService.getDisabledStageLabels(dbcs)).thenReturn(Set.of());
+    List<String> adminDbcs = List.of(ADMIN_GROUP);
+    when(reviewStageService.getEnabledStageLabels(adminDbcs)).thenReturn(Set.of());
+    when(reviewStageService.getDisabledStageLabels(adminDbcs)).thenReturn(Set.of());
 
-    Set<String> result = service.getReviewStageLabels(dbcs);
+    Set<String> result = service.getReviewStageLabels();
 
     assertThat("Expected empty labels.", result, hasSize(0));
   }
 
   @Test
   void shouldIncludeDisabledStageLabelsWhenFormsExistInThem() {
-    List<String> dbcs = List.of(ADMIN_GROUP);
-    when(reviewStageService.getEnabledStageLabels(dbcs)).thenReturn(Set.of("Triage"));
-    when(reviewStageService.getDisabledStageLabels(dbcs)).thenReturn(Set.of("Disabled Stage"));
+    List<String> adminDbcs = List.of(ADMIN_GROUP);
+    when(reviewStageService.getEnabledStageLabels(adminDbcs)).thenReturn(Set.of("Triage"));
+    when(reviewStageService.getDisabledStageLabels(adminDbcs)).thenReturn(Set.of("Disabled Stage"));
 
     LtftForm form = new LtftForm();
     form.setStatus(Status.builder()
@@ -2201,10 +2200,10 @@ class LtftServiceTest {
         .build());
     when(repository
         .findByContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
-            eq(dbcs), any()))
+            eq(adminDbcs), any()))
         .thenReturn(List.of(form));
 
-    Set<String> result = service.getReviewStageLabels(dbcs);
+    Set<String> result = service.getReviewStageLabels();
 
     assertThat("Expected enabled, terminal and disabled labels.", result, hasSize(3));
     assertThat("Expected Triage label.", result, hasItem("Triage"));
@@ -2214,11 +2213,11 @@ class LtftServiceTest {
 
   @Test
   void shouldNotQueryForDisabledStagesWhenNoneConfigured() {
-    List<String> dbcs = List.of(ADMIN_GROUP);
-    when(reviewStageService.getEnabledStageLabels(dbcs)).thenReturn(Set.of("Triage"));
-    when(reviewStageService.getDisabledStageLabels(dbcs)).thenReturn(Set.of());
+    List<String> adminDbcs = List.of(ADMIN_GROUP);
+    when(reviewStageService.getEnabledStageLabels(adminDbcs)).thenReturn(Set.of("Triage"));
+    when(reviewStageService.getDisabledStageLabels(adminDbcs)).thenReturn(Set.of());
 
-    Set<String> result = service.getReviewStageLabels(dbcs);
+    Set<String> result = service.getReviewStageLabels();
 
     verify(repository, never())
         .findByContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
@@ -2228,32 +2227,19 @@ class LtftServiceTest {
 
   @Test
   void shouldNotQueryForDisabledStagesAlreadyInEnabledSet() {
-    List<String> dbcs = List.of(ADMIN_GROUP, "DBC-2");
-    List<String> filteredDbcs = List.of(ADMIN_GROUP);
+    List<String> adminDbcs = List.of(ADMIN_GROUP);
     // "Triage" is enabled for one DBC and disabled for another
-    when(reviewStageService.getEnabledStageLabels(filteredDbcs)).thenReturn(Set.of("Triage", "Review"));
-    when(reviewStageService.getDisabledStageLabels(filteredDbcs))
+    when(reviewStageService.getEnabledStageLabels(adminDbcs)).thenReturn(Set.of("Triage", "Review"));
+    when(reviewStageService.getDisabledStageLabels(adminDbcs))
         .thenReturn(new java.util.HashSet<>(Set.of("Triage")));
 
-    Set<String> result = service.getReviewStageLabels(dbcs);
+    Set<String> result = service.getReviewStageLabels();
 
     // Should not query because the disabled label "Triage" is already in the enabled set
     verify(repository, never())
         .findByContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
             any(), any());
     assertThat("Expected enabled + terminal labels.", result, hasSize(3));
-  }
-
-  @Test
-  void shouldFilterDbcsToOnlyIncludeAdminGroups() {
-    List<String> dbcs = List.of("not-admin-group-1", "not-admin-group-2");
-    // No DBCs match admin groups, so filtered list is empty
-    when(reviewStageService.getEnabledStageLabels(List.of())).thenReturn(Set.of());
-    when(reviewStageService.getDisabledStageLabels(List.of())).thenReturn(Set.of());
-
-    Set<String> result = service.getReviewStageLabels(dbcs);
-
-    assertThat("Expected empty labels when no DBCs match admin groups.", result, hasSize(0));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -2156,7 +2156,7 @@ class LtftServiceTest {
   }
 
   @Test
-  void shouldReturnEnabledStageLabelsFromReviewStageService() {
+  void shouldReturnEnabledStageLabelsAndTerminalStageFromReviewStageService() {
     Set<String> enabledLabels = Set.of("Triage", "Review");
     List<String> dbcs = List.of("DBC-1", "DBC-2");
     when(reviewStageService.getEnabledStageLabels(dbcs)).thenReturn(enabledLabels);
@@ -2164,13 +2164,14 @@ class LtftServiceTest {
 
     Set<String> result = service.getReviewStageLabels(dbcs);
 
-    assertThat("Unexpected number of labels.", result, hasSize(2));
+    assertThat("Unexpected number of labels.", result, hasSize(3));
     assertThat("Expected Triage label.", result, hasItem("Triage"));
     assertThat("Expected Review label.", result, hasItem("Review"));
+    assertThat("Expected terminal stage label.", result, hasItem("Review complete"));
   }
 
   @Test
-  void shouldReturnEmptyLabelsWhenNoStagesConfigured() {
+  void shouldNotIncludeTerminalStageWhenNoEnabledStagesExist() {
     List<String> dbcs = List.of("DBC-1");
     when(reviewStageService.getEnabledStageLabels(dbcs)).thenReturn(Set.of());
     when(reviewStageService.getDisabledStageLabels(dbcs)).thenReturn(Set.of());
@@ -2200,8 +2201,9 @@ class LtftServiceTest {
 
     Set<String> result = service.getReviewStageLabels(dbcs);
 
-    assertThat("Expected enabled and disabled labels.", result, hasSize(2));
+    assertThat("Expected enabled, terminal and disabled labels.", result, hasSize(3));
     assertThat("Expected Triage label.", result, hasItem("Triage"));
+    assertThat("Expected terminal stage label.", result, hasItem("Review complete"));
     assertThat("Expected Disabled Stage label.", result, hasItem("Disabled Stage"));
   }
 
@@ -2216,7 +2218,7 @@ class LtftServiceTest {
     verify(repository, never())
         .findByStatus_Current_StateAndContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
             any(), any(), any());
-    assertThat("Expected only enabled labels.", result, hasSize(1));
+    assertThat("Expected enabled + terminal labels.", result, hasSize(2));
   }
 
   @Test
@@ -2233,7 +2235,7 @@ class LtftServiceTest {
     verify(repository, never())
         .findByStatus_Current_StateAndContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
             any(), any(), any());
-    assertThat("Expected only enabled labels.", result, hasSize(2));
+    assertThat("Expected enabled + terminal labels.", result, hasSize(3));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -2162,9 +2162,10 @@ class LtftServiceTest {
   @Test
   void shouldReturnEnabledStageLabelsAndTerminalStageFromReviewStageService() {
     Set<String> enabledLabels = Set.of("Triage", "Review");
-    List<String> dbcs = List.of("DBC-1", "DBC-2");
-    when(reviewStageService.getEnabledStageLabels(dbcs)).thenReturn(enabledLabels);
-    when(reviewStageService.getDisabledStageLabels(dbcs)).thenReturn(Set.of());
+    List<String> dbcs = List.of(ADMIN_GROUP, "DBC-2");
+    List<String> filteredDbcs = List.of(ADMIN_GROUP);
+    when(reviewStageService.getEnabledStageLabels(filteredDbcs)).thenReturn(enabledLabels);
+    when(reviewStageService.getDisabledStageLabels(filteredDbcs)).thenReturn(Set.of());
 
     Set<String> result = service.getReviewStageLabels(dbcs);
 
@@ -2176,7 +2177,7 @@ class LtftServiceTest {
 
   @Test
   void shouldNotIncludeTerminalStageWhenNoEnabledStagesExist() {
-    List<String> dbcs = List.of("DBC-1");
+    List<String> dbcs = List.of(ADMIN_GROUP);
     when(reviewStageService.getEnabledStageLabels(dbcs)).thenReturn(Set.of());
     when(reviewStageService.getDisabledStageLabels(dbcs)).thenReturn(Set.of());
 
@@ -2187,7 +2188,7 @@ class LtftServiceTest {
 
   @Test
   void shouldIncludeDisabledStageLabelsWhenFormsExistInThem() {
-    List<String> dbcs = List.of("DBC-1");
+    List<String> dbcs = List.of(ADMIN_GROUP);
     when(reviewStageService.getEnabledStageLabels(dbcs)).thenReturn(Set.of("Triage"));
     when(reviewStageService.getDisabledStageLabels(dbcs)).thenReturn(Set.of("Disabled Stage"));
 
@@ -2199,8 +2200,8 @@ class LtftServiceTest {
             .build())
         .build());
     when(repository
-        .findByStatus_Current_StateAndContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
-            eq(SUBMITTED), eq(dbcs), any()))
+        .findByContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
+            eq(dbcs), any()))
         .thenReturn(List.of(form));
 
     Set<String> result = service.getReviewStageLabels(dbcs);
@@ -2213,33 +2214,46 @@ class LtftServiceTest {
 
   @Test
   void shouldNotQueryForDisabledStagesWhenNoneConfigured() {
-    List<String> dbcs = List.of("DBC-1");
+    List<String> dbcs = List.of(ADMIN_GROUP);
     when(reviewStageService.getEnabledStageLabels(dbcs)).thenReturn(Set.of("Triage"));
     when(reviewStageService.getDisabledStageLabels(dbcs)).thenReturn(Set.of());
 
     Set<String> result = service.getReviewStageLabels(dbcs);
 
     verify(repository, never())
-        .findByStatus_Current_StateAndContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
-            any(), any(), any());
+        .findByContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
+            any(), any());
     assertThat("Expected enabled + terminal labels.", result, hasSize(2));
   }
 
   @Test
   void shouldNotQueryForDisabledStagesAlreadyInEnabledSet() {
-    List<String> dbcs = List.of("DBC-1", "DBC-2");
+    List<String> dbcs = List.of(ADMIN_GROUP, "DBC-2");
+    List<String> filteredDbcs = List.of(ADMIN_GROUP);
     // "Triage" is enabled for one DBC and disabled for another
-    when(reviewStageService.getEnabledStageLabels(dbcs)).thenReturn(Set.of("Triage", "Review"));
-    when(reviewStageService.getDisabledStageLabels(dbcs))
+    when(reviewStageService.getEnabledStageLabels(filteredDbcs)).thenReturn(Set.of("Triage", "Review"));
+    when(reviewStageService.getDisabledStageLabels(filteredDbcs))
         .thenReturn(new java.util.HashSet<>(Set.of("Triage")));
 
     Set<String> result = service.getReviewStageLabels(dbcs);
 
     // Should not query because the disabled label "Triage" is already in the enabled set
     verify(repository, never())
-        .findByStatus_Current_StateAndContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
-            any(), any(), any());
+        .findByContent_ProgrammeMembership_DesignatedBodyCodeInAndStatus_Current_ReviewStage_LabelIn(
+            any(), any());
     assertThat("Expected enabled + terminal labels.", result, hasSize(3));
+  }
+
+  @Test
+  void shouldFilterDbcsToOnlyIncludeAdminGroups() {
+    List<String> dbcs = List.of("not-admin-group-1", "not-admin-group-2");
+    // No DBCs match admin groups, so filtered list is empty
+    when(reviewStageService.getEnabledStageLabels(List.of())).thenReturn(Set.of());
+    when(reviewStageService.getDisabledStageLabels(List.of())).thenReturn(Set.of());
+
+    Set<String> result = service.getReviewStageLabels(dbcs);
+
+    assertThat("Expected empty labels when no DBCs match admin groups.", result, hasSize(0));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageServiceTest.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.trainee.forms.service;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -37,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -883,5 +885,76 @@ class ReviewStageServiceTest {
 
     assertTrue(service.canTransitionToLifecycleState(form, UNSUBMITTED),
         "Expected UNSUBMIT to be allowed from terminal stage.");
+  }
+
+  @Test
+  void shouldReturnEmptyEnabledLabelsWhenNoDbcsProvided() {
+    Set<String> labels = service.getEnabledStageLabels(Set.of());
+    assertThat("Expected empty labels for empty DBCs.", labels, empty());
+  }
+
+  @Test
+  void shouldReturnEmptyEnabledLabelsWhenDbcHasNoWorkflow() {
+    Set<String> labels = service.getEnabledStageLabels(Set.of("UNKNOWN-DBC"));
+    assertThat("Expected empty labels for unknown DBC.", labels, empty());
+  }
+
+  @Test
+  void shouldReturnEnabledLabelsForSingleDbc() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), disabledStage("Disabled"), stage("Review"))));
+
+    Set<String> labels = service.getEnabledStageLabels(Set.of(DBC));
+    assertThat("Expected only enabled labels.", labels,
+        containsInAnyOrder("Triage", "Review"));
+  }
+
+  @Test
+  void shouldDeduplicateEnabledLabelsAcrossMultipleDbcs() {
+    String dbc2 = "OTHER-DBC";
+    workflowProperties.setReviewWorkflows(Map.of(
+        DBC, List.of(stage("Triage"), stage("Review")),
+        dbc2, List.of(stage("Triage"), stage("Approval"))));
+
+    Set<String> labels = service.getEnabledStageLabels(Set.of(DBC, dbc2));
+    assertThat("Expected deduplicated labels.", labels,
+        containsInAnyOrder("Triage", "Review", "Approval"));
+  }
+
+  @Test
+  void shouldReturnEmptyDisabledLabelsWhenNoDbcsProvided() {
+    Set<String> labels = service.getDisabledStageLabels(Set.of());
+    assertThat("Expected empty labels for empty DBCs.", labels, empty());
+  }
+
+  @Test
+  void shouldReturnEmptyDisabledLabelsWhenAllStagesEnabled() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Review"))));
+
+    Set<String> labels = service.getDisabledStageLabels(Set.of(DBC));
+    assertThat("Expected no disabled labels.", labels, empty());
+  }
+
+  @Test
+  void shouldReturnDisabledLabelsForSingleDbc() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), disabledStage("Disabled One"), disabledStage("Disabled Two"))));
+
+    Set<String> labels = service.getDisabledStageLabels(Set.of(DBC));
+    assertThat("Expected disabled labels.", labels,
+        containsInAnyOrder("Disabled One", "Disabled Two"));
+  }
+
+  @Test
+  void shouldDeduplicateDisabledLabelsAcrossMultipleDbcs() {
+    String dbc2 = "OTHER-DBC";
+    workflowProperties.setReviewWorkflows(Map.of(
+        DBC, List.of(disabledStage("Shared Disabled"), stage("Enabled")),
+        dbc2, List.of(disabledStage("Shared Disabled"), disabledStage("Other Disabled"))));
+
+    Set<String> labels = service.getDisabledStageLabels(Set.of(DBC, dbc2));
+    assertThat("Expected deduplicated disabled labels.", labels,
+        containsInAnyOrder("Shared Disabled", "Other Disabled"));
   }
 }


### PR DESCRIPTION
new endpoint: `api/admin/ltft/review-stages` returns the set of enabled and in-current-use-by-forms review stage labels for the users group DBCs.

example response:
`[
    "Programme Manager Review",
    "Education Team Review",
    "Programme/Education Team Triage",
    "APD Approval",
    "Completeness checks",
    "Associate Dean Approval",
    "Review complete"
]`
or `[]` if no review stages are configured.

`api/admin/ltft/count?reviewStage=label1,label2&...` extended to allow reviewStage param filter

`api/admin/ltft?reviewStage=label1,label2&...` extended to allow reviewStage param filter and includes reviewStage in summary list response, e.g.

```
{
    "content": [
        {
            "id": "23c306eb-f644-4dfa-8098-12f956d6873b",
            "formRef": "ltft_47165_20250101_002",
            "personalDetails": {
                "id": "47165",
                "forenames": "Testy",
                "surname": "McTest",
                "gmcNumber": "1234567"
            },
            "programmeName": "General Practice",
            "proposedStartDate": "2026-03-01",
            "altStartDate": null,
            "submissionDate": "2025-07-29",
            "reason": "Other",
            "daysToStart": -151,
            "shortNotice": false,
            "tpd": {
                "email": "tpd@example.com",
                "emailStatus": null
            },
            "status": "SUBMITTED",
            "reviewStage": "Programme/Education Team Triage",
            "assignedAdmin": {
                "name": null,
                "email": null,
                "role": null
            }
        }
    ],
    "page": {
        "size": 2000,
        "number": 0,
        "totalElements": 1,
        "totalPages": 1
    }
}
```

TIS21-8888