### PR TITLE
fix(ltft): set change start date when exceptional

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/CctChange.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/CctChange.java
@@ -24,6 +24,7 @@ package uk.nhs.hee.tis.trainee.forms.model.content;
 import java.time.LocalDate;
 import java.util.UUID;
 import lombok.Builder;
+import lombok.With;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 /**
@@ -44,6 +45,7 @@ public record CctChange(
     UUID calculationId,
     CctChangeType type,
     Double wte,
+    @With
     LocalDate startDate,
     LocalDate altStartDate,
     LocalDate endDate) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/LtftContent.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/model/content/LtftContent.java
@@ -51,6 +51,7 @@ public record LtftContent(
     ProgrammeMembership programmeMembership,
     Declarations declarations,
     Discussions discussions,
+    @With
     CctChange change,
     Reasons reasons,
     ExceptionalReasons exceptionalReasons,

--- a/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/forms/service/LtftService.java
@@ -37,6 +37,8 @@ import jakarta.annotation.Nullable;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -82,7 +84,9 @@ import uk.nhs.hee.tis.trainee.forms.model.AbstractAuditedForm.Status.StatusDetai
 import uk.nhs.hee.tis.trainee.forms.model.LtftForm;
 import uk.nhs.hee.tis.trainee.forms.model.Person;
 import uk.nhs.hee.tis.trainee.forms.model.ReviewStageStatus;
+import uk.nhs.hee.tis.trainee.forms.model.content.CctChange;
 import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent;
+import uk.nhs.hee.tis.trainee.forms.model.content.LtftContent.ExceptionalReasons;
 import uk.nhs.hee.tis.trainee.forms.repository.LtftFormRepository;
 
 /**
@@ -99,6 +103,8 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
   private static final String FORM_OBJECT_NAME = "LtftForm";
   private static final String METHOD_UPDATE_STATUS = "updateStatus";
   private static final String METHOD_ADVANCE_REVIEW_STAGE = "advanceReviewStage";
+
+  private static final int MINIMUM_NOTICE_DAYS = 7 * 16; // 16 weeks in days
 
   private final AdminIdentity adminIdentity;
   private final TraineeIdentity traineeIdentity;
@@ -119,6 +125,7 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
 
   private final SubmissionHistoryService<LtftForm> ltftSubmissionHistoryService;
   private final ReviewStageService reviewStageService;
+  private final ZoneId timezone;
 
   /**
    * Instantiate the LTFT form service.
@@ -144,7 +151,7 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
       @Value("${application.aws.sns.ltft-status-updated}") String ltftStatusUpdateTopic,
       @Value("${application.aws.sns.ltft-content-updated}") String ltftContentUpdateTopic,
       SubmissionHistoryService<LtftForm> ltftSubmissionHistoryService,
-      ReviewStageService reviewStageService) {
+      ReviewStageService reviewStageService, @Value("${application.timezone}") ZoneId timezone) {
     super(ltftFormRepository, ltftSubmissionHistoryService);
 
     this.adminIdentity = adminIdentity;
@@ -160,6 +167,7 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
     this.ltftSubmissionHistoryService = ltftSubmissionHistoryService;
     this.eventBroadcastService = eventBroadcastService;
     this.reviewStageService = reviewStageService;
+    this.timezone = timezone;
   }
 
   /**
@@ -665,9 +673,8 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
    * Get a deduplicated set of review stage labels relevant to the user's group DBCs.
    *
    * <p>This includes all <em>enabled</em> configured stages, the implicit "Review complete"
-   * terminal stage (when at least one enabled stage exists), plus any <em>disabled</em> stages
-   * that currently have LTFT forms in them (i.e. forms that entered the stage before it was
-   * disabled).
+   * terminal stage (when at least one enabled stage exists), plus any <em>disabled</em> stages that
+   * currently have LTFT forms in them (i.e. forms that entered the stage before it was disabled).
    *
    * @return A set of deduplicated review stage labels.
    */
@@ -708,8 +715,8 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
    * @param formId The ID of the form to advance.
    * @return The updated LTFT application, or empty if the form was not found or does not belong to
    *     the admin's local office.
