### PR TITLE
fix: disabled stage index arithmetic

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.72.0"
+version = "0.72.1"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceIntegrationTest.java
@@ -90,6 +90,8 @@ class LtftServiceIntegrationTest {
   private static final String DBC_THREE_STAGES = "TEST-DBC-3-STAGES";
   private static final String DBC_ONE_STAGE = "TEST-DBC-1-STAGE";
   private static final String DBC_NO_WORKFLOW = "unknown-dbc"; // not in config
+  private static final String DBC_DISABLED_FIRST = "TEST-DBC-DISABLED-FIRST";
+  private static final String DBC_MIXED = "TEST-DBC-MIXED";
 
   private static final String TRAINEE_ID = "47165";
   private static final UUID PM_UUID = UUID.randomUUID();
@@ -763,5 +765,171 @@ class LtftServiceIntegrationTest {
         current.reviewStage().index(), is(0));
     assertThat("Unexpected review stage label on re-submit.",
         current.reviewStage().label(), is("Stage One"));
+  }
+
+  // -- disabled stage index consistency --
+
+  @Test
+  void shouldAssignVisibleIndexZeroWhenFirstConfiguredStageIsDisabled() {
+    // TEST-DBC-DISABLED-FIRST: [Triage(disabled), Education Review(enabled), APD Approval(enabled)]
+    // First enabled stage should get visible index 0, not absolute index 1.
+    LtftFormDto dto = LtftFormDto.builder()
+        .traineeTisId(TRAINEE_ID)
+        .name("disabled first stage test")
+        .programmeMembership(LtftFormDto.ProgrammeMembershipDto.builder()
+            .id(PM_UUID)
+            .designatedBodyCode(DBC_DISABLED_FIRST)
+            .build())
+        .build();
+
+    LtftFormDto draft = service.createLtftForm(dto).orElseThrow();
+    LtftFormDto submitted = service.submitLtftForm(draft.id(), null).orElseThrow();
+
+    StatusInfoDto current = submitted.status().current();
+    assertThat("Unexpected state.", current.state(), is(LifecycleState.SUBMITTED));
+    assertThat("Unexpected review stage index — should be visible index 0.",
+        current.reviewStage().index(), is(0));
+    assertThat("Unexpected review stage label.",
+        current.reviewStage().label(), is("Education Review"));
+  }
+
+  @Test
+  void shouldReturnConsistentIndexBetweenFormStatusAndWorkflowEndpoint() {
+    // Submit a form to DBC with disabled first stage, then verify that the index in the form's
+    // status matches the currentStage from the review-workflow endpoint.
+    adminIdentity.setGroups(Set.of(DBC_DISABLED_FIRST));
+
+    LtftFormDto dto = LtftFormDto.builder()
+        .traineeTisId(TRAINEE_ID)
+        .name("consistency test")
+        .programmeMembership(LtftFormDto.ProgrammeMembershipDto.builder()
+            .id(PM_UUID)
+            .designatedBodyCode(DBC_DISABLED_FIRST)
+            .build())
+        .build();
+
+    LtftFormDto draft = service.createLtftForm(dto).orElseThrow();
+    LtftFormDto submitted = service.submitLtftForm(draft.id(), null).orElseThrow();
+
+    int formStatusIndex = submitted.status().current().reviewStage().index();
+    Optional<ReviewWorkflowDto> workflow = service.getReviewWorkflow(submitted.id());
+
+    assertThat("Workflow should be present.", workflow.isPresent(), is(true));
+    assertThat("Form status index should match workflow endpoint currentStage.",
+        formStatusIndex, is(workflow.get().currentStage()));
+  }
+
+  @Test
+  void shouldAdvanceThroughStagesWithCorrectVisibleIndicesWhenMiddleStageDisabled()
+      throws MethodArgumentNotValidException {
+    // TEST-DBC-MIXED: A(enabled=0), B(disabled), C(enabled=1), D(enabled=2)
+    // Advance: A(0) → C(1) → D(2) → terminal(3)
+    adminIdentity.setGroups(Set.of(DBC_MIXED));
+    adminIdentity.setName("Ad Min");
+    adminIdentity.setEmail("ad.min@test.com");
+
+    LtftForm form = savedSubmittedFormWithReviewStage(DBC_MIXED, 0, "Stage A");
+
+    // Advance from A(0) → should skip B(disabled) → C(1)
+    Optional<LtftFormDto> step1 = service.advanceReviewStage(form.getId(), null);
+    assertThat("Step 1 result presence.", step1.isPresent(), is(true));
+    assertThat("Step 1 index.", step1.get().status().current().reviewStage().index(), is(1));
+    assertThat("Step 1 label.", step1.get().status().current().reviewStage().label(),
+        is("Stage C"));
+
+    // Advance from C(1) → D(2)
+    Optional<LtftFormDto> step2 = service.advanceReviewStage(form.getId(), null);
+    assertThat("Step 2 result presence.", step2.isPresent(), is(true));
+    assertThat("Step 2 index.", step2.get().status().current().reviewStage().index(), is(2));
+    assertThat("Step 2 label.", step2.get().status().current().reviewStage().label(),
+        is("Stage D"));
+
+    // Advance from D(2) → terminal(3 = enabled count)
+    Optional<LtftFormDto> step3 = service.advanceReviewStage(form.getId(), null);
+    assertThat("Step 3 result presence.", step3.isPresent(), is(true));
+    assertThat("Step 3 (terminal) index.", step3.get().status().current().reviewStage().index(),
+        is(3));
+    assertThat("Step 3 (terminal) label.", step3.get().status().current().reviewStage().label(),
+        is("Review complete"));
+  }
+
+  @Test
+  void shouldAdvanceThroughStagesWithCorrectVisibleIndicesWhenFirstStageDisabled()
+      throws MethodArgumentNotValidException {
+    // TEST-DBC-DISABLED-FIRST: [Triage(disabled), Education Review(enabled=0),
+    //                           APD Approval(enabled=1)]
+    // Advance: Education(0) → APD(1) → terminal(2)
+    adminIdentity.setGroups(Set.of(DBC_DISABLED_FIRST));
+    adminIdentity.setName("Ad Min");
+    adminIdentity.setEmail("ad.min@test.com");
+
+    LtftForm form = savedSubmittedFormWithReviewStage(DBC_DISABLED_FIRST, 0, "Education Review");
+
+    // Advance from Education Review(0) → APD Approval(1)
+    Optional<LtftFormDto> step1 = service.advanceReviewStage(form.getId(), null);
+    assertThat("Step 1 result presence.", step1.isPresent(), is(true));
+    assertThat("Step 1 index.", step1.get().status().current().reviewStage().index(), is(1));
+    assertThat("Step 1 label.", step1.get().status().current().reviewStage().label(),
+        is("APD Approval"));
+
+    // Advance from APD Approval(1) → terminal(2 = enabled count)
+    Optional<LtftFormDto> step2 = service.advanceReviewStage(form.getId(), null);
+    assertThat("Step 2 result presence.", step2.isPresent(), is(true));
+    assertThat("Step 2 (terminal) index.", step2.get().status().current().reviewStage().index(),
+        is(2));
+    assertThat("Step 2 (terminal) label.", step2.get().status().current().reviewStage().label(),
+        is("Review complete"));
+  }
+
+  @Test
+  void shouldAdvanceFromDisabledStageToNextEnabledStageWithCorrectIndex()
+      throws MethodArgumentNotValidException {
+    // TEST-DBC-MIXED: A(enabled=0), B(disabled), C(enabled=1), D(enabled=2)
+    // Form is at B (entered when B was enabled). Should advance to C with visible index 1.
+    adminIdentity.setGroups(Set.of(DBC_MIXED));
+    adminIdentity.setName("Ad Min");
+    adminIdentity.setEmail("ad.min@test.com");
+
+    // Simulate a form that entered B when it was enabled (visible index was 1 at that time).
+    LtftForm form = savedSubmittedFormWithReviewStage(DBC_MIXED, 1, "Stage B");
+
+    Optional<LtftFormDto> result = service.advanceReviewStage(form.getId(), null);
+    assertThat("Result presence.", result.isPresent(), is(true));
+    // Note that reviewStage.index remains 1: this is because the disabled stage it moved out of
+    // is no longer counted (and will no longer be visible in the review-workflow either).
+    assertThat("Next stage index.", result.get().status().current().reviewStage().index(), is(1));
+    assertThat("Next stage label.", result.get().status().current().reviewStage().label(),
+        is("Stage C"));
+  }
+
+  @Test
+  void shouldReturnCorrectWorkflowStagesAndCurrentPositionForDisabledFirstStage() {
+    // Verify the workflow endpoint returns only enabled stages + terminal,
+    // with the correct currentStage position.
+    adminIdentity.setGroups(Set.of(DBC_DISABLED_FIRST));
+
+    LtftForm form = savedSubmittedFormWithReviewStage(DBC_DISABLED_FIRST, 0, "Education Review");
+
+    Optional<ReviewWorkflowDto> workflow = service.getReviewWorkflow(form.getId());
+
+    assertThat("Workflow should be present.", workflow.isPresent(), is(true));
+    assertThat("Unexpected stages.", workflow.get().stages(),
+        contains("Education Review", "APD Approval", "Review complete"));
+    assertThat("Unexpected currentStage.", workflow.get().currentStage(), is(0));
+  }
+
+  @Test
+  void shouldReturnCorrectWorkflowStagesAndCurrentPositionForMixedDisabledStages() {
+    // TEST-DBC-MIXED at Stage D (visible index 2).
+    adminIdentity.setGroups(Set.of(DBC_MIXED));
+
+    LtftForm form = savedSubmittedFormWithReviewStage(DBC_MIXED, 2, "Stage D");
+
+    Optional<ReviewWorkflowDto> workflow = service.getReviewWorkflow(form.getId());
+
+    assertThat("Workflow should be present.", workflow.isPresent(), is(true));
+    assertThat("Unexpected stages.", workflow.get().stages(),
+        contains("Stage A", "Stage C", "Stage D", "Review complete"));
+    assertThat("Unexpected currentStage.", workflow.get().currentStage(), is(2));
   }
 }

