### PR TITLE
fix: exceptional reason field naming in JSON

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.72.3"
+version = "0.72.4"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java
@@ -21,7 +21,6 @@
 
 package uk.nhs.hee.tis.trainee.forms.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMax;
@@ -182,13 +181,8 @@ public record LtftFormDto(
    */
   @Builder
   public record ExceptionalReasonsDto(
-      @JsonProperty("isExceptional")
       Boolean exceptional,
-
-      @JsonProperty("exceptionalReasons")
       String supportingInformation,
-
-      @JsonProperty("exceptionalReasonsDate")
       LocalDate startDate) {
 
   }


### PR DESCRIPTION
The `@JsonProperty` used on exceptional reason fields is no longer needed, remove it as the frontend applications will be updated to reflect the original field naming.

TIS21-8831
TIS21-8852