-   * @throws MethodArgumentNotValidException If the form is not currently SUBMITTED or is already
-   *                                         at the final review stage.
+   * @throws MethodArgumentNotValidException If the form is not currently SUBMITTED or is already at
+   *                                         the final review stage.
    */
   public Optional<LtftFormDto> advanceReviewStage(UUID formId)
       throws MethodArgumentNotValidException {
@@ -727,8 +734,8 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
    * @param detail Optional detail to record alongside the stage change.
    * @return The updated LTFT application, or empty if the form was not found or does not belong to
    *     the admin's local office.
-   * @throws MethodArgumentNotValidException If the form is not currently SUBMITTED or is already
-   *                                         at the final review stage.
+   * @throws MethodArgumentNotValidException If the form is not currently SUBMITTED or is already at
+   *                                         the final review stage.
    */
   public Optional<LtftFormDto> advanceReviewStage(UUID formId,
       @Nullable LftfStatusInfoDetailDto detail) throws MethodArgumentNotValidException {
@@ -847,6 +854,7 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
     form.setLifecycleState(targetState, detailEntity, modifiedBy, form.getRevision(), reviewStage);
 
     assignFormRefIfNew(form, targetState);
+    calculateNonExceptionalStartDate(form, targetState);
 
     LtftForm savedForm = ltftFormRepository.save(form);
     if (targetState == SUBMITTED) {
@@ -870,7 +878,7 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
       LifecycleState currentState = (form.getStatus() != null && form.getStatus().current() != null)
           ? form.getStatus().current().state() : null;
       log.warn("Could not update form {}, invalid lifecycle transition from {} to {} "
-              + "for form type '{}'", form.getId(), currentState, targetState, form.getFormType());
+          + "for form type '{}'", form.getId(), currentState, targetState, form.getFormType());
 
       BeanPropertyBindingResult result = new BeanPropertyBindingResult(form, "form");
       result.addError(new FieldError(FORM_OBJECT_NAME, FORM_ATTRIBUTE_FORM_STATUS,
@@ -963,6 +971,32 @@ public class LtftService extends AbstractAuditedFormService<LtftForm> {
       log.info("Assigning form reference {} to LTFT {}", formRef, form.getId());
       form.setFormRef(formRef);
     }
+  }
+
+  /**
+   * Calculate a start date for the LTFT form if it is being submitted as an exceptional application
+   * and there is no current start date, the minimum notice period is applied to the current date to
+   * calculate the start date.
+   *
+   * @param form        The form being updated.
+   * @param targetState The target lifecycle state.
+   */
+  private void calculateNonExceptionalStartDate(LtftForm form, LifecycleState targetState) {
+    if (targetState != SUBMITTED || form.getContent() == null) {
+      return;
+    }
+
+    LtftContent content = form.getContent();
+    CctChange change = content.change();
+    ExceptionalReasons exceptionalReasons = content.exceptionalReasons();
+
+    if (exceptionalReasons == null || !Boolean.TRUE.equals(exceptionalReasons.exceptional())
+        || change == null || change.startDate() != null) {
+      return;
+    }
+
+    LocalDate startDate = LocalDate.now(timezone).plusDays(MINIMUM_NOTICE_DAYS);
+    form.setContent(content.withChange(change.withStartDate(startDate)));
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/forms/service/LtftServiceTest.java
@@ -39,6 +39,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -164,6 +165,8 @@ class LtftServiceTest {
   private static final String LTFT_STATUS_CONTENT_TOPIC = "update/topic/content";
   private static final UUID PM_UUID = UUID.randomUUID();
 
+  private static final ZoneId TIMEZONE = ZoneId.of("Europe/London");
+
   private LtftService service;
   private LtftFormRepository repository;
   private MongoTemplate mongoTemplate;
@@ -203,14 +206,14 @@ class LtftServiceTest {
     when(reviewStageService.canTransitionToLifecycleState(any(), any())).thenReturn(true);
 
     jsonMapper = (JsonMapper) new JsonMapper().registerModule(new JavaTimeModule());
-    temporalMapper = mock();
-    mapper = new LtftMapperImpl(new TemporalMapper(ZoneId.of("Etc/UTC")));
+    temporalMapper = spy(new TemporalMapper(ZoneId.of("Etc/UTC")));
+    mapper = new LtftMapperImpl(temporalMapper);
     mapper.setTemporalMapper(temporalMapper);
     validator = mock();
     service = new LtftService(adminIdentity, traineeIdentity, repository, mongoTemplate, jsonMapper,
         mapper, validator, eventBroadcastService, LTFT_ASSIGNMENT_UPDATE_TOPIC,
         LTFT_STATUS_UPDATE_TOPIC, LTFT_STATUS_CONTENT_TOPIC, ltftSubmissionHistoryService,
-        reviewStageService);
+        reviewStageService, TIMEZONE);
   }
 
   @Test
@@ -2311,7 +2314,8 @@ class LtftServiceTest {
   void shouldNotQueryForDisabledStagesAlreadyInEnabledSet() {
     List<String> adminDbcs = List.of(ADMIN_GROUP);
     // "Triage" is enabled for one DBC and disabled for another
-    when(reviewStageService.getEnabledStageLabels(adminDbcs)).thenReturn(Set.of("Triage", "Review"));
+    when(reviewStageService.getEnabledStageLabels(adminDbcs)).thenReturn(
+        Set.of("Triage", "Review"));
     when(reviewStageService.getDisabledStageLabels(adminDbcs))
         .thenReturn(new java.util.HashSet<>(Set.of("Triage")));
 
@@ -2882,7 +2886,7 @@ class LtftServiceTest {
     service = new LtftService(adminIdentity, traineeIdentity, repository, mongoTemplate, jsonMapper,
         mapper, validator, eventBroadcastService, LTFT_ASSIGNMENT_UPDATE_TOPIC,
         LTFT_STATUS_UPDATE_TOPIC, LTFT_STATUS_CONTENT_TOPIC, ltftSubmissionHistoryService,
-        reviewStageService);
+        reviewStageService, TIMEZONE);
 
     LtftFormDto dtoToSave = LtftFormDto.builder()
         .traineeTisId(TRAINEE_ID)
@@ -2920,7 +2924,7 @@ class LtftServiceTest {
     service = new LtftService(adminIdentity, traineeIdentity, repository, mongoTemplate, jsonMapper,
         mapper, validator, eventBroadcastService, LTFT_ASSIGNMENT_UPDATE_TOPIC,
         LTFT_STATUS_UPDATE_TOPIC, LTFT_STATUS_CONTENT_TOPIC, ltftSubmissionHistoryService,
-        reviewStageService);
+        reviewStageService, TIMEZONE);
 
     LtftFormDto dtoToSave = LtftFormDto.builder()
         .traineeTisId(TRAINEE_ID)
@@ -2957,7 +2961,7 @@ class LtftServiceTest {
     service = new LtftService(adminIdentity, traineeIdentity, repository, mongoTemplate, jsonMapper,
         mapper, validator, eventBroadcastService, LTFT_ASSIGNMENT_UPDATE_TOPIC,
         LTFT_STATUS_UPDATE_TOPIC, LTFT_STATUS_CONTENT_TOPIC, ltftSubmissionHistoryService,
-        reviewStageService);
+        reviewStageService, TIMEZONE);
 
     LtftFormDto dtoToSave = LtftFormDto.builder()
         .traineeTisId(TRAINEE_ID)
@@ -4042,6 +4046,60 @@ class LtftServiceTest {
     assertThat("Unexpected form ref.", form.getFormRef(), is(formRef));
     verify(repository).save(form);
     verify(ltftSubmissionHistoryService).takeSnapshot(form);
+  }
+
+  @Test
+  void shouldNotChangeStartDateWhenSubmittingExceptionalFormWithStartDate() {
+    LtftForm form = new LtftForm();
+    form.setId(ID);
+    form.setTraineeTisId(TRAINEE_ID);
+    form.setLifecycleState(DRAFT);
+    form.setContent(LtftContent.builder()
+        .change(CctChange.builder()
+            .type(CctChangeType.LTFT)
+            .startDate(LocalDate.EPOCH)
+            .wte(1.0).build())
+        .exceptionalReasons(ExceptionalReasons.builder()
+            .exceptional(true)
+            .build())
+        .build());
+
+    when(repository.findByTraineeTisIdAndId(TRAINEE_ID, ID)).thenReturn(Optional.of(form));
+    when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    Optional<LtftFormDto> result = service.submitLtftForm(ID, null);
+
+    assertThat("Unexpected result when form is submitted.", result.isPresent(), is(true));
+
+    LocalDate startDate = form.getContent().change().startDate();
+    assertThat("Unexpected change state date.", startDate, is(LocalDate.EPOCH));
+  }
+
+  @Test
+  void shouldSetStartDateWhenSubmittingExceptionalFormWithNoStartDate() {
+    LtftForm form = new LtftForm();
+    form.setId(ID);
+    form.setTraineeTisId(TRAINEE_ID);
+    form.setLifecycleState(DRAFT);
+    form.setContent(LtftContent.builder()
+        .change(CctChange.builder()
+            .type(CctChangeType.LTFT)
+            .wte(1.0).build())
+        .exceptionalReasons(ExceptionalReasons.builder()
+            .exceptional(true)
+            .build())
+        .build());
+
+    when(repository.findByTraineeTisIdAndId(TRAINEE_ID, ID)).thenReturn(Optional.of(form));
+    when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    Optional<LtftFormDto> result = service.submitLtftForm(ID, null);
+
+    assertThat("Unexpected result when form is submitted.", result.isPresent(), is(true));
+
+    LocalDate startDate = form.getContent().change().startDate();
+    LocalDate expectedStartDate = LocalDate.now(ZoneId.of("Europe/London")).plusDays(112);
+    assertThat("Unexpected change state date.", startDate, is(expectedStartDate));
   }
 
   @Test


### PR DESCRIPTION
When an exceptional LTFT is submitted, the `content.change.startDate` should be defaulted to 16-weeks from the date of submission.

Update LtftService to forcefully populate the change start date with an appropriate value if the application is exceptional and no `content.change.startDate` has been set.

TIS21-8831