--- a/src/integrationTest/resources/application-test.yml
+++ b/src/integrationTest/resources/application-test.yml
@@ -15,6 +15,22 @@ application:
     "TEST-DBC-DISABLED":
       - label: "Disabled Stage"
         enabled: false
+    "TEST-DBC-DISABLED-FIRST":
+      - label: "Triage"
+        enabled: false
+      - label: "Education Review"
+        enabled: true
+      - label: "APD Approval"
+        enabled: true
+    "TEST-DBC-MIXED":
+      - label: "Stage A"
+        enabled: true
+      - label: "Stage B"
+        enabled: false
+      - label: "Stage C"
+        enabled: true
+      - label: "Stage D"
+        enabled: true
   aws:
     sns:
       formr-file-event: dummy

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/config/ReviewWorkflowProperties.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/config/ReviewWorkflowProperties.java
@@ -23,8 +23,10 @@ package uk.nhs.hee.tis.trainee.forms.config;
 
 import jakarta.annotation.PostConstruct;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -63,17 +65,23 @@ public class ReviewWorkflowProperties {
   /**
    * Validates the configured review workflows after properties have been bound.
    *
-   * @throws IllegalStateException if any stage label is blank.
+   * @throws IllegalStateException if any stage label is blank or duplicated within a DBC.
    */
   @PostConstruct
   void validate() {
     reviewWorkflows.forEach((dbc, stages) -> {
+      Set<String> seenLabels = new HashSet<>();
       for (int i = 0; i < stages.size(); i++) {
         String label = stages.get(i).label();
         if (label == null || label.isBlank()) {
           throw new IllegalStateException(
               "Review workflow for DBC '%s' contains a blank stage label at index %d."
                   .formatted(dbc, i));
+        }
+        if (!seenLabels.add(label)) {
+          throw new IllegalStateException(
+              "Review workflow for DBC '%s' contains duplicate stage label '%s' at index %d."
+                  .formatted(dbc, label, i));
         }
       }
     });

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/ReviewStageStatus.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/ReviewStageStatus.java
@@ -24,8 +24,10 @@ package uk.nhs.hee.tis.trainee.forms.model;
 /**
  * The active review stage of an LTFT form, recorded in the form's status history.
  *
- * @param index The zero-based visible position for this stage in the review workflow, counting only enabled stages.
- *              If a stage is later disabled/removed, the stored index may no longer match the current workflow view.
+ * @param index The zero-based visible position for this stage in the review workflow, counting
+ *              only enabled stages.
+ *              If a stage is later disabled/removed, the stored index may no longer match the
+ *              current workflow view.
  * @param label The display label for this stage.
  */
 public record ReviewStageStatus(int index, String label) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/ReviewStageStatus.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/ReviewStageStatus.java
@@ -24,8 +24,8 @@ package uk.nhs.hee.tis.trainee.forms.model;
 /**
  * The active review stage of an LTFT form, recorded in the form's status history.
  *
- * @param index The zero-based position of this stage among <em>enabled</em> (visible) stages in the
- *              configured workflow. Disabled stages are not counted.
+ * @param index The zero-based visible position for this stage in the review workflow, counting only enabled stages.
+ *              If a stage is later disabled/removed, the stored index may no longer match the current workflow view.
  * @param label The display label for this stage.
  */
 public record ReviewStageStatus(int index, String label) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/ReviewStageStatus.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/ReviewStageStatus.java
@@ -24,7 +24,8 @@ package uk.nhs.hee.tis.trainee.forms.model;
 /**
  * The active review stage of an LTFT form, recorded in the form's status history.
  *
- * @param index The zero-based position of this stage within the configured workflow.
+ * @param index The zero-based position of this stage among <em>enabled</em> (visible) stages in the
+ *              configured workflow. Disabled stages are not counted.
  * @param label The display label for this stage.
  */
 public record ReviewStageStatus(int index, String label) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
@@ -100,15 +100,15 @@ public class ReviewStageService {
         form.getStatus() != null
             && form.getStatus().current() != null
             && form.getStatus().current().state() == SUBMITTED;
-    Integer currentAbsoluteIndex =
-        (isSubmitted && currentReviewStage != null) ? currentReviewStage.index() : null;
+    String currentLabel =
+        (isSubmitted && currentReviewStage != null) ? currentReviewStage.label() : null;
 
     List<String> visibleLabels = new ArrayList<>();
     Integer currentVisiblePosition = null;
 
     for (int i = 0; i < allStages.size(); i++) {
       StateStage stage = allStages.get(i);
-      boolean isCurrent = currentAbsoluteIndex != null && currentAbsoluteIndex == i;
+      boolean isCurrent = currentLabel != null && currentLabel.equals(stage.label());
       if (stage.enabled() || isCurrent) {
         if (isCurrent) {
           currentVisiblePosition = visibleLabels.size();
@@ -120,7 +120,7 @@ public class ReviewStageService {
     // Append the implicit terminal stage if any configured stages are enabled.
     boolean anyEnabled = allStages.stream().anyMatch(StateStage::enabled);
     if (anyEnabled) {
-      if (currentAbsoluteIndex != null && currentAbsoluteIndex == allStages.size()) {
+      if (TERMINAL_STAGE_LABEL.equals(currentLabel)) {
         currentVisiblePosition = visibleLabels.size();
       }
       visibleLabels.add(TERMINAL_STAGE_LABEL);
@@ -208,15 +208,25 @@ public class ReviewStageService {
     int currentIndex = current.index();
 
     // Already at the terminal stage — no further advancement is possible.
-    // Note, not stages.size() - 1, as the terminal stage is not part of the configured stages list.
-    if (currentIndex == stages.size()) {
+    if (TERMINAL_STAGE_LABEL.equals(current.label())) {
       log.debug(
           "Form {} is already at the terminal review stage; no advancement possible.",
           form.getId());
       return Optional.empty();
     }
 
-    Optional<ReviewStageStatus> next = nextEnabledStageAfter(stages, currentIndex);
+    int currentAbsoluteIndex = findAbsoluteIndexByLabel(stages, current.label());
+    if (currentAbsoluteIndex == -1) {
+      log.warn(
+          "Form {} has review stage label '{}' which does not match any configured stage for "
+              + "DBC '{}'; cannot advance.",
+          form.getId(),
+          current.label(),
+          dbc);
+      return Optional.empty();
+    }
+
+    Optional<ReviewStageStatus> next = nextEnabledStageAfter(stages, currentAbsoluteIndex);
     if (next.isPresent()) {
       log.debug(
           "Advancing form {} from review stage index {} to {} ('{}').",
@@ -228,11 +238,12 @@ public class ReviewStageService {
     }
 
     // At the effective final configured stage — advance to the implicit terminal stage.
+    int enabledCount = (int) stages.stream().filter(StateStage::enabled).count();
     log.debug(
         "Advancing form {} from final configured stage (index {}) to terminal stage.",
         form.getId(),
         currentIndex);
-    return Optional.of(new ReviewStageStatus(stages.size(), TERMINAL_STAGE_LABEL));
+    return Optional.of(new ReviewStageStatus(enabledCount, TERMINAL_STAGE_LABEL));
   }
 
   /**
@@ -281,7 +292,7 @@ public class ReviewStageService {
 
     // Terminal transitions (APPROVED, REJECTED, WITHDRAWN) are only permitted from the implicit
     // terminal stage, i.e. after all configured review stages have been completed.
-    boolean atTerminalStage = currentReviewStage.index() >= stages.size();
+    boolean atTerminalStage = TERMINAL_STAGE_LABEL.equals(currentReviewStage.label());
     if (!atTerminalStage) {
       log.warn(
           "Form {} is at review stage index {} but attempted to transition to {}; "
@@ -361,22 +372,47 @@ public class ReviewStageService {
 
   /**
    * Find the next enabled stage in {@code stages} whose index is strictly greater than {@code
-   * fromIndex}.
+   * fromAbsoluteIndex}.
    *
-   * <p>Pass {@code -1} as {@code fromIndex} to find the very first enabled stage.
+   * <p>Pass {@code -1} as {@code fromAbsoluteIndex} to find the very first enabled stage.
+   *
+   * <p>The returned {@link ReviewStageStatus} uses a <em>visible</em> index: the zero-based
+   * position among enabled stages only.
    *
    * @param stages The ordered list of configured stages.
-   * @param fromIndex The index to start searching <em>after</em> (exclusive).
+   * @param fromAbsoluteIndex The absolute index to start searching <em>after</em> (exclusive).
    * @return The first enabled stage found, or empty if none exists.
    */
   private Optional<ReviewStageStatus> nextEnabledStageAfter(
-      List<StateStage> stages, int fromIndex) {
-    for (int i = fromIndex + 1; i < stages.size(); i++) {
+      List<StateStage> stages, int fromAbsoluteIndex) {
+    int enabledCount = 0;
+    for (int i = 0; i <= fromAbsoluteIndex && i < stages.size(); i++) {
       if (stages.get(i).enabled()) {
-        return Optional.of(new ReviewStageStatus(i, stages.get(i).label()));
+        enabledCount++;
+      }
+    }
+    for (int i = fromAbsoluteIndex + 1; i < stages.size(); i++) {
+      if (stages.get(i).enabled()) {
+        return Optional.of(new ReviewStageStatus(enabledCount, stages.get(i).label()));
       }
     }
     return Optional.empty();
+  }
+
+  /**
+   * Find the absolute index of the stage with the given label in the configured stages list.
+   *
+   * @param stages The ordered list of configured stages.
+   * @param label The label to find.
+   * @return The absolute index, or {@code -1} if not found.
+   */
+  private int findAbsoluteIndexByLabel(List<StateStage> stages, String label) {
+    for (int i = 0; i < stages.size(); i++) {
+      if (stages.get(i).label().equals(label)) {
+        return i;
+      }
+    }
+    return -1;
   }
 
   @Nullable

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/config/ReviewWorkflowPropertiesTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/config/ReviewWorkflowPropertiesTest.java
@@ -132,12 +132,12 @@ class ReviewWorkflowPropertiesTest {
   }
 
   @Test
-  void shouldAllowDuplicateStageLabelsWithinSameDbc() {
+  void shouldThrowWhenDuplicateStageLabelsWithinSameDbc() {
     properties.setReviewWorkflows(
         Map.of(DBC_1, List.of(stage("Review", true), stage("Review", false),
             stage("Final Review", true))));
 
-    assertDoesNotThrow(() -> properties.validate());
+    assertThrows(IllegalStateException.class, () -> properties.validate());
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageServiceTest.java
@@ -430,6 +430,53 @@ class ReviewStageServiceTest {
   }
 
   @Test
+  void shouldComputeCorrectVisibleIndexWhenAdvancingFromLastStageWithDisabledPriorStages() {
+    // [disabled, enabled, disabled, enabled] — advance from abs index 3 (last, "D")
+    // Exercises the boundary: fromAbsoluteIndex == stages.size()-1 with disabled prior stages.
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        disabledStage("A"), stage("B"), disabledStage("C"), stage("D"))));
+
+    LtftForm form = formAtReviewStage(DBC, 1, "D");
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    // First loop [0..3]: A(disabled→0), B(enabled→1), C(disabled→1), D(enabled→2)
+    // Second loop starts at 4 which >= size → empty. Terminal index = total enabled = 2.
+    assertTrue(result.isPresent(), "Expected terminal stage to be present.");
+    assertThat("Unexpected terminal stage index — should count only enabled stages in list.",
+        result.get().index(), is(2));
+    assertThat("Unexpected terminal stage label.", result.get().label(), is(TERMINAL_STAGE_LABEL));
+  }
+
+  @Test
+  void shouldComputeCorrectVisibleIndexThroughFullMixedWorkflowAdvancement() {
+    // [enabled, disabled, enabled, disabled, enabled] — advance step-by-step verifying the
+    // first loop's enabledCount accumulation produces correct visible indices at each step.
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("S1"), disabledStage("S2"), stage("S3"), disabledStage("S4"), stage("S5"))));
+
+    // Step 1: From S1 (abs 0). First loop [0..0]: S1→1. Next enabled S3 → index 1.
+    LtftForm form1 = formAtReviewStage(DBC, 0, "S1");
+    Optional<ReviewStageStatus> step1 = service.resolveAdvance(form1);
+    assertTrue(step1.isPresent(), "Expected step 1 to be present.");
+    assertThat("Unexpected step 1 index.", step1.get().index(), is(1));
+    assertThat("Unexpected step 1 label.", step1.get().label(), is("S3"));
+
+    // Step 2: From S3 (abs 2). First loop [0..2]: S1(1), S2(skip), S3(2). Next S5 → index 2.
+    LtftForm form2 = formAtReviewStage(DBC, 1, "S3");
+    Optional<ReviewStageStatus> step2 = service.resolveAdvance(form2);
+    assertTrue(step2.isPresent(), "Expected step 2 to be present.");
+    assertThat("Unexpected step 2 index.", step2.get().index(), is(2));
+    assertThat("Unexpected step 2 label.", step2.get().label(), is("S5"));
+
+    // Step 3: From S5 (abs 4, last). No enabled after → terminal at enabledCount=3.
+    LtftForm form3 = formAtReviewStage(DBC, 2, "S5");
+    Optional<ReviewStageStatus> step3 = service.resolveAdvance(form3);
+    assertTrue(step3.isPresent(), "Expected terminal stage to be present.");
+    assertThat("Unexpected step 3 (terminal) index.", step3.get().index(), is(3));
+    assertThat("Unexpected step 3 label.", step3.get().label(), is(TERMINAL_STAGE_LABEL));
+  }
+
+  @Test
   void shouldAllowUnsubmitFromAnyStageWhenNoWorkflowConfigured() {
     LtftForm form = formWithDbc(DBC);
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageServiceTest.java
@@ -170,7 +170,7 @@ class ReviewStageServiceTest {
     LtftForm form = formWithDbc(DBC);
     ReviewStageStatus result = service.resolveReviewStageForTransition(form, SUBMITTED);
 
-    assertThat("Unexpected stage index.", result.index(), is(1));
+    assertThat("Unexpected stage index.", result.index(), is(0));
     assertThat("Unexpected stage label.", result.label(), is("Manager Review"));
   }
 
@@ -320,7 +320,7 @@ class ReviewStageServiceTest {
     Optional<ReviewStageStatus> result = service.resolveAdvance(form);
 
     assertTrue(result.isPresent(), "Expected next stage to be present after skipping disabled.");
-    assertThat("Unexpected next stage index.", result.get().index(), is(2));
+    assertThat("Unexpected next stage index.", result.get().index(), is(1));
     assertThat("Unexpected next stage label.", result.get().label(), is("Dean Approval"));
   }
 
@@ -334,7 +334,7 @@ class ReviewStageServiceTest {
 
     assertTrue(result.isPresent(),
         "Expected terminal stage when no enabled stages follow the current stage.");
-    assertThat("Unexpected terminal stage index.", result.get().index(), is(2));
+    assertThat("Unexpected terminal stage index.", result.get().index(), is(1));
     assertThat("Unexpected terminal stage label.", result.get().label(), is(TERMINAL_STAGE_LABEL));
   }
 
@@ -347,7 +347,7 @@ class ReviewStageServiceTest {
     Optional<ReviewStageStatus> result = service.resolveAdvance(form);
 
     assertTrue(result.isPresent(), "Expected next stage when advancing from a disabled stage.");
-    assertThat("Unexpected next stage index.", result.get().index(), is(2));
+    assertThat("Unexpected next stage index.", result.get().index(), is(1));
     assertThat("Unexpected next stage label.", result.get().label(), is("Dean Approval"));
   }
 
@@ -361,7 +361,7 @@ class ReviewStageServiceTest {
 
     assertTrue(result.isPresent(),
         "Expected terminal stage at disabled final stage.");
-    assertThat("Unexpected terminal stage index.", result.get().index(), is(2));
+    assertThat("Unexpected terminal stage index.", result.get().index(), is(1));
     assertThat("Unexpected terminal stage label.", result.get().label(), is(TERMINAL_STAGE_LABEL));
   }
 
@@ -374,7 +374,7 @@ class ReviewStageServiceTest {
     Optional<ReviewStageStatus> result = service.resolveAdvance(form);
 
     assertTrue(result.isPresent(), "Expected next stage after skipping multiple disabled stages.");
-    assertThat("Unexpected next stage index.", result.get().index(), is(3));
+    assertThat("Unexpected next stage index.", result.get().index(), is(1));
     assertThat("Unexpected next stage label.", result.get().label(), is("Stage D"));
   }
 
@@ -414,6 +414,19 @@ class ReviewStageServiceTest {
 
     assertTrue(result.isEmpty(),
         "Expected empty optional when form has no programme membership.");
+  }
+
+  @Test
+  void shouldReturnEmptyWhenCurrentStageLabelNotFoundInConfig() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        stage("Triage"), stage("Manager Review"))));
+
+    // Form is at a stage whose label no longer exists in config (e.g. stage was renamed/removed).
+    LtftForm form = formAtReviewStage(DBC, 0, "Removed Stage");
+    Optional<ReviewStageStatus> result = service.resolveAdvance(form);
+
+    assertTrue(result.isEmpty(),
+        "Expected empty optional when current stage label is not in configured stages.");
   }
 
   @Test
@@ -885,6 +898,28 @@ class ReviewStageServiceTest {
 
     assertTrue(service.canTransitionToLifecycleState(form, UNSUBMITTED),
         "Expected UNSUBMIT to be allowed from terminal stage.");
+  }
+
+  @Test
+  void shouldReturnConsistentIndexBetweenFormStatusAndWorkflowWhenFirstStageDisabled() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        disabledStage("Triage"), stage("Education Team Review"), stage("APD Approval"))));
+
+    LtftForm form = formWithDbc(DBC);
+    ReviewStageStatus reviewStage = service.resolveReviewStageForTransition(form, SUBMITTED);
+
+    // Simulate the form having been submitted with this review stage.
+    form.setStatus(Status.builder()
+        .current(StatusInfo.builder()
+            .state(SUBMITTED)
+            .reviewStage(reviewStage)
+            .build())
+        .build());
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Form status index should match workflow endpoint index.",
+        reviewStage.index(), is(dto.currentStage()));
   }
 
   @Test


### PR DESCRIPTION
_Intention is to resolve the bugs without affecting the API contracts; if we want to refactor to remove the index altogether, that probably needs a bit of design and coordination with the Admin team over API changes._

 Status reviewStage index made consistent with review-workflow endpoint to only index enabled stages (or a stage it is in).

Where first review stage is disabled (as for North Central and East London in application-preprod.yml), the FE is listing the remaining enabled stages correctly, but it is marking the first one with a green-check instead of a number, before it has been progressed. After progressing it, the next (in this case final) review stage is prematurely green-checked and no option is given to complete the review, only to update the status, which then fails since the review is not complete.
Example: 
[TIS](https://alpha-apps.tis.nhs.uk/admin/ltft/14b6ce4f-835d-4fcb-ba00-fd5951e51ff1)

After unsubmit and resubmit of the above form, the FE is showing the previous (historic) progress-stage message under 'Education Team Review', instead of nothing which might be confusing since it needs to be re-evaluated against the first review stage.

Neither of these issues arise for LTFT forms whose review stages are all enabled.

This issue seems to arise because the first (enabled) review stage is being given {index: 1} instead of {index: 0} in the current status; the review-workflow endpoint is returning the correct {index: 0}.

TIS21-8900