### PR TITLE
fix: in single disabled review stage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.72.1"
+version = "0.72.2"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceIntegrationTest.java
@@ -92,6 +92,7 @@ class LtftServiceIntegrationTest {
   private static final String DBC_NO_WORKFLOW = "unknown-dbc"; // not in config
   private static final String DBC_DISABLED_FIRST = "TEST-DBC-DISABLED-FIRST";
   private static final String DBC_MIXED = "TEST-DBC-MIXED";
+  private static final String DBC_ALL_DISABLED = "TEST-DBC-DISABLED";
 
   private static final String TRAINEE_ID = "47165";
   private static final UUID PM_UUID = UUID.randomUUID();
@@ -931,5 +932,79 @@ class LtftServiceIntegrationTest {
     assertThat("Unexpected stages.", workflow.get().stages(),
         contains("Stage A", "Stage C", "Stage D", "Review complete"));
     assertThat("Unexpected currentStage.", workflow.get().currentStage(), is(2));
+  }
+
+  // -- all-disabled DBC (TEST-DBC-DISABLED) in-flight form behaviour --
+
+  @Test
+  void shouldAppendTerminalStageInWorkflowWhenFormIsAtDisabledStageInAllDisabledDbc() {
+    // TEST-DBC-DISABLED has a single disabled stage "Disabled Stage".
+    // A form in-flight at that stage should see the terminal stage appended.
+    adminIdentity.setGroups(Set.of(DBC_ALL_DISABLED));
+
+    LtftForm form = savedSubmittedFormWithReviewStage(DBC_ALL_DISABLED, 0, "Disabled Stage");
+
+    Optional<ReviewWorkflowDto> workflow = service.getReviewWorkflow(form.getId());
+
+    assertThat("Workflow should be present.", workflow.isPresent(), is(true));
+    assertThat("Expected disabled stage and terminal stage.", workflow.get().stages(),
+        contains("Disabled Stage", "Review complete"));
+    assertThat("Expected current stage to be at the disabled stage.",
+        workflow.get().currentStage(), is(0));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, names = {"APPROVED", "REJECTED", "WITHDRAWN"})
+  void shouldDenyTerminalTransitionWhenFormIsAtDisabledStageInAllDisabledDbc(
+      LifecycleState targetState) {
+    // Form is in-flight at the disabled stage — must advance to "Review complete" first.
+    adminIdentity.setGroups(Set.of(DBC_ALL_DISABLED));
+
+    LtftForm form = savedSubmittedFormWithReviewStage(DBC_ALL_DISABLED, 0, "Disabled Stage");
+
+    assertThrows(MethodArgumentNotValidException.class,
+        () -> service.updateStatusAsAdmin(form.getId(), targetState, null),
+        "Expected terminal transition to be denied from disabled stage.");
+  }
+
+  @Test
+  void shouldAdvanceFromDisabledStageToTerminalInAllDisabledDbc()
+      throws MethodArgumentNotValidException {
+    // Form is in-flight at the disabled stage — advance should go to "Review complete".
+    adminIdentity.setGroups(Set.of(DBC_ALL_DISABLED));
+    adminIdentity.setName("Ad Min");
+    adminIdentity.setEmail("ad.min@test.com");
+
+    LtftForm form = savedSubmittedFormWithReviewStage(DBC_ALL_DISABLED, 0, "Disabled Stage");
+
+    Optional<LtftFormDto> result = service.advanceReviewStage(form.getId(), null);
+
+    assertThat("Expected advancement to succeed.", result.isPresent(), is(true));
+    assertThat("Unexpected terminal stage index.",
+        result.get().status().current().reviewStage().index(), is(0));
+    assertThat("Unexpected terminal stage label.",
+        result.get().status().current().reviewStage().label(), is("Review complete"));
+  }
+
+  @Test
+  void shouldAllowApprovalAfterAdvancingToTerminalInAllDisabledDbc()
+      throws MethodArgumentNotValidException {
+    // Full lifecycle: advance to terminal, then approve.
+    adminIdentity.setGroups(Set.of(DBC_ALL_DISABLED));
+    adminIdentity.setName("Ad Min");
+    adminIdentity.setEmail("ad.min@test.com");
+
+    LtftForm form = savedSubmittedFormWithReviewStage(DBC_ALL_DISABLED, 0, "Disabled Stage");
+
+    // Advance to terminal stage.
+    service.advanceReviewStage(form.getId(), null);
+
+    // Now approve should succeed.
+    Optional<LtftFormDto> approved = service.updateStatusAsAdmin(
+        form.getId(), LifecycleState.APPROVED, null);
+
+    assertThat("Expected approval to succeed.", approved.isPresent(), is(true));
+    assertThat("Unexpected state.", approved.get().status().current().state(),
+        is(LifecycleState.APPROVED));
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
@@ -93,44 +93,61 @@ public class ReviewStageService {
    * @return The workflow DTO describing the visible stages and the form's current position.
    */
   public ReviewWorkflowDto getWorkflowDto(LtftForm form) {
-    String dbc = getDesignatedBodyCode(form);
-    List<StateStage> allStages = getConfiguredStages(dbc);
+    List<StateStage> allStages = getConfiguredStages(getDesignatedBodyCode(form));
+    String activeLabel = getActiveReviewLabel(form);
 
-    ReviewStageStatus currentReviewStage = getCurrentReviewStage(form);
-    boolean isSubmitted =
-        form.getStatus() != null
-            && form.getStatus().current() != null
-            && form.getStatus().current().state() == SUBMITTED;
-    String currentLabel =
-        (isSubmitted && currentReviewStage != null) ? currentReviewStage.label() : null;
+    List<String> visibleLabels = buildVisibleLabels(allStages, activeLabel);
+    Integer currentPosition =
+        activeLabel != null ? indexOfOrNull(visibleLabels, activeLabel) : null;
 
-    List<String> visibleLabels = new ArrayList<>();
-    Integer currentVisiblePosition = null;
+    return new ReviewWorkflowDto(visibleLabels, currentPosition);
+  }
 
-    for (int i = 0; i < allStages.size(); i++) {
-      StateStage stage = allStages.get(i);
-      boolean isCurrent = currentLabel != null && currentLabel.equals(stage.label());
-      if (stage.enabled() || isCurrent) {
-        if (isCurrent) {
-          currentVisiblePosition = visibleLabels.size();
-        }
-        visibleLabels.add(stage.label());
-      }
+  /**
+   * Return the label of the form's active review stage, or {@code null} if the form is not
+   * SUBMITTED or has no review stage.
+   */
+  @Nullable
+  private String getActiveReviewLabel(LtftForm form) {
+    if (form.getStatus() == null || form.getStatus().current() == null
+        || form.getStatus().current().state() != SUBMITTED) {
+      return null;
     }
+    ReviewStageStatus stage = getCurrentReviewStage(form);
+    return stage != null ? stage.label() : null;
+  }
 
-    // Append the implicit terminal stage if any configured stages are enabled, or if the form
-    // is genuinely in-flight (its current label exists in the configured workflow or is the
-    // terminal label itself). Stale/unknown labels do not trigger terminal stage appending.
+  /**
+   * Build the list of visible stage labels for the workflow DTO.
+   *
+   * <p>Includes all enabled stages, plus the {@code activeLabel} stage if it is disabled but
+   * current. Appends the terminal "Review complete" stage when the workflow is active (has enabled
+   * stages) or the form is genuinely in-flight.
+   */
+  private List<String> buildVisibleLabels(List<StateStage> allStages,
+      @Nullable String activeLabel) {
+    List<String> labels = allStages.stream()
+        .filter(s -> s.enabled() || s.label().equals(activeLabel))
+        .map(StateStage::label)
+        .collect(Collectors.toCollection(ArrayList::new));
+
     boolean anyEnabled = allStages.stream().anyMatch(StateStage::enabled);
-    boolean inFlight = currentVisiblePosition != null || TERMINAL_STAGE_LABEL.equals(currentLabel);
-    if (anyEnabled || inFlight) {
-      if (TERMINAL_STAGE_LABEL.equals(currentLabel)) {
-        currentVisiblePosition = visibleLabels.size();
-      }
-      visibleLabels.add(TERMINAL_STAGE_LABEL);
-    }
+    boolean inFlight = activeLabel != null
+        && (labels.contains(activeLabel) || TERMINAL_STAGE_LABEL.equals(activeLabel));
 
-    return new ReviewWorkflowDto(visibleLabels, currentVisiblePosition);
+    if (anyEnabled || inFlight) {
+      labels.add(TERMINAL_STAGE_LABEL);
+    }
+    return labels;
+  }
+
+  /**
+   * Return the index of {@code label} in the list, or {@code null} if not found.
+   */
+  @Nullable
+  private Integer indexOfOrNull(List<String> labels, String label) {
+    int index = labels.indexOf(label);
+    return index >= 0 ? index : null;
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
@@ -82,7 +82,8 @@ public class ReviewStageService {
    * <p>The {@code stages} list contains only enabled stages, with one exception: if the form is
    * currently SUBMITTED and its active review stage is disabled (e.g. the stage was disabled after
    * the form entered it), that stage is also included at its correct position. When at least one
-   * configured stage is enabled, an implicit terminal "Review complete" stage is appended.
+   * configured stage is enabled, or the form is currently at a stage in the workflow (in-flight),
+   * an implicit terminal "Review complete" stage is appended.
    *
    * <p>The {@code currentStage} field is the zero-based index of the form's current review stage
    * within the returned {@code stages} list, or {@code null} if the form is not SUBMITTED or has no
@@ -117,9 +118,10 @@ public class ReviewStageService {
       }
     }
 
-    // Append the implicit terminal stage if any configured stages are enabled.
+    // Append the implicit terminal stage if any configured stages are enabled, or if the form
+    // is currently at a stage in the workflow (i.e. it was in-flight when stages were disabled).
     boolean anyEnabled = allStages.stream().anyMatch(StateStage::enabled);
-    if (anyEnabled) {
+    if (anyEnabled || (currentLabel != null && !allStages.isEmpty())) {
       if (TERMINAL_STAGE_LABEL.equals(currentLabel)) {
         currentVisiblePosition = visibleLabels.size();
       }
@@ -191,12 +193,6 @@ public class ReviewStageService {
     String dbc = getDesignatedBodyCode(form);
     List<StateStage> stages = getConfiguredStages(dbc);
 
-    boolean anyEnabled = stages.stream().anyMatch(StateStage::enabled);
-    if (!anyEnabled) {
-      log.debug("All review stages disabled for DBC '{}'; no stages to advance through.", dbc);
-      return Optional.empty();
-    }
-
     ReviewStageStatus current = getCurrentReviewStage(form);
     if (current == null) {
       log.warn(
@@ -254,8 +250,8 @@ public class ReviewStageService {
    * REJECTED, WITHDRAWN) require the form to be at the implicit terminal stage, i.e. past all
    * configured stages.
    *
-   * <p>If no workflow is configured for the form's DBC, or all configured stages are disabled, the
-   * transition is always permitted.
+   * <p>If no workflow is configured for the form's DBC, or the form has no current review stage
+   * (e.g. it was submitted after all stages were disabled), the transition is always permitted.
    *
    * @param form The form to check.
    * @param targetState The lifecycle state the form is being transitioned to.
@@ -270,13 +266,6 @@ public class ReviewStageService {
     List<StateStage> stages = getConfiguredStages(dbc);
 
     if (stages.isEmpty()) {
-      return true;
-    }
-
-    // If all stages are disabled treat as no workflow — allow any transition.
-    boolean anyEnabled = stages.stream().anyMatch(StateStage::enabled);
-    if (!anyEnabled) {
-      log.debug("All review stages disabled for DBC '{}'; treating as no workflow.", dbc);
       return true;
     }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageService.java
@@ -119,9 +119,11 @@ public class ReviewStageService {
     }
 
     // Append the implicit terminal stage if any configured stages are enabled, or if the form
-    // is currently at a stage in the workflow (i.e. it was in-flight when stages were disabled).
+    // is genuinely in-flight (its current label exists in the configured workflow or is the
+    // terminal label itself). Stale/unknown labels do not trigger terminal stage appending.
     boolean anyEnabled = allStages.stream().anyMatch(StateStage::enabled);
-    if (anyEnabled || (currentLabel != null && !allStages.isEmpty())) {
+    boolean inFlight = currentVisiblePosition != null || TERMINAL_STAGE_LABEL.equals(currentLabel);
+    if (anyEnabled || inFlight) {
       if (TERMINAL_STAGE_LABEL.equals(currentLabel)) {
         currentVisiblePosition = visibleLabels.size();
       }

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageServiceTest.java
@@ -270,15 +270,17 @@ class ReviewStageServiceTest {
   }
 
   @Test
-  void shouldReturnEmptyWhenAllStagesDisabledForAdvance() {
+  void shouldAdvanceToTerminalStageWhenAllStagesDisabledButFormIsAtStage() {
     workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
         disabledStage("Triage"), disabledStage("Manager Review"))));
 
     LtftForm form = formAtReviewStage(DBC, 0, "Triage");
     Optional<ReviewStageStatus> result = service.resolveAdvance(form);
 
-    assertTrue(result.isEmpty(),
-        "Expected empty optional when all stages are disabled.");
+    assertTrue(result.isPresent(),
+        "Expected advancement to terminal stage when form is at a disabled stage.");
+    assertThat("Unexpected terminal index.", result.get().index(), is(0));
+    assertThat("Unexpected terminal label.", result.get().label(), is(TERMINAL_STAGE_LABEL));
   }
 
   @Test
@@ -638,14 +640,30 @@ class ReviewStageServiceTest {
 
   @ParameterizedTest
   @EnumSource(value = LifecycleState.class, names = {"APPROVED", "REJECTED", "WITHDRAWN"})
-  void shouldAllowTerminalTransitionWhenAllStagesDisabled(LifecycleState targetState) {
+  void shouldAllowTerminalTransitionWhenAllStagesDisabledAndFormHasNoReviewStage(
+      LifecycleState targetState) {
     workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
         disabledStage("Triage"), disabledStage("Manager Review"))));
 
     LtftForm form = formWithDbc(DBC);
 
     assertTrue(service.canTransitionToLifecycleState(form, targetState),
-        "Expected terminal transition to be allowed when all stages disabled.");
+        "Expected terminal transition to be allowed when form has no review stage.");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = LifecycleState.class, names = {"APPROVED", "REJECTED", "WITHDRAWN"})
+  void shouldDenyTerminalTransitionWhenAllStagesDisabledButFormIsAtDisabledStage(
+      LifecycleState targetState) {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        disabledStage("Triage"), disabledStage("Manager Review"))));
+
+    // Form was in-flight when stage was disabled — must advance to terminal first.
+    LtftForm form = formAtReviewStage(DBC, 0, "Triage");
+
+    assertFalse(service.canTransitionToLifecycleState(form, targetState),
+        "Expected terminal transition denied from disabled stage "
+            + "(must advance to terminal stage first).");
   }
 
   @ParameterizedTest
@@ -889,6 +907,20 @@ class ReviewStageServiceTest {
 
     assertThat("Unexpected stages when all disabled.", dto.stages(), empty());
     assertThat("Unexpected current stage when all disabled.", dto.currentStage(), nullValue());
+  }
+
+  @Test
+  void shouldIncludeTerminalStageWhenAllStagesDisabledButFormIsAtDisabledStage() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        disabledStage("Triage"), disabledStage("Middle"))));
+
+    LtftForm form = formAtReviewStage(DBC, 0, "Triage");
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Unexpected stages.", dto.stages(),
+        contains("Triage", TERMINAL_STAGE_LABEL));
+    assertThat("Unexpected current stage.", dto.currentStage(), is(0));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/ReviewStageServiceTest.java
@@ -924,6 +924,20 @@ class ReviewStageServiceTest {
   }
 
   @Test
+  void shouldNotAppendTerminalStageWhenFormHasStaleReviewStageLabelAndAllStagesDisabled() {
+    workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(
+        disabledStage("Triage"), disabledStage("Middle"))));
+
+    // Form has a stale label that no longer exists in the configured workflow.
+    LtftForm form = formAtReviewStage(DBC, 0, "Renamed Stage");
+
+    ReviewWorkflowDto dto = service.getWorkflowDto(form);
+
+    assertThat("Expected empty stages for stale label.", dto.stages(), empty());
+    assertThat("Expected null current stage for stale label.", dto.currentStage(), nullValue());
+  }
+
+  @Test
   void shouldReturnEmptyStagesWhenFormHasContentButNoProgrammeMembership() {
     workflowProperties.setReviewWorkflows(Map.of(DBC, List.of(stage("Triage"))));
 


### PR DESCRIPTION
Should require a 'Review complete' advance before form can be approved/rejected/etc to be consistent with other forms in disabled stages

TIS21-8901